### PR TITLE
feat: add Tyk Gateway and Redis services to Docker Compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,3 +173,4 @@ jobs:
         env:
           DESCOPE_PROJECT_ID: "test-project-id"
           POSTGRES_PASSWORD: "ci-build-only"
+          TYK_GATEWAY_SECRET: "ci-build-only"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,3 +38,7 @@ DESCOPE_MANAGEMENT_KEY=your-management-key
 # In gateway mode, Tyk handles JWT validation and rate limiting;
 # TokenValidationMiddleware and SlowAPIMiddleware are skipped.
 # DEPLOYMENT_MODE=standalone
+
+# Tyk Gateway secret (required for gateway profile)
+# Must match the secret in tyk/tyk.conf. Used by docker-compose env var substitution.
+# TYK_GATEWAY_SECRET=your-tyk-gateway-secret

--- a/backend/tests/unit/test_docker_compose_gateway.py
+++ b/backend/tests/unit/test_docker_compose_gateway.py
@@ -1,0 +1,209 @@
+"""Unit tests for docker-compose gateway profile (Story 1.3).
+
+Validates that the docker-compose.yml defines tyk-gateway and tyk-redis services
+correctly under the gateway profile, and that default compose behavior is unchanged.
+"""
+
+import json
+from pathlib import Path
+
+import yaml
+
+# Repo root is two levels up from tests/unit/
+REPO_ROOT = Path(__file__).resolve().parents[2].parent
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+TYK_DIR = REPO_ROOT / "tyk"
+ENV_EXAMPLE = REPO_ROOT / "backend" / ".env.example"
+
+
+def _load_compose() -> dict:
+    """Load and parse docker-compose.yml."""
+    return yaml.safe_load(COMPOSE_FILE.read_text())
+
+
+class TestTykGatewayService:
+    """AC1: tyk-gateway service configuration."""
+
+    def test_tyk_gateway_service_exists(self):
+        compose = _load_compose()
+        assert "tyk-gateway" in compose["services"]
+
+    def test_tyk_gateway_image(self):
+        svc = _load_compose()["services"]["tyk-gateway"]
+        assert svc["image"] == "tykio/tyk-gateway:v5.3"
+
+    def test_tyk_gateway_port(self):
+        svc = _load_compose()["services"]["tyk-gateway"]
+        assert "8080:8080" in svc["ports"]
+
+    def test_tyk_gateway_volume_tyk_conf(self):
+        svc = _load_compose()["services"]["tyk-gateway"]
+        volumes = svc["volumes"]
+        assert any("tyk/tyk.conf" in v for v in volumes)
+
+    def test_tyk_gateway_volume_apps(self):
+        svc = _load_compose()["services"]["tyk-gateway"]
+        volumes = svc["volumes"]
+        assert any("tyk/apps" in v for v in volumes)
+
+    def test_tyk_gateway_volume_middleware(self):
+        svc = _load_compose()["services"]["tyk-gateway"]
+        volumes = svc["volumes"]
+        assert any("tyk/middleware" in v for v in volumes)
+
+    def test_tyk_gateway_volume_policies(self):
+        svc = _load_compose()["services"]["tyk-gateway"]
+        volumes = svc["volumes"]
+        assert any("tyk/policies" in v for v in volumes)
+
+
+class TestTykRedisService:
+    """AC2: tyk-redis service configuration."""
+
+    def test_tyk_redis_service_exists(self):
+        compose = _load_compose()
+        assert "tyk-redis" in compose["services"]
+
+    def test_tyk_redis_image(self):
+        svc = _load_compose()["services"]["tyk-redis"]
+        assert svc["image"] == "redis:7-alpine"
+
+    def test_tyk_redis_named_volume(self):
+        svc = _load_compose()["services"]["tyk-redis"]
+        volumes = svc.get("volumes", [])
+        assert any("tyk-redis-data" in v for v in volumes)
+
+    def test_tyk_redis_volume_declared(self):
+        compose = _load_compose()
+        assert "tyk-redis-data" in compose.get("volumes", {})
+
+
+class TestTykGatewayDependencies:
+    """AC3: tyk-gateway depends on tyk-redis and backend."""
+
+    def test_depends_on_tyk_redis(self):
+        svc = _load_compose()["services"]["tyk-gateway"]
+        deps = svc.get("depends_on", [])
+        # depends_on can be a list or dict
+        if isinstance(deps, dict):
+            assert "tyk-redis" in deps
+        else:
+            assert "tyk-redis" in deps
+
+    def test_depends_on_backend(self):
+        svc = _load_compose()["services"]["tyk-gateway"]
+        deps = svc.get("depends_on", [])
+        if isinstance(deps, dict):
+            assert "backend" in deps
+        else:
+            assert "backend" in deps
+
+
+class TestGatewayProfiles:
+    """AC4: Both tyk services under gateway profile — not started by default."""
+
+    def test_tyk_gateway_has_gateway_profile(self):
+        svc = _load_compose()["services"]["tyk-gateway"]
+        assert "gateway" in svc.get("profiles", [])
+
+    def test_tyk_redis_has_gateway_profile(self):
+        svc = _load_compose()["services"]["tyk-redis"]
+        assert "gateway" in svc.get("profiles", [])
+
+    def test_existing_services_have_no_profile(self):
+        """Default services (frontend, backend, postgres, etc.) have no profiles."""
+        compose = _load_compose()
+        default_services = ["frontend", "backend", "postgres", "aspire-dashboard", "redis"]
+        for name in default_services:
+            svc = compose["services"].get(name)
+            if svc is not None:
+                assert "profiles" not in svc, f"Service '{name}' should not have profiles"
+
+
+class TestTykGatewaySecret:
+    """AC5: TYK_GATEWAY_SECRET sourced from env var substitution, not hardcoded."""
+
+    def test_tyk_gateway_secret_env_var(self):
+        svc = _load_compose()["services"]["tyk-gateway"]
+        env_list = svc.get("environment", [])
+        secret_entries = [e for e in env_list if "TYK_GW_SECRET" in str(e)]
+        assert len(secret_entries) == 1
+        entry = secret_entries[0]
+        # Must reference ${TYK_GATEWAY_SECRET}, not a hardcoded value
+        assert "${TYK_GATEWAY_SECRET}" in str(entry)
+
+    def test_tyk_conf_secret_placeholder(self):
+        """tyk.conf uses a placeholder (not a real secret)."""
+        conf = json.loads((TYK_DIR / "tyk.conf").read_text())
+        secret = conf.get("secret", "")
+        assert secret == "${TYK_GATEWAY_SECRET}"
+
+
+class TestEnvExample:
+    """AC6: .env.example has TYK_GATEWAY_SECRET placeholder."""
+
+    def test_env_example_has_tyk_gateway_secret(self):
+        content = ENV_EXAMPLE.read_text()
+        assert "TYK_GATEWAY_SECRET" in content
+
+
+class TestDefaultComposeUnchanged:
+    """AC7: Default compose (no profile) starts only original services."""
+
+    def test_only_default_services_without_profile(self):
+        """Services without profiles are the 'default' set."""
+        compose = _load_compose()
+        default_services = []
+        for name, svc in compose["services"].items():
+            if "profiles" not in svc:
+                default_services.append(name)
+        # Original set: frontend, backend, postgres, aspire-dashboard, redis
+        expected = {"frontend", "backend", "postgres", "aspire-dashboard", "redis"}
+        assert set(default_services) == expected
+
+
+class TestTykConfigJsonValidity:
+    """Validate Tyk JSON config files are syntactically valid with required keys."""
+
+    def test_tyk_conf_valid_json(self):
+        conf = json.loads((TYK_DIR / "tyk.conf").read_text())
+        assert isinstance(conf, dict)
+
+    def test_tyk_conf_required_keys(self):
+        conf = json.loads((TYK_DIR / "tyk.conf").read_text())
+        assert conf["listen_port"] == 8080
+        assert conf["use_db_app_configs"] is False
+        assert conf["storage"]["type"] == "redis"
+        assert conf["storage"]["host"] == "tyk-redis"
+
+    def test_api_definition_valid_json(self):
+        api_def = json.loads((TYK_DIR / "apps" / "saas-backend.json").read_text())
+        assert isinstance(api_def, dict)
+
+    def test_api_definition_required_keys(self):
+        api_def = json.loads((TYK_DIR / "apps" / "saas-backend.json").read_text())
+        assert api_def["api_id"] == "saas-backend"
+        assert api_def["use_openid"] is True
+        assert api_def["target_url"] == "http://backend:8000/api/"
+        assert api_def["active"] is True
+
+
+class TestServiceIsolation:
+    """tyk-redis and app redis are separate services."""
+
+    def test_two_redis_services(self):
+        compose = _load_compose()
+        assert "redis" in compose["services"]
+        assert "tyk-redis" in compose["services"]
+
+    def test_separate_redis_volumes(self):
+        """tyk-redis uses its own named volume, not the app redis volume."""
+        compose = _load_compose()
+        app_redis = compose["services"]["redis"]
+        tyk_redis = compose["services"]["tyk-redis"]
+        # App redis has no named volume (no volumes key or different volume)
+        app_volumes = app_redis.get("volumes", [])
+        tyk_volumes = tyk_redis.get("volumes", [])
+        # tyk-redis-data should only appear in tyk-redis
+        assert any("tyk-redis-data" in str(v) for v in tyk_volumes)
+        assert not any("tyk-redis-data" in str(v) for v in app_volumes)

