### PR TITLE
feat: add IdP Link and Provider domain services

### DIFF
--- a/backend/app/dependencies/identity.py
+++ b/backend/app/dependencies/identity.py
@@ -5,6 +5,7 @@ AC-2.2.6: get_role_service(), get_permission_service(), get_tenant_service()
 with DescopeSyncAdapter wrapping the singleton DescopeManagementClient.
 AC-3.1.1: get_inbound_sync_service() wires repositories for inbound sync.
 AC-3.2.1: get_reconciliation_service() wires repositories + Descope client for reconciliation.
+AC-4.1.3: get_idp_link_service(), get_provider_service() for IdP link/provider domain services.
 """
 
 from __future__ import annotations
@@ -24,8 +25,10 @@ from app.repositories.user import UserRepository
 from app.services.adapters.descope import DescopeSyncAdapter
 from app.services.cache_invalidation import get_cache_publisher
 from app.services.descope import get_descope_client
+from app.services.idp_link import IdPLinkService
 from app.services.inbound_sync import InboundSyncService
 from app.services.permission import PermissionService
+from app.services.provider import ProviderService
 from app.services.reconciliation import ReconciliationService
 from app.services.role import RoleService
 from app.services.tenant import TenantService
@@ -158,3 +161,33 @@ async def get_reconciliation_service(
         provider_repository=provider_repository,
         publisher=get_cache_publisher(),
     )
+
+
+async def get_idp_link_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> IdPLinkService:
+    """Build an IdPLinkService with its repositories.
+
+    AC-4.1.3: Wiring: AsyncSession -> IdPLinkRepository + UserRepository + ProviderRepository
+               -> IdPLinkService(repository, user_repository, provider_repository)
+    """
+    repository = IdPLinkRepository(session)
+    user_repository = UserRepository(session)
+    provider_repository = ProviderRepository(session)
+    return IdPLinkService(
+        repository=repository,
+        user_repository=user_repository,
+        provider_repository=provider_repository,
+    )
+
+
+async def get_provider_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> ProviderService:
+    """Build a ProviderService with its repository.
+
+    AC-4.1.3: Wiring: AsyncSession -> ProviderRepository(session)
+               -> ProviderService(repository)
+    """
+    repository = ProviderRepository(session)
+    return ProviderService(repository=repository)

--- a/backend/app/repositories/idp_link.py
+++ b/backend/app/repositories/idp_link.py
@@ -25,6 +25,19 @@ class IdPLinkRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
+    async def get(self, link_id: uuid.UUID) -> IdPLink | None:
+        """Fetch an IdP link by primary key. Returns None if not found."""
+        return await self._session.get(IdPLink, link_id)
+
+    async def delete(self, link_id: uuid.UUID) -> bool:
+        """Delete an IdP link by primary key. Returns True if deleted, False if not found."""
+        link = await self._session.get(IdPLink, link_id)
+        if link is None:
+            return False
+        await self._session.delete(link)
+        await self._session.flush()
+        return True
+
     async def get_by_provider_and_sub(self, provider_id: uuid.UUID, external_sub: str) -> IdPLink | None:
         """Fetch an IdP link by provider and external subject. Returns None if not found."""
         stmt = sa.select(IdPLink).where(

--- a/backend/app/repositories/provider.py
+++ b/backend/app/repositories/provider.py
@@ -29,12 +29,13 @@ class ProviderRepository:
         """Add a new provider to the session and flush to generate defaults.
 
         Raises RepositoryConflictError if a uniqueness constraint is violated.
-        Does NOT rollback — the caller (service layer) owns the transaction.
+        Rolls back the session before raising so it is not left in an invalid state.
         """
         self._session.add(provider)
         try:
             await self._session.flush()
         except IntegrityError as exc:
+            await self._session.rollback()
             raise RepositoryConflictError(str(exc)) from exc
         return provider
 
@@ -42,10 +43,12 @@ class ProviderRepository:
         """Flush pending mutations on a provider already attached to the session.
 
         Raises RepositoryConflictError if a uniqueness constraint is violated.
+        Rolls back the session before raising so it is not left in an invalid state.
         """
         try:
             await self._session.flush()
         except IntegrityError as exc:
+            await self._session.rollback()
             raise RepositoryConflictError(str(exc)) from exc
         return provider
 
@@ -72,3 +75,7 @@ class ProviderRepository:
     async def commit(self) -> None:
         """Commit the current transaction."""
         await self._session.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the current transaction."""
+        await self._session.rollback()

--- a/backend/app/repositories/provider.py
+++ b/backend/app/repositories/provider.py
@@ -1,6 +1,6 @@
 """ProviderRepository — data access layer for canonical Provider model.
 
-Handles all SQLAlchemy queries for provider lookup.
+Handles all SQLAlchemy queries for provider CRUD.
 Contains NO business logic, NO OTel spans, NO adapter calls — data access only.
 """
 
@@ -9,9 +9,11 @@ from __future__ import annotations
 import uuid
 
 import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.identity.provider import Provider, ProviderType
+from app.repositories.user import RepositoryConflictError
 
 
 class ProviderRepository:
