### PR TITLE
feat: replace Swagger UI with Scalar API reference

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 import httpx
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from scalar_fastapi import get_scalar_api_reference
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
@@ -31,7 +32,7 @@ async def lifespan(app: FastAPI):
     shutdown_descope_client()
 
 
-app = FastAPI(title="Descope SaaS Starter API", redoc_url="/redoc", lifespan=lifespan)
+app = FastAPI(title="Descope SaaS Starter API", docs_url=None, redoc_url="/redoc", lifespan=lifespan)
 
 # Rate limiter state and exception handler
 app.state.limiter = limiter
@@ -79,3 +80,11 @@ app.include_router(attributes.router, prefix="/api")
 app.include_router(accesskeys.router, prefix="/api")
 app.include_router(permissions.router, prefix="/api")
 app.include_router(users.router, prefix="/api")
+
+
+@app.get("/docs", include_in_schema=False)
+async def scalar_docs():
+    return get_scalar_api_reference(
+        openapi_url=app.openapi_url,
+        title=app.title,
+    )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic[email]>=2.0",
     "slowapi>=0.1.9,<1",
     "python-json-logger>=3.0,<5",
+    "scalar-fastapi>=1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Replaces default Swagger UI with [Scalar](https://github.com/scalar/scalar) at `/docs` for a modern, faster API docs experience
- Adds `scalar-fastapi` dependency to backend
- Disables built-in Swagger UI (`docs_url=None`), Redoc remains at `/redoc`

Closes #126

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] All 215 unit tests pass
- [ ] Verify `/docs` serves Scalar API reference
- [ ] Verify `/redoc` still serves Redoc
- [ ] Verify `/openapi.json` still returns the OpenAPI spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)