--- a/backend/tests/unit/test_docker_compose_gateway.py
+++ b/backend/tests/unit/test_docker_compose_gateway.py
@@ -96,18 +96,12 @@ class TestTykGatewayDependencies:
     def test_depends_on_tyk_redis(self):
         svc = _load_compose()["services"]["tyk-gateway"]
         deps = svc.get("depends_on", [])
-        if isinstance(deps, dict):
-            assert "tyk-redis" in deps
-        else:
-            assert "tyk-redis" in deps
+        assert "tyk-redis" in deps
 
     def test_depends_on_backend(self):
         svc = _load_compose()["services"]["tyk-gateway"]
         deps = svc.get("depends_on", [])
-        if isinstance(deps, dict):
-            assert "backend" in deps
-        else:
-            assert "backend" in deps
+        assert "backend" in deps
 
 
 class TestGatewayProfiles:

--- a/backend/tests/unit/test_docker_compose_gateway.py
+++ b/backend/tests/unit/test_docker_compose_gateway.py
@@ -34,7 +34,14 @@ class TestTykGatewayService:
 
     def test_tyk_gateway_port(self):
         svc = _load_compose()["services"]["tyk-gateway"]
-        assert "8080:8080" in svc["ports"]
+        ports = svc["ports"]
+        assert any("8080" in str(p) for p in ports)
+
+    def test_tyk_gateway_port_localhost_binding(self):
+        """Gateway port must bind to 127.0.0.1, matching other services."""
+        svc = _load_compose()["services"]["tyk-gateway"]
+        ports = svc["ports"]
+        assert any("127.0.0.1:8080:8080" in str(p) for p in ports)
 
     def test_tyk_gateway_volume_tyk_conf(self):
         svc = _load_compose()["services"]["tyk-gateway"]
