### PR TITLE
feat: E2E Tests + Regression for Identity CRUD (Story 2.5)

### DIFF
--- a/backend/tests/e2e/test_identity_crud_e2e.py
+++ b/backend/tests/e2e/test_identity_crud_e2e.py
@@ -473,9 +473,9 @@ class TestMemberCrud:
                 pytest.skip("Invite returned 207 (sync failed) — canonical fields not in Problem Detail body")
             assert "user" in body, f"Missing 'user' key in invite response: {body.keys()}"
             user = body["user"]
-            created_user_id = str(user["id"])
             assert "id" in user, f"Missing 'id' in user response: {user}"
             assert "created_at" in user, f"Missing 'created_at' in user response: {user}"
+            created_user_id = str(user["id"])
         finally:
             if created_user_id:
                 with contextlib.suppress(Exception):
@@ -579,3 +579,7 @@ class TestTenantOperations:
         body = resp.json()
         assert "tenant_id" in body
         assert "tenant" in body, f"Missing 'tenant' key in current tenant response: {body.keys()}"
+        tenant = body["tenant"]
+        assert "id" in tenant, f"Missing 'id' in tenant response: {tenant}"
+        assert "created_at" in tenant, f"Missing 'created_at' in tenant response: {tenant}"
+        assert "updated_at" in tenant, f"Missing 'updated_at' in tenant response: {tenant}"


### PR DESCRIPTION
## Summary
- Add comprehensive E2E tests for identity CRUD operations (users, roles, permissions, tenants)
- Verify 3-tier auth enforcement: unauthenticated (401), non-admin (403), admin (success)
- Validate response shapes include canonical fields (id, created_at, updated_at)
- Regression verification: existing E2E tests unaffected by onion architecture refactor

## Story
Refs #148
Part of PRD 5: Canonical Identity Domain Model

## Chained PR
Based on #206 (merged into story-2.3 branch) — merge story-2.3 first

## Review Findings Addressed
- Security: 0 BLOCK, 2 WARN — out of scope (existing helpers/auth.py)
- Blind Hunter: 0 MUST FIX, 1 SHOULD FIX, 2 NITPICK — all resolved
- Edge Cases: 0 findings
- Acceptance: 4/4 PASS, 0 FAIL, 0 PARTIAL

## Verification Evidence
- Lint: pass (ruff check + format)
- Unit tests: 1127 passed
- Frontend tests: 86 passed (9 suites)

## Test plan
- [x] Unit tests pass (`make test-unit` — 1127 passed)
- [x] Frontend tests pass (`make test-frontend` — 86 passed)
- [x] Lint passes (`make lint`)
- [x] Independent review agents passed
- [ ] CI passes
- [ ] E2E tests pass (`make test-e2e` — requires live Descope environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)