### PR TITLE
feat: add role definition CRUD endpoints

### DIFF
--- a/backend/app/routers/roles.py
+++ b/backend/app/routers/roles.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Annotated
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -22,14 +23,14 @@ class RoleAssignmentRequest(BaseModel):
 
 class CreateRoleRequest(BaseModel):
     name: str = Field(min_length=1, max_length=200)
-    description: str = ""
-    permission_names: list[str] = Field(default_factory=list)
+    description: str = Field(default="", max_length=1000)
+    permission_names: list[Annotated[str, Field(min_length=1)]] = Field(default_factory=list, max_length=100)
 
 
 class UpdateRoleRequest(BaseModel):
-    new_name: str = Field(min_length=1, max_length=200)
-    description: str = ""
-    permission_names: list[str] = Field(default_factory=list)
+    new_name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = Field(default=None, max_length=1000)
+    permission_names: list[Annotated[str, Field(min_length=1)]] | None = Field(default=None, max_length=100)
 
 
 # --- Existing user-facing endpoints (must stay before /roles/{name}) ---
@@ -101,10 +102,10 @@ async def list_roles(
         return {"roles": roles}
     except httpx.HTTPStatusError as exc:
         logger.warning("Descope API error listing roles: %s", exc.response.status_code)
-        raise HTTPException(status_code=502, detail="Failed to list roles from Descope")
+        raise HTTPException(status_code=502, detail="Failed to list roles from Descope") from exc
     except httpx.RequestError as exc:
         logger.error("Network error listing roles: %s", exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API")
+        raise HTTPException(status_code=502, detail="Failed to reach Descope API") from exc
 
 
 @router.post("/roles", status_code=201)
@@ -121,12 +122,14 @@ async def create_role(
         return {"name": body.name, "description": body.description, "permission_names": body.permission_names}
     except httpx.HTTPStatusError as exc:
         logger.warning("Descope API error creating role '%s': %s", body.name, exc.response.status_code)
-        if exc.response.status_code in (400, 409):
-            raise HTTPException(status_code=exc.response.status_code, detail="Role already exists or invalid")
-        raise HTTPException(status_code=502, detail="Failed to create role in Descope")
+        if exc.response.status_code == 400:
+            raise HTTPException(status_code=400, detail="Invalid role data") from exc
+        if exc.response.status_code == 409:
+            raise HTTPException(status_code=409, detail="Role already exists") from exc
+        raise HTTPException(status_code=502, detail="Failed to create role in Descope") from exc
     except httpx.RequestError as exc:
         logger.error("Network error creating role '%s': %s", body.name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API")
+        raise HTTPException(status_code=502, detail="Failed to reach Descope API") from exc
 
 
 @router.put("/roles/{name}")
@@ -140,16 +143,21 @@ async def update_role(
     """Update a role definition. Requires owner or admin role."""
     try:
         client = get_descope_client()
-        await client.update_role(name, body.new_name, body.description, body.permission_names)
-        return {"name": body.new_name, "description": body.description, "permission_names": body.permission_names}
+        effective_name = body.new_name if body.new_name is not None else name
+        await client.update_role(name, effective_name, body.description, body.permission_names)
+        return {"name": effective_name, "description": body.description, "permission_names": body.permission_names}
     except httpx.HTTPStatusError as exc:
         logger.warning("Descope API error updating role '%s': %s", name, exc.response.status_code)
-        if exc.response.status_code in (400, 404, 409):
-            raise HTTPException(status_code=exc.response.status_code, detail="Role not found or invalid")
-        raise HTTPException(status_code=502, detail="Failed to update role in Descope")
+        if exc.response.status_code == 404:
+            raise HTTPException(status_code=404, detail="Role not found") from exc
+        if exc.response.status_code == 409:
+            raise HTTPException(status_code=409, detail="Role name conflict") from exc
+        if exc.response.status_code == 400:
+            raise HTTPException(status_code=400, detail="Invalid role data") from exc
+        raise HTTPException(status_code=502, detail="Failed to update role in Descope") from exc
     except httpx.RequestError as exc:
         logger.error("Network error updating role '%s': %s", name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API")
+        raise HTTPException(status_code=502, detail="Failed to reach Descope API") from exc
 
 
 @router.delete("/roles/{name}")
@@ -166,9 +174,11 @@ async def delete_role(
         return {"status": "deleted", "name": name}
     except httpx.HTTPStatusError as exc:
         logger.warning("Descope API error deleting role '%s': %s", name, exc.response.status_code)
-        if exc.response.status_code in (400, 404):
-            raise HTTPException(status_code=exc.response.status_code, detail="Role not found or invalid")
-        raise HTTPException(status_code=502, detail="Failed to delete role in Descope")
+        if exc.response.status_code == 404:
+            raise HTTPException(status_code=404, detail="Role not found") from exc
+        if exc.response.status_code == 400:
+            raise HTTPException(status_code=400, detail="Invalid role data") from exc
+        raise HTTPException(status_code=502, detail="Failed to delete role in Descope") from exc
     except httpx.RequestError as exc:
         logger.error("Network error deleting role '%s': %s", name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API")
+        raise HTTPException(status_code=502, detail="Failed to reach Descope API") from exc

--- a/backend/app/services/descope.py
+++ b/backend/app/services/descope.py
@@ -177,20 +177,22 @@ class DescopeManagementClient:
     async def list_roles(self) -> list[dict]:
         """List all role definitions in the Descope project."""
         resp = await self._request("/v1/mgmt/role/all", {})
-        return resp.json().get("roles", [])
+        return resp.json().get("roles") or []
 
     async def create_role(self, name: str, description: str = "", permission_names: list[str] | None = None) -> None:
         """Create a new role definition with optional permission mappings."""
         body: dict = {"name": name, "description": description}
-        if permission_names:
+        if permission_names is not None:
             body["permissionNames"] = permission_names
         await self._request("/v1/mgmt/role/create", body)
 
     async def update_role(
-        self, name: str, new_name: str, description: str = "", permission_names: list[str] | None = None
+        self, name: str, new_name: str, description: str | None = None, permission_names: list[str] | None = None
     ) -> None:
         """Update an existing role definition."""
-        body: dict = {"name": name, "newName": new_name, "description": description}
+        body: dict = {"name": name, "newName": new_name}
+        if description is not None:
+            body["description"] = description
         if permission_names is not None:
             body["permissionNames"] = permission_names
         await self._request("/v1/mgmt/role/update", body)

--- a/backend/tests/unit/test_descope_service.py
+++ b/backend/tests/unit/test_descope_service.py
@@ -438,6 +438,20 @@ class TestDescopeManagementClient:
 
     @pytest.mark.anyio
     @patch("app.services.descope.httpx.AsyncClient")
+    async def test_update_role_without_description(self, mock_cls, client):
+        mock_http = AsyncMock()
+        mock_cls.return_value = mock_http
+        mock_http.post.return_value = MagicMock(status_code=200, raise_for_status=MagicMock())
+
+        await client.update_role("editor", "senior-editor")
+        call_json = mock_http.post.call_args[1]["json"]
+        assert "description" not in call_json
+        assert "permissionNames" not in call_json
+        assert call_json["name"] == "editor"
+        assert call_json["newName"] == "senior-editor"
+
+    @pytest.mark.anyio
+    @patch("app.services.descope.httpx.AsyncClient")
     async def test_update_role_without_permissions(self, mock_cls, client):
         mock_http = AsyncMock()
         mock_cls.return_value = mock_http

--- a/backend/tests/unit/test_roles_router.py
+++ b/backend/tests/unit/test_roles_router.py
@@ -410,6 +410,77 @@ async def test_delete_role(mock_validate, mock_factory, client):
     mock_client.delete_role.assert_called_once_with("editor")
 
 
+# --- Partial update ---
+
+
+@pytest.mark.anyio
+@patch("app.routers.roles.get_descope_client")
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_update_role_partial_description_only(mock_validate, mock_factory, client):
+    """Omitting new_name and permission_names should not wipe them."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_client = AsyncMock()
+    mock_factory.return_value = mock_client
+
+    response = await client.put(
+        "/api/roles/editor",
+        headers=AUTH_HEADER,
+        json={"description": "Updated desc"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "editor"  # defaults to path param
+    assert data["description"] == "Updated desc"
+    assert data["permission_names"] is None  # not sent → unchanged
+    mock_client.update_role.assert_called_once_with("editor", "editor", "Updated desc", None)
+
+
+@pytest.mark.anyio
+@patch("app.routers.roles.get_descope_client")
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_update_role_empty_body(mock_validate, mock_factory, client):
+    """Empty body is a no-op: name defaults to path param, others are None."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_client = AsyncMock()
+    mock_factory.return_value = mock_client
+
+    response = await client.put(
+        "/api/roles/editor",
+        headers=AUTH_HEADER,
+        json={},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "editor"
+    mock_client.update_role.assert_called_once_with("editor", "editor", None, None)
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_role_empty_permission_name_rejected(mock_validate, client):
+    """Empty strings in permission_names list should be rejected."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/roles",
+        headers=AUTH_HEADER,
+        json={"name": "test-role", "permission_names": ["", "docs.read"]},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_update_role_empty_permission_name_rejected(mock_validate, client):
+    """Empty strings in permission_names list should be rejected on update."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.put(
+        "/api/roles/editor",
+        headers=AUTH_HEADER,
+        json={"permission_names": ["", "docs.read"]},
+    )
+    assert response.status_code == 422
+
+
 # --- Error handling ---
 
 


### PR DESCRIPTION
## Summary
- Add 4 Descope Management API client methods: `list_roles`, `create_role`, `update_role`, `delete_role`
- Add 4 CRUD endpoints in roles router: `GET /roles`, `POST /roles`, `PUT /roles/{name}`, `DELETE /roles/{name}`
- Preserve existing role assignment endpoints (`/roles/me`, `/roles/assign`, `/roles/remove`) with correct route ordering
- All admin endpoints gated with `require_role("owner", "admin")`, write endpoints rate-limited

## Story
Refs #102
Part of Epic 2: Role & Permission Administration

## Chained PR
Based on #105 — must be merged first

## Review Findings Addressed
- Security: 0 BLOCK, 2 WARN — tenant scoping deferred (architectural, same as permissions.py)
- Blind Hunter: 3 MUST FIX (all fixed), 5 SHOULD FIX (3 fixed, 2 deferred)
- Edge Cases: 7 unhandled paths found, 5 fixed, 2 deferred
- Acceptance: 10 PASS, 0 FAIL, 1 PARTIAL (fixed — new_name now optional on PUT)

### Key Fixes from Review
- **Data-loss bug**: UpdateRoleRequest fields default to `None` (not zero-values), client only sends non-None fields
- **new_name optional**: PUT no longer requires `new_name` — defaults to path param
- **Input validation**: `min_length=1` on permission name items, `max_length=1000` on description, `max_length=100` on permission list
- **Error messages**: Per-status-code details (404→"not found", 409→"conflict", 400→"invalid")
- **Exception chains**: All `raise HTTPException` uses `from exc`

## Test plan
- [x] Unit tests pass (`make test-unit`) — 263 total, 33 new
- [x] Lint passes (`make lint`)
- [ ] CI passes
- [ ] Manual verification against Descope sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)