@@ -55,6 +62,11 @@ class TestTykGatewayService:
         svc = _load_compose()["services"]["tyk-gateway"]
         volumes = svc["volumes"]
         assert any("tyk/policies" in v for v in volumes)
+
+    def test_tyk_gateway_restart_policy(self):
+        """Gateway should have a restart policy for crash recovery."""
+        svc = _load_compose()["services"]["tyk-gateway"]
+        assert "restart" in svc
 
 
 class TestTykRedisService:
@@ -84,7 +96,6 @@ class TestTykGatewayDependencies:
     def test_depends_on_tyk_redis(self):
         svc = _load_compose()["services"]["tyk-gateway"]
         deps = svc.get("depends_on", [])
-        # depends_on can be a list or dict
         if isinstance(deps, dict):
             assert "tyk-redis" in deps
         else:
@@ -100,15 +111,23 @@ class TestTykGatewayDependencies:
 
 
 class TestGatewayProfiles:
-    """AC4: Both tyk services under gateway profile — not started by default."""
+    """AC4: Both tyk services under gateway and full profiles — not started by default."""
 
     def test_tyk_gateway_has_gateway_profile(self):
         svc = _load_compose()["services"]["tyk-gateway"]
         assert "gateway" in svc.get("profiles", [])
 
+    def test_tyk_gateway_has_full_profile(self):
+        svc = _load_compose()["services"]["tyk-gateway"]
+        assert "full" in svc.get("profiles", [])
+
     def test_tyk_redis_has_gateway_profile(self):
         svc = _load_compose()["services"]["tyk-redis"]
         assert "gateway" in svc.get("profiles", [])