@@ -22,6 +24,30 @@ class ProviderRepository:
 
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
+
+    async def create(self, provider: Provider) -> Provider:
+        """Add a new provider to the session and flush to generate defaults.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        Does NOT rollback — the caller (service layer) owns the transaction.
+        """
+        self._session.add(provider)
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return provider
+
+    async def update(self, provider: Provider) -> Provider:
+        """Flush pending mutations on a provider already attached to the session.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        """
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return provider
 
     async def get_by_type(self, provider_type: ProviderType) -> Provider | None:
         """Fetch a provider by type. Returns the first match or None.

--- a/backend/app/services/idp_link.py
+++ b/backend/app/services/idp_link.py
@@ -1,0 +1,120 @@
+"""IdPLinkService — domain orchestration for canonical IdP link operations.
+
+Middle layer of onion architecture: orchestrates IdPLinkRepository, UserRepository,
+and ProviderRepository (data access). All methods return Result[T, IdentityError].
+OTel spans on every method.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from expression import Error, Ok, Result
+from opentelemetry import trace
+
+from app.errors.identity import Conflict, IdentityError, NotFound
+from app.models.identity.user import IdPLink
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.user import RepositoryConflictError, UserRepository
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+
+class IdPLinkService:
+    """Domain service for IdP link operations.
+
+    Orchestrates IdPLinkRepository, UserRepository, and ProviderRepository (inner).
+    Contains NO direct SQLAlchemy imports — uses repository methods only.
+    """
+
+    def __init__(
+        self,
+        *,
+        repository: IdPLinkRepository,
+        user_repository: UserRepository,
+        provider_repository: ProviderRepository,
+    ) -> None:
+        self._repository = repository
+        self._user_repository = user_repository
+        self._provider_repository = provider_repository
+
+    async def create_idp_link(
+        self,
+        *,
+        user_id: uuid.UUID,
+        provider_id: uuid.UUID,
+        external_sub: str,
+        external_email: str = "",
+        metadata: dict | None = None,
+    ) -> Result[dict, IdentityError]:
+        """Create a new IdP link between a user and an external identity.
+
+        AC-4.1.1: validates user and provider exist, enforces unique constraints.
+        """
+        with tracer.start_as_current_span("IdPLinkService.create_idp_link") as span:
+            span.set_attribute("user.id", str(user_id))
+            span.set_attribute("provider.id", str(provider_id))
+
+            user = await self._user_repository.get(user_id)
+            if user is None:
+                return Error(NotFound(message=f"User '{user_id}' not found"))
+
+            provider = await self._provider_repository.get(provider_id)
+            if provider is None:
+                return Error(NotFound(message=f"Provider '{provider_id}' not found"))
+
+            link = IdPLink(
+                user_id=user_id,
+                provider_id=provider_id,
+                external_sub=external_sub,
+                external_email=external_email,
+                metadata_=metadata,
+            )
+            try:
+                link = await self._repository.create(link)
+            except RepositoryConflictError:
+                msg = f"IdP link already exists for user '{user_id}' with provider '{provider_id}'"
+                return Error(Conflict(message=msg))
+
+            result_dict = link.model_dump()
+            await self._repository.commit()
+
+            return Ok(result_dict)
+
+    async def get_user_idp_links(
+        self,
+        *,
+        user_id: uuid.UUID,
+    ) -> Result[list[dict], IdentityError]:
+        """Retrieve all IdP links for a user.
+
+        AC-4.1.1: delegates to IdPLinkRepository.get_by_user.
+        """
+        with tracer.start_as_current_span("IdPLinkService.get_user_idp_links") as span:
+            span.set_attribute("user.id", str(user_id))
+
+            links = await self._repository.get_by_user(user_id)
+            return Ok([link.model_dump() for link in links])
+
+    async def delete_idp_link(
+        self,
+        *,
+        link_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Delete an IdP link by ID.
+
+        AC-4.1.1: returns NotFound if link does not exist.
+        """
+        with tracer.start_as_current_span("IdPLinkService.delete_idp_link") as span:
+            span.set_attribute("link.id", str(link_id))
+
+            deleted = await self._repository.delete(link_id)
+            if not deleted:
+                return Error(NotFound(message=f"IdP link '{link_id}' not found"))
+
+            await self._repository.commit()
+
+            return Ok({"status": "deleted", "link_id": str(link_id)})

--- a/backend/app/services/provider.py
+++ b/backend/app/services/provider.py
@@ -66,6 +66,10 @@ class ProviderService:
                 capabilities=capabilities or [],
                 config_ref=config_ref,
             )
+            # TOCTOU guard: get_by_name pre-check above provides clean error
+            # messages, but a concurrent insert can race past it. The
+            # RepositoryConflictError fallback below catches the DB-level
+            # unique constraint violation. Both checks are required.
             try:
                 provider = await self._repository.create(provider)
             except RepositoryConflictError:
@@ -92,8 +96,14 @@ class ProviderService:
             if provider is None:
                 return Error(NotFound(message=f"Provider '{provider_id}' not found"))
 
+            if not provider.active:
+                return Ok(provider.model_dump())
+
             provider.active = False
-            provider = await self._repository.update(provider)
+            try:
+                provider = await self._repository.update(provider)
+            except RepositoryConflictError:
+                return Error(Conflict(message=f"Provider '{provider_id}' conflict during deactivation"))
 
             result_dict = provider.model_dump()
             await self._repository.commit()

--- a/backend/app/services/provider.py
+++ b/backend/app/services/provider.py
@@ -1,0 +1,119 @@
+"""ProviderService — domain orchestration for canonical Provider operations.
+
+Middle layer of onion architecture: orchestrates ProviderRepository (data access).
+All methods return Result[T, IdentityError]. OTel spans on every method.
+No credentials stored in Postgres — config_ref points to external secret manager.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from expression import Error, Ok, Result
+from opentelemetry import trace
+
+from app.errors.identity import Conflict, IdentityError, NotFound
+from app.models.identity.provider import Provider, ProviderType
+from app.repositories.provider import ProviderRepository
+from app.repositories.user import RepositoryConflictError
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+
+class ProviderService:
+    """Domain service for Provider operations.
+
+    Orchestrates ProviderRepository (inner).
+    Contains NO direct SQLAlchemy imports — uses repository methods only.
+    """
+
+    def __init__(
+        self,
+        *,
+        repository: ProviderRepository,
+    ) -> None:
+        self._repository = repository
+
+    async def register_provider(
+        self,
+        *,
+        name: str,
+        type: ProviderType,
+        issuer_url: str = "",
+        base_url: str = "",
+        capabilities: list[str] | None = None,
+        config_ref: str = "",
+    ) -> Result[dict, IdentityError]:
+        """Register a new identity provider.
+
+        AC-4.1.2: no credentials in Postgres, config_ref only.
+        """
+        with tracer.start_as_current_span("ProviderService.register_provider") as span:
+            span.set_attribute("provider.name", name)
+            span.set_attribute("provider.type", type.value)
+
+            existing = await self._repository.get_by_name(name)
+            if existing is not None:
+                return Error(Conflict(message=f"Provider '{name}' already exists"))
+
+            provider = Provider(
+                name=name,
+                type=type,
+                issuer_url=issuer_url,
+                base_url=base_url,
+                capabilities=capabilities or [],
+                config_ref=config_ref,
+            )
+            try:
+                provider = await self._repository.create(provider)
+            except RepositoryConflictError:
+                return Error(Conflict(message=f"Provider '{name}' already exists"))
+
+            result_dict = provider.model_dump()
+            await self._repository.commit()
+
+            return Ok(result_dict)
+
+    async def deactivate_provider(
+        self,
+        *,
+        provider_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Deactivate a provider. Idempotent — already-inactive returns Ok.
+
+        AC-4.1.2: sets active=False.
+        """
+        with tracer.start_as_current_span("ProviderService.deactivate_provider") as span:
+            span.set_attribute("provider.id", str(provider_id))
+
+            provider = await self._repository.get(provider_id)
+            if provider is None:
+                return Error(NotFound(message=f"Provider '{provider_id}' not found"))
+
+            provider.active = False
+            provider = await self._repository.update(provider)
+
+            result_dict = provider.model_dump()
+            await self._repository.commit()
+
+            return Ok(result_dict)
+
+    async def get_provider_capabilities(
+        self,
+        *,
+        provider_id: uuid.UUID,
+    ) -> Result[list[str], IdentityError]:
+        """Get the capabilities list for a provider.
+
+        AC-4.1.2: returns the capabilities JSON array.
+        """
+        with tracer.start_as_current_span("ProviderService.get_provider_capabilities") as span:
+            span.set_attribute("provider.id", str(provider_id))
+
+            provider = await self._repository.get(provider_id)
+            if provider is None:
+                return Error(NotFound(message=f"Provider '{provider_id}' not found"))
+
+            return Ok(provider.capabilities)

--- a/backend/tests/unit/repositories/test_idp_link_repository.py
+++ b/backend/tests/unit/repositories/test_idp_link_repository.py
@@ -1,0 +1,179 @@
+"""Unit tests for IdPLinkRepository — data access layer tests against real Postgres.
+
+Tests cover:
+- create: happy path, duplicate user+provider → RepositoryConflictError,
+          duplicate provider+external_sub → RepositoryConflictError
+- get: found, not found
+- delete: found → True, not found → False
+- get_by_user: returns all links for user, empty when none
+- get_by_provider_and_sub: found, not found
+"""
+
+import uuid
+
+import pytest
+
+from app.models.identity.provider import Provider, ProviderType
+from app.models.identity.user import IdPLink, User, UserStatus
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.user import RepositoryConflictError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_user(**overrides) -> User:
+    defaults = {
+        "id": uuid.uuid4(),
+        "email": f"user-{uuid.uuid4().hex[:8]}@test.com",
+        "user_name": "testuser",
+        "given_name": "Test",
+        "family_name": "User",
+        "status": UserStatus.active,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _make_provider(**overrides) -> Provider:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"provider-{uuid.uuid4().hex[:8]}",
+        "type": ProviderType.descope,
+    }
+    defaults.update(overrides)
+    return Provider(**defaults)
+
+
+def _make_idp_link(user_id: uuid.UUID, provider_id: uuid.UUID, **overrides) -> IdPLink:
+    defaults = {
+        "user_id": user_id,
+        "provider_id": provider_id,
+        "external_sub": f"ext-{uuid.uuid4().hex[:8]}",
+        "external_email": "ext@example.com",
+    }
+    defaults.update(overrides)
+    return IdPLink(**defaults)
+
+
+async def _seed_user_and_provider(db_session) -> tuple[User, Provider]:
+    """Insert a user and provider to satisfy FK constraints."""
+    user = _make_user()
+    provider = _make_provider()
+    db_session.add(user)
+    db_session.add(provider)
+    await db_session.flush()
+    return user, provider
+
+
+async def test_create_idp_link(db_session):
+    user, provider = await _seed_user_and_provider(db_session)
+    repo = IdPLinkRepository(db_session)
+    link = _make_idp_link(user.id, provider.id)
+
+    created = await repo.create(link)
+
+    assert created.id == link.id
+    assert created.user_id == user.id
+    assert created.provider_id == provider.id
+
+
+async def test_create_duplicate_user_provider(db_session):
+    """Unique constraint: same user + same provider → RepositoryConflictError."""
+    user, provider = await _seed_user_and_provider(db_session)
+    repo = IdPLinkRepository(db_session)
+
+    await repo.create(_make_idp_link(user.id, provider.id, external_sub="sub-1"))
+    with pytest.raises(RepositoryConflictError):
+        await repo.create(_make_idp_link(user.id, provider.id, external_sub="sub-2"))
+
+
+async def test_create_duplicate_provider_external_sub(db_session):
+    """Unique constraint: same provider + same external_sub → RepositoryConflictError."""
+    user1 = _make_user()
+    user2 = _make_user()
+    provider = _make_provider()
+    db_session.add_all([user1, user2, provider])
+    await db_session.flush()
+    repo = IdPLinkRepository(db_session)
+    ext_sub = "shared-ext-sub"
+
+    await repo.create(_make_idp_link(user1.id, provider.id, external_sub=ext_sub))
+    with pytest.raises(RepositoryConflictError):
+        await repo.create(_make_idp_link(user2.id, provider.id, external_sub=ext_sub))
+
+
+async def test_get_found(db_session):
+    user, provider = await _seed_user_and_provider(db_session)
+    repo = IdPLinkRepository(db_session)
+    link = _make_idp_link(user.id, provider.id)
+    await repo.create(link)
+
+    fetched = await repo.get(link.id)
+
+    assert fetched is not None
+    assert fetched.id == link.id
+
+
+async def test_get_not_found(db_session):
+    repo = IdPLinkRepository(db_session)
+    result = await repo.get(uuid.uuid4())
+    assert result is None
+
+
+async def test_delete_found(db_session):
+    user, provider = await _seed_user_and_provider(db_session)
+    repo = IdPLinkRepository(db_session)
+    link = _make_idp_link(user.id, provider.id)
+    await repo.create(link)
+
+    deleted = await repo.delete(link.id)
+
+    assert deleted is True
+    assert await repo.get(link.id) is None
+
+
+async def test_delete_not_found(db_session):
+    repo = IdPLinkRepository(db_session)
+    deleted = await repo.delete(uuid.uuid4())
+    assert deleted is False
+
+
+async def test_get_by_user(db_session):
+    user = _make_user()
+    p1 = _make_provider()
+    p2 = _make_provider()
+    db_session.add_all([user, p1, p2])
+    await db_session.flush()
+    repo = IdPLinkRepository(db_session)
+
+    await repo.create(_make_idp_link(user.id, p1.id))
+    await repo.create(_make_idp_link(user.id, p2.id))
+
+    links = await repo.get_by_user(user.id)
+    assert len(links) == 2
+    assert all(link.user_id == user.id for link in links)
+
+
+async def test_get_by_user_empty(db_session):
+    repo = IdPLinkRepository(db_session)
+    links = await repo.get_by_user(uuid.uuid4())
+    assert links == []
+
+
+async def test_get_by_provider_and_sub(db_session):
+    user, provider = await _seed_user_and_provider(db_session)
+    repo = IdPLinkRepository(db_session)
+    ext_sub = "unique-ext-sub"
+    link = _make_idp_link(user.id, provider.id, external_sub=ext_sub)
+    await repo.create(link)
+
+    fetched = await repo.get_by_provider_and_sub(provider.id, ext_sub)
+
+    assert fetched is not None
+    assert fetched.external_sub == ext_sub
+
+
+async def test_get_by_provider_and_sub_not_found(db_session):
+    repo = IdPLinkRepository(db_session)
+    result = await repo.get_by_provider_and_sub(uuid.uuid4(), "no-such-sub")
+    assert result is None

--- a/backend/tests/unit/repositories/test_provider_repository.py
+++ b/backend/tests/unit/repositories/test_provider_repository.py
@@ -1,0 +1,129 @@
+"""Unit tests for ProviderRepository — data access layer tests against real Postgres.
+
+Tests cover:
+- create: happy path, duplicate name → RepositoryConflictError
+- update: flush mutations, integrity error → RepositoryConflictError
+- get: found, not found
+- get_by_name: found, not found
+- get_by_type: found, not found
+"""
+
+import uuid
+
+import pytest
+
+from app.models.identity.provider import Provider, ProviderType
+from app.repositories.provider import ProviderRepository
+from app.repositories.user import RepositoryConflictError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_provider(**overrides) -> Provider:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"provider-{uuid.uuid4().hex[:8]}",
+        "type": ProviderType.descope,
+        "issuer_url": "https://api.descope.com/P123",
+        "base_url": "https://api.descope.com",
+        "capabilities": ["sso", "mfa"],
+        "config_ref": "infisical://test",
+        "active": True,
+    }
+    defaults.update(overrides)
+    return Provider(**defaults)
+
+
+async def test_create_provider(db_session):
+    repo = ProviderRepository(db_session)
+    provider = _make_provider()
+
+    created = await repo.create(provider)
+
+    assert created.id == provider.id
+    assert created.name == provider.name
+    assert created.type == ProviderType.descope
+    assert created.created_at is not None
+
+
+async def test_create_duplicate_name(db_session):
+    repo = ProviderRepository(db_session)
+    name = f"dup-{uuid.uuid4().hex[:8]}"
+
+    await repo.create(_make_provider(name=name))
+    with pytest.raises(RepositoryConflictError):
+        await repo.create(_make_provider(name=name))
+
+
+async def test_get_found(db_session):
+    repo = ProviderRepository(db_session)
+    provider = _make_provider()
+    await repo.create(provider)
+
+    fetched = await repo.get(provider.id)
+
+    assert fetched is not None
+    assert fetched.id == provider.id
+    assert fetched.name == provider.name
+
+
+async def test_get_not_found(db_session):
+    repo = ProviderRepository(db_session)
+    result = await repo.get(uuid.uuid4())
+    assert result is None
+
+
+async def test_get_by_name_found(db_session):
+    repo = ProviderRepository(db_session)
+    provider = _make_provider()
+    await repo.create(provider)
+
+    fetched = await repo.get_by_name(provider.name)
+
+    assert fetched is not None
+    assert fetched.id == provider.id
+
+
+async def test_get_by_name_not_found(db_session):
+    repo = ProviderRepository(db_session)
+    result = await repo.get_by_name("nonexistent-provider")
+    assert result is None
+
+
+async def test_get_by_type_found(db_session):
+    repo = ProviderRepository(db_session)
+    provider = _make_provider(type=ProviderType.ory)
+    await repo.create(provider)
+
+    fetched = await repo.get_by_type(ProviderType.ory)
+
+    assert fetched is not None
+    assert fetched.type == ProviderType.ory
+
+
+async def test_get_by_type_not_found(db_session):
+    repo = ProviderRepository(db_session)
+    result = await repo.get_by_type(ProviderType.cognito)
+    assert result is None
+
+
+async def test_update_provider(db_session):
+    repo = ProviderRepository(db_session)
+    provider = _make_provider(active=True)
+    await repo.create(provider)
+
+    provider.active = False
+    updated = await repo.update(provider)
+
+    assert updated.active is False
+
+
+async def test_update_capabilities(db_session):
+    repo = ProviderRepository(db_session)
+    provider = _make_provider(capabilities=["sso"])
+    await repo.create(provider)
+
+    provider.capabilities = ["sso", "mfa", "rbac"]
+    updated = await repo.update(provider)
+
+    assert updated.capabilities == ["sso", "mfa", "rbac"]

--- a/backend/tests/unit/test_identity_dependency.py
+++ b/backend/tests/unit/test_identity_dependency.py
@@ -12,18 +12,24 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from app.dependencies.identity import (
+    get_idp_link_service,
     get_permission_service,
+    get_provider_service,
     get_role_service,
     get_tenant_service,
     get_user_service,
 )
 from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.idp_link import IdPLinkRepository
 from app.repositories.permission import PermissionRepository
+from app.repositories.provider import ProviderRepository
 from app.repositories.role import RoleRepository
 from app.repositories.tenant import TenantRepository
 from app.repositories.user import UserRepository
 from app.services.adapters.descope import DescopeSyncAdapter
+from app.services.idp_link import IdPLinkService
 from app.services.permission import PermissionService
+from app.services.provider import ProviderService
 from app.services.role import RoleService
 from app.services.tenant import TenantService
 from app.services.user import UserService
@@ -143,5 +149,50 @@ class TestGetTenantService:
         mock_get_client.return_value = AsyncMock()
 
         service = await get_tenant_service(session=mock_session)
+
+        assert service._repository._session is mock_session
+
+
+@pytest.mark.anyio
+class TestGetIdPLinkService:
+    """AC-4.1.3: get_idp_link_service() wires 3 repositories → IdPLinkService."""
+
+    async def test_returns_idp_link_service(self):
+        mock_session = AsyncMock()
+
+        service = await get_idp_link_service(session=mock_session)
+
+        assert isinstance(service, IdPLinkService)
+        assert isinstance(service._repository, IdPLinkRepository)
+        assert isinstance(service._user_repository, UserRepository)
+        assert isinstance(service._provider_repository, ProviderRepository)
+
+    async def test_all_repositories_share_session(self):
+        """All repositories must receive the same session for transactional consistency."""
+        mock_session = AsyncMock()
+
+        service = await get_idp_link_service(session=mock_session)
+
+        assert service._repository._session is mock_session
+        assert service._user_repository._session is mock_session
+        assert service._provider_repository._session is mock_session
+
+
+@pytest.mark.anyio
+class TestGetProviderService:
+    """AC-4.1.3: get_provider_service() wires ProviderRepository → ProviderService."""
+
+    async def test_returns_provider_service(self):
+        mock_session = AsyncMock()
+
+        service = await get_provider_service(session=mock_session)
+
+        assert isinstance(service, ProviderService)
+        assert isinstance(service._repository, ProviderRepository)
+
+    async def test_repository_receives_session(self):
+        mock_session = AsyncMock()
+
+        service = await get_provider_service(session=mock_session)
 
         assert service._repository._session is mock_session

--- a/backend/tests/unit/test_idp_link_service.py
+++ b/backend/tests/unit/test_idp_link_service.py
@@ -1,0 +1,207 @@
+"""Unit tests for IdPLinkService domain orchestration (Story 4.1).
+
+Tests cover:
+- create_idp_link: validates user+provider exist, unique constraint → Conflict
+- get_user_idp_links: delegates to repository
+- delete_idp_link: found → deleted; not found → NotFound
+"""
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.errors.identity import Conflict, NotFound
+from app.models.identity.user import IdPLink
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.user import RepositoryConflictError, UserRepository
+from app.services.idp_link import IdPLinkService
+
+
+def _make_idp_link(**overrides) -> IdPLink:
+    """Create an IdPLink with sensible defaults."""
+    defaults = {
+        "id": uuid.uuid4(),
+        "user_id": uuid.uuid4(),
+        "provider_id": uuid.uuid4(),
+        "external_sub": "ext-sub-123",
+        "external_email": "ext@example.com",
+        "metadata_": None,
+    }
+    defaults.update(overrides)
+    return IdPLink(**defaults)
+
+
+def _build_service(
+    repo: AsyncMock | None = None,
+    user_repo: AsyncMock | None = None,
+    provider_repo: AsyncMock | None = None,
+) -> tuple[IdPLinkService, AsyncMock, AsyncMock, AsyncMock]:
+    """Build an IdPLinkService with mocked repositories."""
+    if repo is None:
+        repo = AsyncMock(spec=IdPLinkRepository)
+    if user_repo is None:
+        user_repo = AsyncMock(spec=UserRepository)
+    if provider_repo is None:
+        provider_repo = AsyncMock(spec=ProviderRepository)
+    service = IdPLinkService(
+        repository=repo,
+        user_repository=user_repo,
+        provider_repository=provider_repo,
+    )
+    return service, repo, user_repo, provider_repo
+
+
+@pytest.mark.anyio
+class TestCreateIdPLink:
+    """AC-4.1.1: create_idp_link validates user+provider, enforces unique constraints."""
+
+    async def test_create_success(self):
+        service, repo, user_repo, provider_repo = _build_service()
+        user_id = uuid.uuid4()
+        provider_id = uuid.uuid4()
+        link = _make_idp_link(user_id=user_id, provider_id=provider_id)
+
+        user_repo.get.return_value = AsyncMock()  # user exists
+        provider_repo.get.return_value = AsyncMock()  # provider exists
+        repo.create.return_value = link
+
+        result = await service.create_idp_link(
+            user_id=user_id,
+            provider_id=provider_id,
+            external_sub="ext-sub-123",
+            external_email="ext@example.com",
+        )
+
+        assert result.is_ok()
+        user_repo.get.assert_awaited_once_with(user_id)
+        provider_repo.get.assert_awaited_once_with(provider_id)
+        repo.create.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+
+    async def test_create_user_not_found(self):
+        service, repo, user_repo, provider_repo = _build_service()
+        user_repo.get.return_value = None
+
+        result = await service.create_idp_link(
+            user_id=uuid.uuid4(),
+            provider_id=uuid.uuid4(),
+            external_sub="ext-sub",
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        assert "User" in result.error.message
+        repo.create.assert_not_awaited()
+
+    async def test_create_provider_not_found(self):
+        service, repo, user_repo, provider_repo = _build_service()
+        user_repo.get.return_value = AsyncMock()
+        provider_repo.get.return_value = None
+
+        result = await service.create_idp_link(
+            user_id=uuid.uuid4(),
+            provider_id=uuid.uuid4(),
+            external_sub="ext-sub",
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        assert "Provider" in result.error.message
+        repo.create.assert_not_awaited()
+
+    async def test_create_duplicate_returns_conflict(self):
+        """Unique constraint violation (user+provider or provider+sub) → Conflict."""
+        service, repo, user_repo, provider_repo = _build_service()
+        user_repo.get.return_value = AsyncMock()
+        provider_repo.get.return_value = AsyncMock()
+        repo.create.side_effect = RepositoryConflictError("duplicate key")
+
+        result = await service.create_idp_link(
+            user_id=uuid.uuid4(),
+            provider_id=uuid.uuid4(),
+            external_sub="ext-sub",
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        repo.commit.assert_not_awaited()
+
+    async def test_create_with_metadata(self):
+        service, repo, user_repo, provider_repo = _build_service()
+        user_id = uuid.uuid4()
+        provider_id = uuid.uuid4()
+        metadata = {"source": "migration", "version": 2}
+        link = _make_idp_link(user_id=user_id, provider_id=provider_id, metadata_=metadata)
+
+        user_repo.get.return_value = AsyncMock()
+        provider_repo.get.return_value = AsyncMock()
+        repo.create.return_value = link
+
+        result = await service.create_idp_link(
+            user_id=user_id,
+            provider_id=provider_id,
+            external_sub="ext-sub",
+            metadata=metadata,
+        )
+
+        assert result.is_ok()
+        assert result.ok["metadata_"] == metadata
+
+
+@pytest.mark.anyio
+class TestGetUserIdPLinks:
+    """AC-4.1.1: get_user_idp_links delegates to repository."""
+
+    async def test_get_returns_list(self):
+        service, repo, _user_repo, _provider_repo = _build_service()
+        user_id = uuid.uuid4()
+        links = [
+            _make_idp_link(user_id=user_id),
+            _make_idp_link(user_id=user_id),
+        ]
+        repo.get_by_user.return_value = links
+
+        result = await service.get_user_idp_links(user_id=user_id)
+
+        assert result.is_ok()
+        assert len(result.ok) == 2
+        repo.get_by_user.assert_awaited_once_with(user_id)
+
+    async def test_get_empty_list(self):
+        service, repo, _user_repo, _provider_repo = _build_service()
+        repo.get_by_user.return_value = []
+
+        result = await service.get_user_idp_links(user_id=uuid.uuid4())
+
+        assert result.is_ok()
+        assert result.ok == []
+
+
+@pytest.mark.anyio
+class TestDeleteIdPLink:
+    """AC-4.1.1: delete_idp_link removes link; not found → NotFound."""
+
+    async def test_delete_success(self):
+        service, repo, _user_repo, _provider_repo = _build_service()
+        link_id = uuid.uuid4()
+        repo.delete.return_value = True
+
+        result = await service.delete_idp_link(link_id=link_id)
+
+        assert result.is_ok()
+        assert result.ok["status"] == "deleted"
+        assert result.ok["link_id"] == str(link_id)
+        repo.delete.assert_awaited_once_with(link_id)
+        repo.commit.assert_awaited_once()
+
+    async def test_delete_not_found(self):
+        service, repo, _user_repo, _provider_repo = _build_service()
+        repo.delete.return_value = False
+
+        result = await service.delete_idp_link(link_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        repo.commit.assert_not_awaited()

--- a/backend/tests/unit/test_provider_service.py
+++ b/backend/tests/unit/test_provider_service.py
@@ -1,0 +1,195 @@
+"""Unit tests for ProviderService domain orchestration (Story 4.1).
+
+Tests cover:
+- register_provider: happy path, duplicate name → Conflict, integrity error → Conflict
+- deactivate_provider: found → deactivated; already-inactive → idempotent Ok; not found → NotFound
+- get_provider_capabilities: found → capabilities list; not found → NotFound
+"""
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.errors.identity import Conflict, NotFound
+from app.models.identity.provider import Provider, ProviderType
+from app.repositories.provider import ProviderRepository
+from app.repositories.user import RepositoryConflictError
+from app.services.provider import ProviderService
+
+
+def _make_provider(**overrides) -> Provider:
+    """Create a Provider with sensible defaults."""
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": "descope-prod",
+        "type": ProviderType.descope,
+        "issuer_url": "https://api.descope.com/P123",
+        "base_url": "https://api.descope.com",
+        "capabilities": ["sso", "mfa", "rbac"],
+        "config_ref": "infisical://descope-prod",
+        "active": True,
+    }
+    defaults.update(overrides)
+    return Provider(**defaults)
+
+
+def _build_service(
+    repo: AsyncMock | None = None,
+) -> tuple[ProviderService, AsyncMock]:
+    """Build a ProviderService with a mocked repository."""
+    if repo is None:
+        repo = AsyncMock(spec=ProviderRepository)
+    service = ProviderService(repository=repo)
+    return service, repo
+
+
+@pytest.mark.anyio
+class TestRegisterProvider:
+    """AC-4.1.2: register_provider stores config_ref, not credentials."""
+
+    async def test_register_success(self):
+        service, repo = _build_service()
+        provider = _make_provider()
+        repo.get_by_name.return_value = None
+        repo.create.return_value = provider
+
+        result = await service.register_provider(
+            name=provider.name,
+            type=provider.type,
+            issuer_url=provider.issuer_url,
+            base_url=provider.base_url,
+            capabilities=provider.capabilities,
+            config_ref=provider.config_ref,
+        )
+
+        assert result.is_ok()
+        assert result.ok["name"] == provider.name
+        assert result.ok["config_ref"] == provider.config_ref
+        repo.get_by_name.assert_awaited_once_with(provider.name)
+        repo.create.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+
+    async def test_register_duplicate_name_returns_conflict(self):
+        service, repo = _build_service()
+        repo.get_by_name.return_value = _make_provider()
+
+        result = await service.register_provider(
+            name="descope-prod",
+            type=ProviderType.descope,
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        assert "already exists" in result.error.message
+        repo.create.assert_not_awaited()
+
+    async def test_register_integrity_error_returns_conflict(self):
+        """TOCTOU race: get_by_name returns None but create raises IntegrityError."""
+        service, repo = _build_service()
+        repo.get_by_name.return_value = None
+        repo.create.side_effect = RepositoryConflictError("duplicate key")
+
+        result = await service.register_provider(
+            name="descope-prod",
+            type=ProviderType.descope,
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        repo.commit.assert_not_awaited()
+
+    async def test_register_defaults_empty_capabilities(self):
+        """Capabilities default to empty list when None is passed."""
+        service, repo = _build_service()
+        repo.get_by_name.return_value = None
+        provider = _make_provider(capabilities=[])
+        repo.create.return_value = provider
+
+        result = await service.register_provider(
+            name="bare-provider",
+            type=ProviderType.oidc,
+        )
+
+        assert result.is_ok()
+        # Verify the Provider constructor received empty list
+        created_arg = repo.create.call_args[0][0]
+        assert created_arg.capabilities == []
+
+
+@pytest.mark.anyio
+class TestDeactivateProvider:
+    """AC-4.1.2: deactivate_provider sets active=False, idempotent for already-inactive."""
+
+    async def test_deactivate_success(self):
+        service, repo = _build_service()
+        provider = _make_provider(active=True)
+        repo.get.return_value = provider
+        repo.update.return_value = provider
+
+        result = await service.deactivate_provider(provider_id=provider.id)
+
+        assert result.is_ok()
+        assert provider.active is False
+        repo.update.assert_awaited_once_with(provider)
+        repo.commit.assert_awaited_once()
+
+    async def test_deactivate_already_inactive_is_idempotent(self):
+        """Deactivating an already-inactive provider returns Ok (not an error)."""
+        service, repo = _build_service()
+        provider = _make_provider(active=False)
+        repo.get.return_value = provider
+        repo.update.return_value = provider
+
+        result = await service.deactivate_provider(provider_id=provider.id)
+
+        assert result.is_ok()
+        assert provider.active is False
+        repo.update.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+
+    async def test_deactivate_not_found(self):
+        service, repo = _build_service()
+        repo.get.return_value = None
+
+        result = await service.deactivate_provider(provider_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        repo.update.assert_not_awaited()
+
+
+@pytest.mark.anyio
+class TestGetProviderCapabilities:
+    """AC-4.1.2: get_provider_capabilities returns the capabilities list."""
+
+    async def test_get_capabilities_success(self):
+        service, repo = _build_service()
+        capabilities = ["sso", "mfa", "rbac"]
+        provider = _make_provider(capabilities=capabilities)
+        repo.get.return_value = provider
+
+        result = await service.get_provider_capabilities(provider_id=provider.id)
+
+        assert result.is_ok()
+        assert result.ok == capabilities
+        repo.get.assert_awaited_once_with(provider.id)
+
+    async def test_get_capabilities_empty(self):
+        service, repo = _build_service()
+        provider = _make_provider(capabilities=[])
+        repo.get.return_value = provider
+
+        result = await service.get_provider_capabilities(provider_id=provider.id)
+
+        assert result.is_ok()
+        assert result.ok == []
+
+    async def test_get_capabilities_not_found(self):
+        service, repo = _build_service()
+        repo.get.return_value = None
+
+        result = await service.get_provider_capabilities(provider_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)

--- a/backend/tests/unit/test_provider_service.py
+++ b/backend/tests/unit/test_provider_service.py
@@ -135,18 +135,17 @@ class TestDeactivateProvider:
         repo.commit.assert_awaited_once()
 
     async def test_deactivate_already_inactive_is_idempotent(self):
-        """Deactivating an already-inactive provider returns Ok (not an error)."""
+        """Deactivating an already-inactive provider short-circuits without writing."""
         service, repo = _build_service()
         provider = _make_provider(active=False)
         repo.get.return_value = provider
-        repo.update.return_value = provider
 
         result = await service.deactivate_provider(provider_id=provider.id)
 
         assert result.is_ok()
         assert provider.active is False
-        repo.update.assert_awaited_once()
-        repo.commit.assert_awaited_once()
+        repo.update.assert_not_awaited()
+        repo.commit.assert_not_awaited()
 
     async def test_deactivate_not_found(self):
         service, repo = _build_service()
@@ -157,6 +156,19 @@ class TestDeactivateProvider:
         assert result.is_error()
         assert isinstance(result.error, NotFound)
         repo.update.assert_not_awaited()
+
+    async def test_deactivate_conflict_returns_error(self):
+        """RepositoryConflictError on update is caught and returned as Conflict."""
+        service, repo = _build_service()
+        provider = _make_provider(active=True)
+        repo.get.return_value = provider
+        repo.update.side_effect = RepositoryConflictError("constraint violation")
+
+        result = await service.deactivate_provider(provider_id=provider.id)
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        repo.commit.assert_not_awaited()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Add `IdPLinkService` with create/get/delete operations for managing identity provider links, including user+provider validation, unique constraint enforcement, and OTel instrumentation
- Add `ProviderService` with register/deactivate/get-capabilities operations, config_ref-only storage (no credentials in Postgres), and idempotent deactivation
- Extend `IdPLinkRepository` and `ProviderRepository` with missing CRUD methods (get-by-id, delete, create, update) including proper rollback handling
- Add DI factories for both new services in `dependencies/identity.py`
- Comprehensive unit tests for both services and repository additions

Refs #153

## Review Findings Addressed

- **Blind Hunter**: 2 MUST FIX fixed (rollback in ProviderRepository, deactivate guard), 3 of 4 SHOULD FIX fixed (short-circuit, TOCTOU comment, test coverage), 1 accepted (commit exception matches codebase pattern)
- **Edge Case Hunter**: 4 findings all fixed (rollback alignment, rollback() method, deactivate guard)
- **Acceptance Auditor**: 12/13 PASS, 1 PARTIAL (non-blocking)
- **Sentinel**: 0 BLOCK, 2 WARN (tenant scoping + auth docs deferred to story 4.2 router layer)
- Delta re-review: all fixes verified correct, no regressions

## Test plan
- [x] Unit tests pass (all 1335 tests)
- [x] Lint passes
- [x] Independent review agents passed (blind, edge-case, acceptance, sentinel)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)