### PR TITLE
feat: FGA Methods on DescopeManagementClient (Story 3.1)

### DIFF
--- a/backend/app/services/descope.py
+++ b/backend/app/services/descope.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import Literal
 
 import httpx
@@ -13,6 +14,8 @@ class DescopeManagementClient:
     Accepts an httpx.AsyncClient for connection reuse. The caller is responsible
     for closing the client (typically via FastAPI lifespan).
     """
+
+    _FGA_IDENTIFIER_PATTERN = re.compile(r"^[a-zA-Z0-9_:.\-]+$")
 
     def __init__(
         self,
@@ -33,6 +36,15 @@ class DescopeManagementClient:
         if self._http_client is not None:
             return self._http_client
         return httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT)
+
+    def _validate_fga_param(self, value: str, name: str) -> None:
+        """Validate FGA identifier: non-empty, max 200 chars, safe characters only."""
+        if not value or not value.strip():
+            raise ValueError(f"{name} must be a non-empty string")
+        if len(value) > 200:
+            raise ValueError(f"{name} must not exceed 200 characters")
+        if not self._FGA_IDENTIFIER_PATTERN.match(value):
+            raise ValueError(f"{name} contains invalid characters (allowed: alphanumeric, _, :, ., -)")
 
     async def _request(self, path: str, body: dict) -> httpx.Response:
         """Send a POST request to the Descope Management API."""
@@ -206,14 +218,20 @@ class DescopeManagementClient:
     async def get_fga_schema(self) -> dict:
         """Load the current FGA schema definition."""
         resp = await self._request("/v1/mgmt/authz/schema/load", {})
-        return resp.json()
+        return resp.json().get("schema", {})
 
     async def update_fga_schema(self, schema: str) -> None:
         """Save/update the FGA schema definition."""
+        if not schema or not schema.strip():
+            raise ValueError("schema must be a non-empty string")
         await self._request("/v1/mgmt/authz/schema/save", {"schema": schema})
 
     async def create_relation(self, resource_type: str, resource_id: str, relation: str, target: str) -> None:
         """Create an FGA relation tuple."""
+        self._validate_fga_param(resource_type, "resource_type")
+        self._validate_fga_param(resource_id, "resource_id")
+        self._validate_fga_param(relation, "relation")
+        self._validate_fga_param(target, "target")
         await self._request(
             "/v1/mgmt/authz/re/save",
             {
@@ -226,6 +244,10 @@ class DescopeManagementClient:
 
     async def delete_relation(self, resource_type: str, resource_id: str, relation: str, target: str) -> None:
         """Delete an FGA relation tuple."""
+        self._validate_fga_param(resource_type, "resource_type")
+        self._validate_fga_param(resource_id, "resource_id")
+        self._validate_fga_param(relation, "relation")
+        self._validate_fga_param(target, "target")
         await self._request(
             "/v1/mgmt/authz/re/delete",
             {
@@ -236,16 +258,29 @@ class DescopeManagementClient:
             },
         )
 
-    async def list_relations(self, resource_type: str, resource_id: str) -> list[dict]:
+    async def list_relations(
+        self, resource_type: str, resource_id: str, relation: str | None = None, target: str | None = None
+    ) -> list[dict]:
         """List all relation tuples for a specific resource. Returns empty list if none."""
-        resp = await self._request(
-            "/v1/mgmt/authz/re/who",
-            {"resourceType": resource_type, "resource": resource_id},
-        )
+        self._validate_fga_param(resource_type, "resource_type")
+        self._validate_fga_param(resource_id, "resource_id")
+        if relation is not None:
+            self._validate_fga_param(relation, "relation")
+        if target is not None:
+            self._validate_fga_param(target, "target")
+        body: dict = {"resourceType": resource_type, "resource": resource_id}
+        if relation is not None:
+            body["relationDefinition"] = relation
+        if target is not None:
+            body["target"] = target
+        resp = await self._request("/v1/mgmt/authz/re/who", body)
         return resp.json().get("relationInfo") or []
 
     async def list_user_resources(self, resource_type: str, relation: str, target: str) -> list[dict]:
         """List resources a target has a specific relation to. Returns empty list if none."""
+        self._validate_fga_param(resource_type, "resource_type")
+        self._validate_fga_param(relation, "relation")
+        self._validate_fga_param(target, "target")
         resp = await self._request(
             "/v1/mgmt/authz/re/resource",
             {
@@ -257,7 +292,16 @@ class DescopeManagementClient:
         return resp.json().get("resources") or []
 
     async def check_permission(self, resource_type: str, resource_id: str, relation: str, target: str) -> bool:
-        """Check if a target has a specific relation to a resource. Returns True/False."""
+        """Check if a subject has a relation to a resource. Returns True/False.
+
+        Raises httpx.HTTPStatusError on API errors (4xx/5xx).
+        Raises httpx.RequestError on network/transport errors.
+        Callers should handle these for fail-closed behavior.
+        """
+        self._validate_fga_param(resource_type, "resource_type")
+        self._validate_fga_param(resource_id, "resource_id")
+        self._validate_fga_param(relation, "relation")
+        self._validate_fga_param(target, "target")
         resp = await self._request(
             "/v1/mgmt/authz/re/has",
             {

--- a/backend/tests/unit/test_descope_service.py
+++ b/backend/tests/unit/test_descope_service.py
@@ -490,7 +490,7 @@ class TestDescopeManagementClient:
         )
 
         result = await client.get_fga_schema()
-        assert result == {"schema": {"name": "test-schema"}}
+        assert result == {"name": "test-schema"}
         mock_http.post.assert_called_once_with(
             "https://api.descope.com/v1/mgmt/authz/schema/load",
             headers={"Authorization": "Bearer proj-123:mgmt-key-456"},
@@ -760,6 +760,135 @@ class TestDescopeManagementClient:
 
         with pytest.raises(httpx.HTTPStatusError):
             await client.check_permission("document", "doc-123", "editor", "user:u1")
+
+    # --- FGA input validation tests ---
+
+    @pytest.mark.anyio
+    async def test_create_relation_rejects_empty_resource_type(self, client):
+        with pytest.raises(ValueError, match="resource_type must be a non-empty string"):
+            await client.create_relation("", "doc-1", "editor", "user:u1")
+
+    @pytest.mark.anyio
+    async def test_create_relation_rejects_whitespace_only(self, client):
+        with pytest.raises(ValueError, match="resource_type must be a non-empty string"):
+            await client.create_relation("   ", "doc-1", "editor", "user:u1")
+
+    @pytest.mark.anyio
+    async def test_create_relation_rejects_invalid_characters(self, client):
+        with pytest.raises(ValueError, match="resource_type contains invalid characters"):
+            await client.create_relation("doc;DROP TABLE", "doc-1", "editor", "user:u1")
+
+    @pytest.mark.anyio
+    async def test_create_relation_rejects_too_long(self, client):
+        with pytest.raises(ValueError, match="resource_type must not exceed 200 characters"):
+            await client.create_relation("a" * 201, "doc-1", "editor", "user:u1")
+
+    @pytest.mark.anyio
+    async def test_delete_relation_rejects_empty_target(self, client):
+        with pytest.raises(ValueError, match="target must be a non-empty string"):
+            await client.delete_relation("document", "doc-1", "editor", "")
+
+    @pytest.mark.anyio
+    async def test_list_relations_rejects_empty_resource_id(self, client):
+        with pytest.raises(ValueError, match="resource_id must be a non-empty string"):
+            await client.list_relations("document", "")
+
+    @pytest.mark.anyio
+    async def test_list_user_resources_rejects_invalid_chars(self, client):
+        with pytest.raises(ValueError, match="relation contains invalid characters"):
+            await client.list_user_resources("document", "editor/../../etc", "user:u1")
+
+    @pytest.mark.anyio
+    async def test_check_permission_rejects_empty_relation(self, client):
+        with pytest.raises(ValueError, match="relation must be a non-empty string"):
+            await client.check_permission("document", "doc-1", "", "user:u1")
+
+    @pytest.mark.anyio
+    async def test_update_fga_schema_rejects_empty(self, client):
+        with pytest.raises(ValueError, match="schema must be a non-empty string"):
+            await client.update_fga_schema("")
+
+    @pytest.mark.anyio
+    async def test_update_fga_schema_rejects_whitespace(self, client):
+        with pytest.raises(ValueError, match="schema must be a non-empty string"):
+            await client.update_fga_schema("   ")
+
+    @pytest.mark.anyio
+    async def test_fga_param_allows_valid_identifiers(self, client):
+        """Verify that valid FGA identifiers pass validation."""
+        # Should not raise — uses colons, dots, hyphens, underscores
+        client._validate_fga_param("user:u1", "target")
+        client._validate_fga_param("my_resource.type-v2", "resource_type")
+        client._validate_fga_param("org:tenant-123", "resource_id")
+
+    # --- list_relations with filter params ---
+
+    @pytest.mark.anyio
+    @patch("app.services.descope.httpx.AsyncClient")
+    async def test_list_relations_with_relation_filter(self, mock_cls, client):
+        mock_http = AsyncMock()
+        mock_cls.return_value = mock_http
+        mock_http.post.return_value = MagicMock(
+            status_code=200,
+            raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"relationInfo": [{"target": "user:u1", "relationDefinition": "editor"}]}),
+        )
+
+        result = await client.list_relations("document", "doc-123", relation="editor")
+        assert len(result) == 1
+        mock_http.post.assert_called_once_with(
+            "https://api.descope.com/v1/mgmt/authz/re/who",
+            headers={"Authorization": "Bearer proj-123:mgmt-key-456"},
+            json={"resourceType": "document", "resource": "doc-123", "relationDefinition": "editor"},
+        )
+
+    @pytest.mark.anyio
+    @patch("app.services.descope.httpx.AsyncClient")
+    async def test_list_relations_with_target_filter(self, mock_cls, client):
+        mock_http = AsyncMock()
+        mock_cls.return_value = mock_http
+        mock_http.post.return_value = MagicMock(
+            status_code=200,
+            raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"relationInfo": [{"target": "user:u1", "relationDefinition": "editor"}]}),
+        )
+
+        result = await client.list_relations("document", "doc-123", target="user:u1")
+        assert len(result) == 1
+        mock_http.post.assert_called_once_with(
+            "https://api.descope.com/v1/mgmt/authz/re/who",
+            headers={"Authorization": "Bearer proj-123:mgmt-key-456"},
+            json={"resourceType": "document", "resource": "doc-123", "target": "user:u1"},
+        )
+
+    @pytest.mark.anyio
+    @patch("app.services.descope.httpx.AsyncClient")
+    async def test_list_relations_with_both_filters(self, mock_cls, client):
+        mock_http = AsyncMock()
+        mock_cls.return_value = mock_http
+        mock_http.post.return_value = MagicMock(
+            status_code=200,
+            raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"relationInfo": [{"target": "user:u1", "relationDefinition": "editor"}]}),
+        )
+
+        result = await client.list_relations("document", "doc-123", relation="editor", target="user:u1")
+        assert len(result) == 1
+        mock_http.post.assert_called_once_with(
+            "https://api.descope.com/v1/mgmt/authz/re/who",
+            headers={"Authorization": "Bearer proj-123:mgmt-key-456"},
+            json={
+                "resourceType": "document",
+                "resource": "doc-123",
+                "relationDefinition": "editor",
+                "target": "user:u1",
+            },
+        )
+
+    @pytest.mark.anyio
+    async def test_list_relations_rejects_invalid_filter_relation(self, client):
+        with pytest.raises(ValueError, match="relation contains invalid characters"):
+            await client.list_relations("document", "doc-1", relation="editor;DROP")
 
 
 class TestGetDescopeClient:


### PR DESCRIPTION
## Summary
- Add 7 FGA (Fine-Grained Authorization) methods to `DescopeManagementClient`: `get_fga_schema`, `update_fga_schema`, `create_relation`, `delete_relation`, `list_relations`, `list_user_resources`, `check_permission`
- All methods use the existing `_request()` pattern with same `httpx.AsyncClient` lifecycle (NFR-19: single abstraction seam)
- `check_permission` returns `bool` with fail-closed default (`False` when `allowed` field is missing or null)
- List methods return `[]` on empty/null responses (never `None`)

## Story
Refs #112
Part of Epic 3: Fine-Grained Authorization (FGA/ReBAC)

## Review Findings Addressed
- Security: 0 BLOCK, 2 WARN — both fixed (bool coercion, null handling)
- Blind Hunter: 0 MUST FIX, 4 SHOULD FIX — 2 fixed, 2 deferred (pre-existing patterns)
- Edge Cases: 4 unhandled paths found, 3 fixed
- Acceptance: 7 PASS, 0 FAIL, 1 PARTIAL (coverage % not measured with tool)

## Test plan
- [x] Unit tests pass (`make test-unit` — 51 tests in service file, all green)
- [x] Lint passes (`ruff check` + `ruff format`)
- [ ] CI passes
- [ ] Manual verification against Descope sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)