+
+    def test_tyk_redis_has_full_profile(self):
+        svc = _load_compose()["services"]["tyk-redis"]
+        assert "full" in svc.get("profiles", [])
 
     def test_existing_services_have_no_profile(self):
         """Default services (frontend, backend, postgres, etc.) have no profiles."""
@@ -121,22 +140,37 @@ class TestGatewayProfiles:
 
 
 class TestTykGatewaySecret:
-    """AC5: TYK_GATEWAY_SECRET sourced from env var substitution, not hardcoded."""
+    """AC5: TYK_GATEWAY_SECRET sourced from env var substitution with fail-fast guard."""
 
     def test_tyk_gateway_secret_env_var(self):
         svc = _load_compose()["services"]["tyk-gateway"]
-        env_list = svc.get("environment", [])
-        secret_entries = [e for e in env_list if "TYK_GW_SECRET" in str(e)]
-        assert len(secret_entries) == 1
-        entry = secret_entries[0]
-        # Must reference ${TYK_GATEWAY_SECRET}, not a hardcoded value
-        assert "${TYK_GATEWAY_SECRET}" in str(entry)
+        env = svc.get("environment", [])
+        # Handle both list and dict forms of environment
+        if isinstance(env, dict):
+            secret_value = env.get("TYK_GW_SECRET", "")
+            assert "TYK_GATEWAY_SECRET" in secret_value
+        else:
+            secret_entries = [e for e in env if "TYK_GW_SECRET" in str(e)]
+            assert len(secret_entries) == 1
+            assert "TYK_GATEWAY_SECRET" in str(secret_entries[0])
 
-    def test_tyk_conf_secret_placeholder(self):
-        """tyk.conf uses a placeholder (not a real secret)."""
+    def test_tyk_gateway_secret_has_fail_fast_guard(self):
+        """TYK_GATEWAY_SECRET must use :? syntax to fail if unset."""
+        svc = _load_compose()["services"]["tyk-gateway"]
+        env = svc.get("environment", [])
+        if isinstance(env, dict):
+            secret_value = env.get("TYK_GW_SECRET", "")
+        else:
+            secret_entries = [e for e in env if "TYK_GW_SECRET" in str(e)]
+            secret_value = str(secret_entries[0]) if secret_entries else ""
+        assert ":?" in secret_value, "TYK_GATEWAY_SECRET must use :? syntax to abort if unset"
+
+    def test_tyk_conf_secret_is_sentinel(self):
+        """tyk.conf uses a sentinel value (not a shell-like variable reference)."""
         conf = json.loads((TYK_DIR / "tyk.conf").read_text())
         secret = conf.get("secret", "")
-        assert secret == "${TYK_GATEWAY_SECRET}"
+        # Must not look like a real secret or a shell variable reference
+        assert secret == "REPLACE_AT_RUNTIME"
 
 
 class TestEnvExample:
@@ -201,7 +235,6 @@ class TestServiceIsolation:
         compose = _load_compose()
         app_redis = compose["services"]["redis"]
         tyk_redis = compose["services"]["tyk-redis"]
-        # App redis has no named volume (no volumes key or different volume)
         app_volumes = app_redis.get("volumes", [])
         tyk_volumes = tyk_redis.get("volumes", [])
         # tyk-redis-data should only appear in tyk-redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,21 +63,23 @@ services:
   tyk-gateway:
     image: tykio/tyk-gateway:v5.3
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     volumes:
       - ./tyk/tyk.conf:/opt/tyk-gateway/tyk.conf
       - ./tyk/apps:/opt/tyk-gateway/apps
       - ./tyk/middleware:/opt/tyk-gateway/middleware
       - ./tyk/policies:/opt/tyk-gateway/policies
     environment:
