### PR TITLE
fix(infra): TF syntax for v1.14+ and import existing resources

### DIFF
--- a/infra/access_key.tf
+++ b/infra/access_key.tf
@@ -11,8 +11,8 @@ resource "descope_access_key" "acme_api" {
   name        = "Acme API Key"
   description = "Programmatic access for Acme Corp integrations"
 
-  key_tenants {
+  key_tenants = [{
     tenant_id = descope_tenant.acme.id
     roles     = [descope_role.viewer.name]
-  }
+  }]
 }

--- a/infra/fga.tf
+++ b/infra/fga.tf
@@ -12,8 +12,8 @@ type user
 type document
   relation owner: user
   relation editor: user
-  relation viewer: user | editor | owner
-  permission can_view: viewer
+  relation viewer: user
+  permission can_view: viewer | editor | owner
   permission can_edit: editor | owner
   permission can_delete: owner
 EOT

--- a/infra/project.tf
+++ b/infra/project.tf
@@ -21,7 +21,7 @@ resource "descope_project" "main" {
     prevent_destroy = true
   }
 
-  project_settings {
+  project_settings = {
     refresh_token_rotation              = true
     session_token_expiration            = var.session_token_expiration
     refresh_token_expiration            = var.refresh_token_expiration

--- a/infra/rbac.tf
+++ b/infra/rbac.tf
@@ -125,3 +125,85 @@ resource "descope_role" "viewer" {
     descope_permission.documents_read.name,
   ]
 }
+
+# Import pre-existing roles into state
+import {
+  to = descope_role.owner
+  id = "owner"
+}
+
+import {
+  to = descope_role.admin
+  id = "admin"
+}
+
+import {
+  to = descope_role.member
+  id = "member"
+}
+
+import {
+  to = descope_role.viewer
+  id = "viewer"
+}
+
+# Import pre-existing permissions into state
+import {
+  to = descope_permission.projects_create
+  id = "projects.create"
+}
+
+import {
+  to = descope_permission.projects_read
+  id = "projects.read"
+}
+
+import {
+  to = descope_permission.projects_update
+  id = "projects.update"
+}
+
+import {
+  to = descope_permission.projects_delete
+  id = "projects.delete"
+}
+
+import {
+  to = descope_permission.members_invite
+  id = "members.invite"
+}
+
+import {
+  to = descope_permission.members_remove
+  id = "members.remove"
+}
+
+import {
+  to = descope_permission.members_update_role
+  id = "members.update_role"
+}
+
+import {
+  to = descope_permission.documents_read
+  id = "documents.read"
+}
+
+import {
+  to = descope_permission.documents_write
+  id = "documents.write"
+}
+
+import {
+  to = descope_permission.documents_delete
+  id = "documents.delete"
+}
+
+import {
+  to = descope_permission.settings_manage
+  id = "settings.manage"
+}
+
+import {
+  to = descope_permission.billing_manage
+  id = "billing.manage"
+}


### PR DESCRIPTION
## Summary
- Fix nested block syntax (`project_settings`, `key_tenants`) for Terraform v1.14.6 on HCP Terraform
- Fix FGA schema: relations can only reference types, not other relations
- Import pre-existing roles (owner, admin, member, viewer) and permissions (12 total) so Terraform manages them

## Context
After keys were purged, `terraform apply` was run to recreate access keys and push CI secrets (`DESCOPE_CLIENT_ID`, `DESCOPE_CLIENT_SECRET`, `DESCOPE_EXPIRED_TOKEN`, `DESCOPE_PROJECT_ID`) to GitHub Actions. These syntax fixes were needed for the apply to succeed.

## Test plan
- [x] `terraform apply` completed successfully (2 imported, 2 added, 3 changed)
- [x] GitHub Actions secrets updated
- [ ] CI should pass with new credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)