### PR TITLE
chore: migrate Terraform provider to jamescrowley321/descope

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ A comprehensive reference project demonstrating Descope's identity platform feat
 
 - Node.js 22+
 - Python 3.12+
-- Go 1.22+ (for building the Terraform provider)
 - Terraform 1.5+
 - A Descope account with a management key
 
@@ -58,14 +57,7 @@ git clone git@github.com:jamescrowley321/descope-saas-starter.git
 cd descope-saas-starter
 ```
 
-### 2. Build the Terraform provider (fork)
-
-```bash
-cd ~/repos/terraform-provider-descope
-make dev  # installs binary + creates ~/.terraformrc with dev_overrides
-```
-
-### 3. Provision Descope project
+### 2. Provision Descope project
 
 ```bash
 cd infra
@@ -81,7 +73,7 @@ terraform output integration_test_access_key_id         # → DESCOPE_CLIENT_ID
 terraform output integration_test_access_key_cleartext   # → DESCOPE_CLIENT_SECRET
 ```
 
-### 4. Run the backend
+### 3. Run the backend
 
 ```bash
 cd backend
@@ -92,7 +84,7 @@ pip install -e ".[dev]"
 uvicorn app.main:app --reload
 ```
 
-### 5. Run the frontend
+### 4. Run the frontend
 
 ```bash
 cd frontend

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -9,14 +9,8 @@ terraform {
 
   required_providers {
     descope = {
-      # Uses the fork at jamescrowley321/terraform-provider-descope.
-      # To use the fork locally, build it and configure dev_overrides:
-      #
-      #   cd ~/repos/terraform-provider-descope && make dev
-      #
-      # This installs the binary to $GOPATH/bin and creates ~/.terraformrc
-      # with dev_overrides pointing descope/descope to the local build.
-      source = "descope/descope"
+      source  = "jamescrowley321/descope"
+      version = "~> 1.0"
     }
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
## Summary

- Switch `required_providers` source from `descope/descope` to `jamescrowley321/descope` with version constraint `~> 1.0`
- Remove `dev_overrides` comments and local build workaround instructions from `infra/main.tf`
- Remove the "Build the Terraform provider" setup step and Go prerequisite from `README.md`
- Renumber Getting Started steps accordingly

Closes #100

## Test plan

- [ ] Run `terraform init` in `infra/` to verify the provider downloads from the new registry source
- [ ] Run `terraform plan` to confirm no unexpected diff from the provider change
- [ ] Verify Terraform Cloud workspace picks up the new provider source on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)