### PR TITLE
fix: missing test deps and migration enum type errors

### DIFF
--- a/backend/app/models/identity/provider.py
+++ b/backend/app/models/identity/provider.py
@@ -24,7 +24,7 @@ class Provider(SQLModel, table=True):
     id: uuid_mod.UUID = Field(default_factory=uuid_mod.uuid4, primary_key=True, sa_type=sa.Uuid)
     name: str = Field(sa_column=sa.Column(sa.String, nullable=False, unique=True))
     type: ProviderType = Field(
-        sa_column=sa.Column(sa.Enum(ProviderType, name="providertype"), nullable=False, index=True)
+        sa_column=sa.Column(sa.Enum(ProviderType, name="provider_type"), nullable=False, index=True)
     )
     issuer_url: str = Field(default="", sa_column=sa.Column(sa.String, nullable=False, server_default=""))
     base_url: str = Field(default="", sa_column=sa.Column(sa.String, nullable=False, server_default=""))

--- a/backend/app/models/identity/tenant.py
+++ b/backend/app/models/identity/tenant.py
@@ -28,7 +28,7 @@ class Tenant(SQLModel, table=True):
     domains: list[str] = Field(default_factory=list, sa_column=sa.Column(sa.JSON, nullable=False, server_default="[]"))
     status: TenantStatus = Field(
         default=TenantStatus.active,
-        sa_column=sa.Column(sa.Enum(TenantStatus, name="tenantstatus"), nullable=False, server_default="active"),
+        sa_column=sa.Column(sa.Enum(TenantStatus, name="tenant_status"), nullable=False, server_default="active"),
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),

--- a/backend/app/models/identity/user.py
+++ b/backend/app/models/identity/user.py
@@ -31,7 +31,7 @@ class User(SQLModel, table=True):
     family_name: str = Field(default="", sa_column=sa.Column(sa.String, nullable=False, server_default=""))
     status: UserStatus = Field(
         default=UserStatus.active,
-        sa_column=sa.Column(sa.Enum(UserStatus, name="userstatus"), nullable=False, server_default="active"),
+        sa_column=sa.Column(sa.Enum(UserStatus, name="user_status"), nullable=False, server_default="active"),
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),

--- a/backend/migrations/versions/002_canonical_identity_schema.py
+++ b/backend/migrations/versions/002_canonical_identity_schema.py
@@ -37,14 +37,10 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     _assert_postgresql()
-    # --- Enum types (use raw SQL for offline-mode compatibility) ---
-    op.execute("CREATE TYPE IF NOT EXISTS userstatus AS ENUM ('active', 'inactive', 'provisioned')")
-    op.execute("CREATE TYPE IF NOT EXISTS tenantstatus AS ENUM ('active', 'suspended')")
-    op.execute("CREATE TYPE IF NOT EXISTS providertype AS ENUM ('descope', 'ory', 'entra', 'cognito', 'oidc')")
-
-    userstatus = sa.Enum("active", "inactive", "provisioned", name="userstatus", create_type=False)
-    tenantstatus = sa.Enum("active", "suspended", name="tenantstatus", create_type=False)
-    providertype = sa.Enum("descope", "ory", "entra", "cognito", "oidc", name="providertype", create_type=False)
+    # --- Enum types (created automatically by sa.Enum in create_table) ---
+    userstatus = sa.Enum("active", "inactive", "provisioned", name="user_status")
+    tenantstatus = sa.Enum("active", "suspended", name="tenant_status")
+    providertype = sa.Enum("descope", "ory", "entra", "cognito", "oidc", name="provider_type")
 
     # --- 1. users ---
     op.create_table(
@@ -236,6 +232,6 @@ def downgrade() -> None:
     op.drop_table("users")
 
     # Drop enum types (use raw SQL for offline-mode compatibility)
-    op.execute("DROP TYPE IF EXISTS providertype")
-    op.execute("DROP TYPE IF EXISTS tenantstatus")
-    op.execute("DROP TYPE IF EXISTS userstatus")
+    op.execute(sa.text("DROP TYPE IF EXISTS provider_type"))
+    op.execute(sa.text("DROP TYPE IF EXISTS tenant_status"))
+    op.execute(sa.text("DROP TYPE IF EXISTS user_status"))

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -61,4 +61,10 @@ markers = [
 dev = [
     "pip-audit>=2.9",
     "pytest-playwright>=0.7.2",
+    "pytest>=8.0",
+    "anyio[trio]>=4.0",
+    "pytest-asyncio>=0.24",
+    "ruff>=0.9",
+    "aiosqlite>=0.20",
+    "testcontainers[postgres]>=4.0",
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -684,8 +684,14 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiosqlite" },
+    { name = "anyio", extra = ["trio"] },
     { name = "pip-audit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-playwright" },
+    { name = "ruff" },
+    { name = "testcontainers" },
 ]
 
 [package.metadata]
@@ -721,8 +727,14 @@ provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiosqlite", specifier = ">=0.20" },
+    { name = "anyio", extras = ["trio"], specifier = ">=4.0" },
     { name = "pip-audit", specifier = ">=2.9" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-playwright", specifier = ">=0.7.2" },
+    { name = "ruff", specifier = ">=0.9" },
+    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Consolidate test dependencies (`aiosqlite`, `pytest`, `pytest-asyncio`, `testcontainers`, `ruff`, `anyio`) into `[dependency-groups] dev` so `uv sync` installs them without `--extra` flag
- Fix Alembic migration 002: `CREATE TYPE IF NOT EXISTS` is invalid PostgreSQL syntax — let SQLAlchemy handle enum creation via `create_table` instead
- Rename enum types to snake_case: `userstatus` → `user_status`, `tenantstatus` → `tenant_status`, `providertype` → `provider_type`

## Test plan
- [x] 835 unit + integration tests pass (`uv run python -m pytest tests/unit/ tests/integration/`)
- [x] Alembic migration upgrade/downgrade/re-upgrade cycle verified against fresh Postgres via testcontainers
- [x] `uv sync` (no flags) installs all test dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)