-      - TYK_GW_SECRET=${TYK_GATEWAY_SECRET}
+      - TYK_GW_SECRET=${TYK_GATEWAY_SECRET:?Set TYK_GATEWAY_SECRET in .env}
       - TYK_GW_STORAGE_HOST=tyk-redis
       - TYK_GW_STORAGE_PORT=6379
     depends_on:
       - tyk-redis
       - backend
+    restart: unless-stopped
     profiles:
       - gateway
+      - full
 
   tyk-redis:
     image: redis:7-alpine
@@ -85,6 +87,7 @@ services:
       - tyk-redis-data:/data
     profiles:
       - gateway
+      - full
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,5 +60,32 @@ services:
       - "127.0.0.1:6379:6379"
     command: redis-server --requirepass ${REDIS_PASSWORD:-changeme}
 
+  tyk-gateway:
+    image: tykio/tyk-gateway:v5.3
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./tyk/tyk.conf:/opt/tyk-gateway/tyk.conf
+      - ./tyk/apps:/opt/tyk-gateway/apps
+      - ./tyk/middleware:/opt/tyk-gateway/middleware
+      - ./tyk/policies:/opt/tyk-gateway/policies
+    environment:
+      - TYK_GW_SECRET=${TYK_GATEWAY_SECRET}
+      - TYK_GW_STORAGE_HOST=tyk-redis
+      - TYK_GW_STORAGE_PORT=6379
+    depends_on:
+      - tyk-redis
+      - backend
+    profiles:
+      - gateway
+
+  tyk-redis:
+    image: redis:7-alpine
+    volumes:
+      - tyk-redis-data:/data
+    profiles:
+      - gateway
+
 volumes:
   pgdata:
+  tyk-redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
     image: redis:7-alpine
     volumes:
       - tyk-redis-data:/data
+    restart: unless-stopped
     profiles:
       - gateway
       - full

--- a/tyk/tyk.conf
+++ b/tyk/tyk.conf
@@ -1,6 +1,6 @@
 {
   "listen_port": 8080,
-  "secret": "${TYK_GATEWAY_SECRET}",
+  "secret": "REPLACE_AT_RUNTIME",
   "template_path": "/opt/tyk-gateway/templates",
   "tyk_js_path": "/opt/tyk-gateway/js/tyk.js",
   "middleware_path": "/opt/tyk-gateway/middleware",


### PR DESCRIPTION
## Summary
- Added `tyk-gateway` service (tykio/tyk-gateway:v5.3) with volume mounts to `tyk/` config directory, port 8080, depends_on tyk-redis and backend
- Added `tyk-redis` service (redis:7-alpine) with dedicated named volume for Tyk storage isolation from app Redis
- Both services gated behind `gateway` and `full` Docker Compose profiles — default `docker compose up` unchanged
- `TYK_GATEWAY_SECRET` sourced from env var substitution with `:?` guard for fail-fast on missing value
- Added `TYK_GATEWAY_SECRET` placeholder to `.env.example`

## Story
Refs #163
Part of PRD 2: API Gateway & Deployment Topology

## Review Findings Addressed
- Security: 0 BLOCK, 2 WARN — out of scope (non-compose deployment paths, OIDC is Story 1.2)
- Blind Hunter: 3 MUST FIX, 4 SHOULD FIX — 2 actionable fixed (dead test logic, tyk-redis restart policy)
- Edge Cases: 10 paths found — 8 standard test behavior, 2 out of scope (Story 1.2 OIDC, Story 1.1 directories)
- Acceptance: 6 PASS, 1 FAIL — AC-7 spec wording factually incorrect (says 2 services, pre-gateway has 5); intent fully satisfied
- Red Team: 2 HIGH, 2 MEDIUM, 1 LOW — all concern future stories or non-compose deployment paths

## Test plan
- [x] Unit tests pass (`make test-unit`)
- [x] Lint passes (`make lint`)
- [x] Independent review agents passed (blind, edge, acceptance, security, red team)
- [ ] CI passes
- [ ] Manual verification against Descope sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)