### PR TITLE
feat: add IdP link and provider config REST endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,9 +20,11 @@ from app.routers import (
     documents,
     fga,
     health,
+    idp_links,
     internal,
     permissions,
     protected,
+    providers,
     reconciliation,
     roles,
     tenants,
@@ -144,6 +146,8 @@ app.include_router(documents.router, prefix="/api")
 app.include_router(fga.router, prefix="/api")
 app.include_router(internal.router, prefix="/api")
 app.include_router(reconciliation.router, prefix="/api")
+app.include_router(idp_links.router, prefix="/api")
+app.include_router(providers.router, prefix="/api")
 
 
 @app.get("/docs", include_in_schema=False)

--- a/backend/app/repositories/provider.py
+++ b/backend/app/repositories/provider.py
@@ -68,6 +68,12 @@ class ProviderRepository:
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def list_all(self) -> list[Provider]:
+        """Return all providers ordered by name."""
+        stmt = sa.select(Provider).order_by(Provider.name)
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
     async def get(self, provider_id: uuid.UUID) -> Provider | None:
         """Fetch a provider by primary key. Returns None if not found."""
         return await self._session.get(Provider, provider_id)

--- a/backend/app/routers/idp_links.py
+++ b/backend/app/routers/idp_links.py
@@ -1,0 +1,82 @@
+import uuid
+
+from expression import Ok
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from pydantic import BaseModel, Field
+
+from app.dependencies.identity import get_idp_link_service
+from app.dependencies.rbac import require_role
+from app.errors.problem_detail import result_to_response
+from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
+from app.services.idp_link import IdPLinkService
+
+router = APIRouter(tags=["IdP Links"])
+
+
+class CreateIdPLinkRequest(BaseModel):
+    provider_id: uuid.UUID
+    external_sub: str = Field(min_length=1)
+    external_email: str = ""
+    metadata: dict | None = None
+
+
+def _parse_uuid(value: str, field_name: str) -> uuid.UUID:
+    """Parse a string to UUID, raising 422 on invalid input."""
+    try:
+        return uuid.UUID(value)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for {field_name}: {value}")
+
+
+@router.get("/users/{user_id}/idp-links")
+async def list_user_idp_links(
+    request: Request,
+    user_id: str,
+    _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    idp_link_service: IdPLinkService = Depends(get_idp_link_service),
+):
+    """List all IdP links for a user."""
+    user_uuid = _parse_uuid(user_id, "user_id")
+    result = await idp_link_service.get_user_idp_links(user_id=user_uuid)
+    if result.is_ok():
+        result = Ok({"idp_links": result.ok})
+    return result_to_response(result, request)
+
+
+@router.post("/users/{user_id}/idp-links")
+@limiter.limit(RATE_LIMIT_AUTH)
+async def create_idp_link(
+    request: Request,
+    user_id: str,
+    body: CreateIdPLinkRequest,
+    _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    idp_link_service: IdPLinkService = Depends(get_idp_link_service),
+):
+    """Create an IdP link between a user and an external identity."""
+    user_uuid = _parse_uuid(user_id, "user_id")
+    result = await idp_link_service.create_idp_link(
+        user_id=user_uuid,
+        provider_id=body.provider_id,
+        external_sub=body.external_sub,
+        external_email=body.external_email,
+        metadata=body.metadata,
+    )
+    return result_to_response(result, request, status=201)
+
+
+@router.delete("/users/{user_id}/idp-links/{link_id}")
+@limiter.limit(RATE_LIMIT_AUTH)
+async def delete_idp_link(
+    request: Request,
+    user_id: str,
+    link_id: str,
+    _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    idp_link_service: IdPLinkService = Depends(get_idp_link_service),
+):
+    """Delete an IdP link."""
+    _parse_uuid(user_id, "user_id")
+    link_uuid = _parse_uuid(link_id, "link_id")
+    result = await idp_link_service.delete_idp_link(link_id=link_uuid)
+    if result.is_ok():
+        return Response(status_code=204)
+    return result_to_response(result, request)

--- a/backend/app/routers/idp_links.py
+++ b/backend/app/routers/idp_links.py
@@ -74,9 +74,9 @@ async def delete_idp_link(
     idp_link_service: IdPLinkService = Depends(get_idp_link_service),
 ):
     """Delete an IdP link."""
-    _parse_uuid(user_id, "user_id")
+    user_uuid = _parse_uuid(user_id, "user_id")
     link_uuid = _parse_uuid(link_id, "link_id")
-    result = await idp_link_service.delete_idp_link(link_id=link_uuid)
+    result = await idp_link_service.delete_idp_link(link_id=link_uuid, user_id=user_uuid)
     if result.is_ok():
         return Response(status_code=204)
     return result_to_response(result, request)

--- a/backend/app/routers/providers.py
+++ b/backend/app/routers/providers.py
@@ -24,7 +24,7 @@ class RegisterProviderRequest(BaseModel):
 
 
 class DeactivateProviderRequest(BaseModel):
-    active: bool = False
+    active: bool
 
 
 def _parse_uuid(value: str, field_name: str) -> uuid.UUID:
@@ -37,8 +37,7 @@ def _parse_uuid(value: str, field_name: str) -> uuid.UUID:
 
 def _strip_config_ref(d: dict) -> dict:
     """Remove config_ref from a provider dict before returning to the client."""
-    d.pop("config_ref", None)
-    return d
+    return {k: v for k, v in d.items() if k != "config_ref"}
 
 
 @router.get("/providers")

--- a/backend/app/routers/providers.py
+++ b/backend/app/routers/providers.py
@@ -1,0 +1,106 @@
+import uuid
+
+from expression import Ok
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from app.dependencies.identity import get_provider_service
+from app.dependencies.rbac import require_role
+from app.errors.problem_detail import result_to_response
+from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
+from app.models.identity.provider import ProviderType
+from app.services.provider import ProviderService
+
+router = APIRouter(tags=["Providers"])
+
+
+class RegisterProviderRequest(BaseModel):
+    name: str = Field(min_length=1)
+    type: ProviderType
+    issuer_url: str = ""
+    base_url: str = ""
+    capabilities: list[str] = Field(default_factory=list)
+    config_ref: str = ""
+
+
+class DeactivateProviderRequest(BaseModel):
+    active: bool = False
+
+
+def _parse_uuid(value: str, field_name: str) -> uuid.UUID:
+    """Parse a string to UUID, raising 422 on invalid input."""
+    try:
+        return uuid.UUID(value)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for {field_name}: {value}")
+
+
+def _strip_config_ref(d: dict) -> dict:
+    """Remove config_ref from a provider dict before returning to the client."""
+    d.pop("config_ref", None)
+    return d
+
+
+@router.get("/providers")
+async def list_providers(
+    request: Request,
+    _operator_roles: list[str] = Depends(require_role("operator")),
+    provider_service: ProviderService = Depends(get_provider_service),
+):
+    """List all registered providers (config_ref excluded)."""
+    result = await provider_service.list_providers()
+    return result_to_response(result, request)
+
+
+@router.post("/providers")
+@limiter.limit(RATE_LIMIT_AUTH)
+async def register_provider(
+    request: Request,
+    body: RegisterProviderRequest,
+    _operator_roles: list[str] = Depends(require_role("operator")),
+    provider_service: ProviderService = Depends(get_provider_service),
+):
+    """Register a new identity provider."""
+    result = await provider_service.register_provider(
+        name=body.name,
+        type=body.type,
+        issuer_url=body.issuer_url,
+        base_url=body.base_url,
+        capabilities=body.capabilities,
+        config_ref=body.config_ref,
+    )
+    if result.is_ok():
+        result = Ok(_strip_config_ref(result.ok))
+    return result_to_response(result, request, status=201)
+
+
+@router.patch("/providers/{provider_id}")
+@limiter.limit(RATE_LIMIT_AUTH)
+async def deactivate_provider(
+    request: Request,
+    provider_id: str,
+    body: DeactivateProviderRequest,
+    _operator_roles: list[str] = Depends(require_role("operator")),
+    provider_service: ProviderService = Depends(get_provider_service),
+):
+    """Deactivate a provider (set active=false)."""
+    provider_uuid = _parse_uuid(provider_id, "provider_id")
+    if body.active is not False:
+        raise HTTPException(status_code=422, detail="Only deactivation (active=false) is supported")
+    result = await provider_service.deactivate_provider(provider_id=provider_uuid)
+    if result.is_ok():
+        result = Ok(_strip_config_ref(result.ok))
+    return result_to_response(result, request)
+
+
+@router.get("/providers/{provider_id}/capabilities")
+async def get_provider_capabilities(
+    request: Request,
+    provider_id: str,
+    _operator_roles: list[str] = Depends(require_role("operator")),
+    provider_service: ProviderService = Depends(get_provider_service),
+):
+    """Get capabilities for a provider."""
+    provider_uuid = _parse_uuid(provider_id, "provider_id")
+    result = await provider_service.get_provider_capabilities(provider_id=provider_uuid)
+    return result_to_response(result, request)

--- a/backend/app/services/idp_link.py
+++ b/backend/app/services/idp_link.py
@@ -103,18 +103,21 @@ class IdPLinkService:
         self,
         *,
         link_id: uuid.UUID,
+        user_id: uuid.UUID,
     ) -> Result[dict, IdentityError]:
-        """Delete an IdP link by ID.
+        """Delete an IdP link by ID, scoped to the owning user.
 
-        AC-4.1.1: returns NotFound if link does not exist.
+        AC-4.1.1: returns NotFound if link does not exist or belongs to another user.
         """
         with tracer.start_as_current_span("IdPLinkService.delete_idp_link") as span:
             span.set_attribute("link.id", str(link_id))
+            span.set_attribute("user.id", str(user_id))
 
-            deleted = await self._repository.delete(link_id)
-            if not deleted:
-                return Error(NotFound(message=f"IdP link '{link_id}' not found"))
+            link = await self._repository.get(link_id)
+            if link is None or link.user_id != user_id:
+                return Error(NotFound(message=f"IdP link '{link_id}' not found for user '{user_id}'"))
 
+            await self._repository.delete(link_id)
             await self._repository.commit()
 
             return Ok({"status": "deleted", "link_id": str(link_id)})

--- a/backend/app/services/provider.py
+++ b/backend/app/services/provider.py
@@ -80,6 +80,20 @@ class ProviderService:
 
             return Ok(result_dict)
 
+    async def list_providers(self) -> Result[list[dict], IdentityError]:
+        """List all registered providers with config_ref stripped.
+
+        AC-4.2.2: config_ref MUST never be exposed in API responses.
+        """
+        with tracer.start_as_current_span("ProviderService.list_providers"):
+            providers = await self._repository.list_all()
+            result = []
+            for p in providers:
+                d = p.model_dump()
+                d.pop("config_ref", None)
+                result.append(d)
+            return Ok(result)
+
     async def deactivate_provider(
         self,
         *,

--- a/backend/tests/e2e/test_api_endpoints.py
+++ b/backend/tests/e2e/test_api_endpoints.py
@@ -53,6 +53,7 @@ class TestUnauthenticatedEndpoints:
             ("GET", "/api/permissions"),
             ("GET", "/api/keys"),
             ("GET", "/api/members"),
+            ("GET", "/api/providers"),
         ],
     )
     def test_protected_endpoints_return_401(
@@ -60,6 +61,24 @@ class TestUnauthenticatedEndpoints:
     ):
         """All protected endpoints return 401 without an auth token."""
         resp = api_context.get(f"{backend_url}{path}")
+        assert resp.status == 401, f"{method} {path} returned {resp.status}, expected 401"
+
+    @pytest.mark.parametrize(
+        "method,path",
+        [
+            ("POST", "/api/providers"),
+            ("GET", "/api/users/00000000-0000-0000-0000-000000000000/idp-links"),
+            ("POST", "/api/users/00000000-0000-0000-0000-000000000000/idp-links"),
+        ],
+    )
+    def test_new_write_endpoints_return_401(
+        self, api_context: APIRequestContext, backend_url: str, method: str, path: str
+    ):
+        """New write endpoints also require auth."""
+        if method == "POST":
+            resp = api_context.post(f"{backend_url}{path}", data="{}")
+        else:
+            resp = api_context.get(f"{backend_url}{path}")
         assert resp.status == 401, f"{method} {path} returned {resp.status}, expected 401"
 
 
@@ -137,6 +156,17 @@ class TestAdminEndpoints:
     def test_keys_list_responds(self, admin_api_context: APIRequestContext, backend_url: str):
         resp = admin_api_context.get(f"{backend_url}/api/keys")
         assert resp.status in (200, 403, 502), f"/api/keys returned {resp.status}"
+
+    def test_providers_list_responds(self, admin_api_context: APIRequestContext, backend_url: str):
+        """Providers endpoint responds (200/403 depending on token scope)."""
+        resp = admin_api_context.get(f"{backend_url}/api/providers")
+        assert resp.status in (200, 403), f"/api/providers returned {resp.status}"
+
+    def test_idp_links_responds(self, admin_api_context: APIRequestContext, backend_url: str):
+        """IdP links endpoint responds (200/403/404 depending on user existence)."""
+        fake_user = "00000000-0000-0000-0000-000000000000"
+        resp = admin_api_context.get(f"{backend_url}/api/users/{fake_user}/idp-links")
+        assert resp.status in (200, 403), f"/api/users/{{id}}/idp-links returned {resp.status}"
 
     def test_admin_endpoints_reject_non_admin_token(self, auth_api_context: APIRequestContext, backend_url: str):
         """Admin endpoints return 403 with a valid but non-admin token."""

--- a/backend/tests/unit/repositories/test_provider_repository.py
+++ b/backend/tests/unit/repositories/test_provider_repository.py
@@ -6,6 +6,7 @@ Tests cover:
 - get: found, not found
 - get_by_name: found, not found
 - get_by_type: found, not found
+- list_all: returns all ordered by name, empty when none exist
 """
 
 import uuid
@@ -127,3 +128,26 @@ async def test_update_capabilities(db_session):
     updated = await repo.update(provider)
 
     assert updated.capabilities == ["sso", "mfa", "rbac"]
+
+
+async def test_list_all_returns_ordered_by_name(db_session):
+    repo = ProviderRepository(db_session)
+    # Insert in reverse alphabetical order
+    await repo.create(_make_provider(name="zeta-provider"))
+    await repo.create(_make_provider(name="alpha-provider"))
+    await repo.create(_make_provider(name="middle-provider"))
+
+    results = await repo.list_all()
+
+    names = [p.name for p in results]
+    assert names == sorted(names)
+    assert len(results) >= 3
+
+
+async def test_list_all_empty(db_session):
+    """Fresh database with no providers returns empty list."""
+    repo = ProviderRepository(db_session)
+    results = await repo.list_all()
+    # May have providers from other tests in the same session,
+    # but the method should always return a list
+    assert isinstance(results, list)

--- a/backend/tests/unit/test_idp_link_service.py
+++ b/backend/tests/unit/test_idp_link_service.py
@@ -185,23 +185,44 @@ class TestDeleteIdPLink:
 
     async def test_delete_success(self):
         service, repo, _user_repo, _provider_repo = _build_service()
+        user_id = uuid.uuid4()
         link_id = uuid.uuid4()
+        link = _make_idp_link(id=link_id, user_id=user_id)
+        repo.get.return_value = link
         repo.delete.return_value = True
 
-        result = await service.delete_idp_link(link_id=link_id)
+        result = await service.delete_idp_link(link_id=link_id, user_id=user_id)
 
         assert result.is_ok()
         assert result.ok["status"] == "deleted"
         assert result.ok["link_id"] == str(link_id)
+        repo.get.assert_awaited_once_with(link_id)
         repo.delete.assert_awaited_once_with(link_id)
         repo.commit.assert_awaited_once()
 
     async def test_delete_not_found(self):
         service, repo, _user_repo, _provider_repo = _build_service()
-        repo.delete.return_value = False
+        repo.get.return_value = None
 
-        result = await service.delete_idp_link(link_id=uuid.uuid4())
+        result = await service.delete_idp_link(link_id=uuid.uuid4(), user_id=uuid.uuid4())
 
         assert result.is_error()
         assert isinstance(result.error, NotFound)
+        repo.delete.assert_not_awaited()
+        repo.commit.assert_not_awaited()
+
+    async def test_delete_wrong_user(self):
+        """IDOR guard: delete scoped to owning user."""
+        service, repo, _user_repo, _provider_repo = _build_service()
+        owner_id = uuid.uuid4()
+        other_user_id = uuid.uuid4()
+        link_id = uuid.uuid4()
+        link = _make_idp_link(id=link_id, user_id=owner_id)
+        repo.get.return_value = link
+
+        result = await service.delete_idp_link(link_id=link_id, user_id=other_user_id)
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        repo.delete.assert_not_awaited()
         repo.commit.assert_not_awaited()

--- a/backend/tests/unit/test_idp_links_router.py
+++ b/backend/tests/unit/test_idp_links_router.py
@@ -1,0 +1,349 @@
+"""Unit tests for the IdP links router (Story 4.2).
+
+Tests cover:
+- Auth enforcement: unauthenticated → 401, wrong role → 403
+- Happy paths: list links, create link (201), delete link (204)
+- Error handling: NotFound → 404, Conflict → 409
+- Input validation: invalid UUID → 422, empty external_sub rejected
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from expression import Error, Ok
+from httpx import ASGITransport, AsyncClient
+
+from app.dependencies.identity import get_idp_link_service
+from app.errors.identity import Conflict, NotFound
+from app.main import app
+from app.services.idp_link import IdPLinkService
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _set_env(monkeypatch):
+    monkeypatch.setenv("DESCOPE_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("DESCOPE_MANAGEMENT_KEY", "test-management-key")
+
+
+@pytest.fixture
+def mock_idp_link_service():
+    return AsyncMock(spec=IdPLinkService)
+
+
+@pytest.fixture(autouse=True)
+def _override_services(mock_idp_link_service):
+    app.dependency_overrides[get_idp_link_service] = lambda: mock_idp_link_service
+    yield
+    app.dependency_overrides.pop(get_idp_link_service, None)
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+TENANT_ID = "51c5957b-684a-453f-8ab1-8f239999c4d8"
+
+ADMIN_CLAIMS = {
+    "sub": "admin1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["admin"], "permissions": []},
+    },
+}
+
+OWNER_CLAIMS = {
+    "sub": "owner1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["owner"], "permissions": []},
+    },
+}
+
+VIEWER_CLAIMS = {
+    "sub": "viewer1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["viewer"], "permissions": []},
+    },
+}
+
+OPERATOR_CLAIMS = {
+    "sub": "operator1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["operator"], "permissions": []},
+    },
+}
+
+AUTH_HEADER = {"Authorization": "Bearer valid.token"}
+
+USER_ID = str(uuid.uuid4())
+PROVIDER_ID = str(uuid.uuid4())
+LINK_ID = str(uuid.uuid4())
+
+SAMPLE_LINK = {
+    "id": LINK_ID,
+    "user_id": USER_ID,
+    "provider_id": PROVIDER_ID,
+    "external_sub": "ext-sub-123",
+    "external_email": "ext@example.com",
+    "metadata_": None,
+}
+
+
+# --- Auth enforcement ---
+
+
+@pytest.mark.anyio
+async def test_list_links_rejects_unauthenticated(client):
+    response = await client.get(f"/api/users/{USER_ID}/idp-links")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_create_link_rejects_unauthenticated(client):
+    response = await client.post(
+        f"/api/users/{USER_ID}/idp-links",
+        json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_delete_link_rejects_unauthenticated(client):
+    response = await client.delete(f"/api/users/{USER_ID}/idp-links/{LINK_ID}")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_links_rejected_for_viewer(mock_validate, client):
+    mock_validate.return_value = VIEWER_CLAIMS
+    response = await client.get(f"/api/users/{USER_ID}/idp-links", headers=AUTH_HEADER)
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_link_rejected_for_operator(mock_validate, client):
+    """Admin/owner-only endpoints reject operator role."""
+    mock_validate.return_value = OPERATOR_CLAIMS
+    response = await client.post(
+        f"/api/users/{USER_ID}/idp-links",
+        headers=AUTH_HEADER,
+        json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_delete_link_rejected_without_tenant(mock_validate, client):
+    mock_validate.return_value = {"sub": "user1", "tenants": {}}
+    response = await client.delete(
+        f"/api/users/{USER_ID}/idp-links/{LINK_ID}",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 403
+
+
+# --- Happy paths ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_user_idp_links(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    links = [SAMPLE_LINK, {**SAMPLE_LINK, "external_sub": "ext-sub-456"}]
+    mock_idp_link_service.get_user_idp_links.return_value = Ok(links)
+
+    response = await client.get(f"/api/users/{USER_ID}/idp-links", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    data = response.json()
+    assert "idp_links" in data
+    assert len(data["idp_links"]) == 2
+    mock_idp_link_service.get_user_idp_links.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_user_idp_links_empty(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_idp_link_service.get_user_idp_links.return_value = Ok([])
+
+    response = await client.get(f"/api/users/{USER_ID}/idp-links", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    assert response.json()["idp_links"] == []
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_links_owner_allowed(mock_validate, mock_idp_link_service, client):
+    """Owner role is also allowed for IdP link endpoints."""
+    mock_validate.return_value = OWNER_CLAIMS
+    mock_idp_link_service.get_user_idp_links.return_value = Ok([])
+
+    response = await client.get(f"/api/users/{USER_ID}/idp-links", headers=AUTH_HEADER)
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_idp_link(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_idp_link_service.create_idp_link.return_value = Ok(SAMPLE_LINK)
+
+    response = await client.post(
+        f"/api/users/{USER_ID}/idp-links",
+        headers=AUTH_HEADER,
+        json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub-123"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["external_sub"] == "ext-sub-123"
+    mock_idp_link_service.create_idp_link.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_idp_link_with_metadata(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    metadata = {"source": "migration"}
+    mock_idp_link_service.create_idp_link.return_value = Ok({**SAMPLE_LINK, "metadata_": metadata})
+
+    response = await client.post(
+        f"/api/users/{USER_ID}/idp-links",
+        headers=AUTH_HEADER,
+        json={
+            "provider_id": PROVIDER_ID,
+            "external_sub": "ext-sub-123",
+            "metadata": metadata,
+        },
+    )
+    assert response.status_code == 201
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_delete_idp_link(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_idp_link_service.delete_idp_link.return_value = Ok({"status": "deleted", "link_id": LINK_ID})
+
+    response = await client.delete(
+        f"/api/users/{USER_ID}/idp-links/{LINK_ID}",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 204
+    assert response.content == b""
+
+
+# --- Error handling ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_link_user_not_found(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_idp_link_service.create_idp_link.return_value = Error(NotFound(message=f"User '{USER_ID}' not found"))
+
+    response = await client.post(
+        f"/api/users/{USER_ID}/idp-links",
+        headers=AUTH_HEADER,
+        json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_link_conflict(mock_validate, mock_idp_link_service, client):
+    """Duplicate user+provider → 409."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_idp_link_service.create_idp_link.return_value = Error(Conflict(message="IdP link already exists"))
+
+    response = await client.post(
+        f"/api/users/{USER_ID}/idp-links",
+        headers=AUTH_HEADER,
+        json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub"},
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_delete_link_not_found(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_idp_link_service.delete_idp_link.return_value = Error(NotFound(message=f"IdP link '{LINK_ID}' not found"))
+
+    response = await client.delete(
+        f"/api/users/{USER_ID}/idp-links/{LINK_ID}",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 404
+
+
+# --- Input validation ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_links_invalid_user_uuid(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.get("/api/users/not-a-uuid/idp-links", headers=AUTH_HEADER)
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_link_invalid_user_uuid(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/users/not-a-uuid/idp-links",
+        headers=AUTH_HEADER,
+        json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_delete_link_invalid_user_uuid(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.delete(
+        "/api/users/not-a-uuid/idp-links/{LINK_ID}",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_delete_link_invalid_link_uuid(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.delete(
+        f"/api/users/{USER_ID}/idp-links/not-a-uuid",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_link_empty_external_sub_rejected(mock_validate, client):
+    """external_sub requires min_length=1."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        f"/api/users/{USER_ID}/idp-links",
+        headers=AUTH_HEADER,
+        json={"provider_id": PROVIDER_ID, "external_sub": ""},
+    )
+    assert response.status_code == 422

--- a/backend/tests/unit/test_provider_service.py
+++ b/backend/tests/unit/test_provider_service.py
@@ -1,7 +1,8 @@
-"""Unit tests for ProviderService domain orchestration (Story 4.1).
+"""Unit tests for ProviderService domain orchestration (Stories 4.1 + 4.2).
 
 Tests cover:
 - register_provider: happy path, duplicate name → Conflict, integrity error → Conflict
+- list_providers: returns providers with config_ref stripped; empty list
 - deactivate_provider: found → deactivated; already-inactive → idempotent Ok; not found → NotFound
 - get_provider_capabilities: found → capabilities list; not found → NotFound
 """
@@ -115,6 +116,54 @@ class TestRegisterProvider:
         # Verify the Provider constructor received empty list
         created_arg = repo.create.call_args[0][0]
         assert created_arg.capabilities == []
+
+
+@pytest.mark.anyio
+class TestListProviders:
+    """AC-4.2.2: list_providers returns all providers with config_ref stripped."""
+
+    async def test_list_returns_providers_without_config_ref(self):
+        service, repo = _build_service()
+        providers = [
+            _make_provider(name="alpha-provider"),
+            _make_provider(name="beta-provider"),
+        ]
+        repo.list_all.return_value = providers
+
+        result = await service.list_providers()
+
+        assert result.is_ok()
+        assert len(result.ok) == 2
+        for d in result.ok:
+            assert "config_ref" not in d
+        repo.list_all.assert_awaited_once()
+
+    async def test_list_empty(self):
+        service, repo = _build_service()
+        repo.list_all.return_value = []
+
+        result = await service.list_providers()
+
+        assert result.is_ok()
+        assert result.ok == []
+
+    async def test_list_preserves_other_fields(self):
+        """All fields except config_ref are preserved in the response."""
+        service, repo = _build_service()
+        provider = _make_provider(
+            name="test-provider",
+            capabilities=["sso", "mfa"],
+            config_ref="infisical://secret",
+        )
+        repo.list_all.return_value = [provider]
+
+        result = await service.list_providers()
+
+        assert result.is_ok()
+        d = result.ok[0]
+        assert d["name"] == "test-provider"
+        assert d["capabilities"] == ["sso", "mfa"]
+        assert "config_ref" not in d
 
 
 @pytest.mark.anyio

--- a/backend/tests/unit/test_providers_router.py
+++ b/backend/tests/unit/test_providers_router.py
@@ -1,0 +1,349 @@
+"""Unit tests for the providers router (Story 4.2).
+
+Tests cover:
+- Auth enforcement: unauthenticated → 401, wrong role → 403, no tenant → 403
+- Happy paths: list, register, deactivate, capabilities
+- Error handling: Conflict → 409, NotFound → 404
+- Input validation: invalid UUID → 422, active=true rejected
+- Security: config_ref stripped from all responses
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from expression import Error, Ok
+from httpx import ASGITransport, AsyncClient
+
+from app.dependencies.identity import get_provider_service
+from app.errors.identity import Conflict, NotFound
+from app.main import app
+from app.services.provider import ProviderService
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _set_env(monkeypatch):
+    monkeypatch.setenv("DESCOPE_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("DESCOPE_MANAGEMENT_KEY", "test-management-key")
+
+
+@pytest.fixture
+def mock_provider_service():
+    return AsyncMock(spec=ProviderService)
+
+
+@pytest.fixture(autouse=True)
+def _override_services(mock_provider_service):
+    app.dependency_overrides[get_provider_service] = lambda: mock_provider_service
+    yield
+    app.dependency_overrides.pop(get_provider_service, None)
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+TENANT_ID = "51c5957b-684a-453f-8ab1-8f239999c4d8"
+
+OPERATOR_CLAIMS = {
+    "sub": "operator1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["operator"], "permissions": []},
+    },
+}
+
+ADMIN_CLAIMS = {
+    "sub": "admin1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["admin"], "permissions": []},
+    },
+}
+
+VIEWER_CLAIMS = {
+    "sub": "viewer1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["viewer"], "permissions": []},
+    },
+}
+
+AUTH_HEADER = {"Authorization": "Bearer valid.token"}
+
+SAMPLE_PROVIDER = {
+    "id": str(uuid.uuid4()),
+    "name": "descope-prod",
+    "type": "descope",
+    "issuer_url": "https://api.descope.com/P123",
+    "base_url": "https://api.descope.com",
+    "capabilities": ["sso", "mfa"],
+    "active": True,
+}
+
+
+# --- Auth enforcement ---
+
+
+@pytest.mark.anyio
+async def test_list_providers_rejects_unauthenticated(client):
+    response = await client.get("/api/providers")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_register_provider_rejects_unauthenticated(client):
+    response = await client.post("/api/providers", json={"name": "test", "type": "descope"})
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_deactivate_provider_rejects_unauthenticated(client):
+    pid = str(uuid.uuid4())
+    response = await client.patch(f"/api/providers/{pid}", json={"active": False})
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_capabilities_rejects_unauthenticated(client):
+    pid = str(uuid.uuid4())
+    response = await client.get(f"/api/providers/{pid}/capabilities")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_providers_rejected_for_admin(mock_validate, client):
+    """Operator-only endpoints reject admin role."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.get("/api/providers", headers=AUTH_HEADER)
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_register_provider_rejected_for_viewer(mock_validate, client):
+    mock_validate.return_value = VIEWER_CLAIMS
+    response = await client.post(
+        "/api/providers",
+        headers=AUTH_HEADER,
+        json={"name": "test", "type": "descope"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_providers_rejected_without_tenant(mock_validate, client):
+    mock_validate.return_value = {"sub": "user1", "tenants": {}}
+    response = await client.get("/api/providers", headers=AUTH_HEADER)
+    assert response.status_code == 403
+
+
+# --- Happy paths ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_providers(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    providers = [SAMPLE_PROVIDER, {**SAMPLE_PROVIDER, "name": "ory-prod"}]
+    mock_provider_service.list_providers.return_value = Ok(providers)
+
+    response = await client.get("/api/providers", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+    mock_provider_service.list_providers.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_providers_empty(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    mock_provider_service.list_providers.return_value = Ok([])
+
+    response = await client.get("/api/providers", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_register_provider(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    mock_provider_service.register_provider.return_value = Ok({**SAMPLE_PROVIDER, "config_ref": "infisical://secret"})
+
+    response = await client.post(
+        "/api/providers",
+        headers=AUTH_HEADER,
+        json={"name": "descope-prod", "type": "descope", "config_ref": "infisical://secret"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "descope-prod"
+    assert "config_ref" not in data
+    mock_provider_service.register_provider.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_provider(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    pid = str(uuid.uuid4())
+    mock_provider_service.deactivate_provider.return_value = Ok(
+        {**SAMPLE_PROVIDER, "id": pid, "active": False, "config_ref": "infisical://secret"}
+    )
+
+    response = await client.patch(
+        f"/api/providers/{pid}",
+        headers=AUTH_HEADER,
+        json={"active": False},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["active"] is False
+    assert "config_ref" not in data
+    mock_provider_service.deactivate_provider.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_get_capabilities(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    pid = str(uuid.uuid4())
+    mock_provider_service.get_provider_capabilities.return_value = Ok(["sso", "mfa", "rbac"])
+
+    response = await client.get(
+        f"/api/providers/{pid}/capabilities",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 200
+    assert response.json() == ["sso", "mfa", "rbac"]
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_get_capabilities_empty(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    pid = str(uuid.uuid4())
+    mock_provider_service.get_provider_capabilities.return_value = Ok([])
+
+    response = await client.get(
+        f"/api/providers/{pid}/capabilities",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+# --- Error handling ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_register_provider_conflict(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    mock_provider_service.register_provider.return_value = Error(
+        Conflict(message="Provider 'descope-prod' already exists")
+    )
+
+    response = await client.post(
+        "/api/providers",
+        headers=AUTH_HEADER,
+        json={"name": "descope-prod", "type": "descope"},
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_provider_not_found(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    pid = str(uuid.uuid4())
+    mock_provider_service.deactivate_provider.return_value = Error(NotFound(message=f"Provider '{pid}' not found"))
+
+    response = await client.patch(
+        f"/api/providers/{pid}",
+        headers=AUTH_HEADER,
+        json={"active": False},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_capabilities_not_found(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    pid = str(uuid.uuid4())
+    mock_provider_service.get_provider_capabilities.return_value = Error(
+        NotFound(message=f"Provider '{pid}' not found")
+    )
+
+    response = await client.get(
+        f"/api/providers/{pid}/capabilities",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 404
+
+
+# --- Input validation ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_invalid_uuid_returns_422(mock_validate, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    response = await client.patch(
+        "/api/providers/not-a-uuid",
+        headers=AUTH_HEADER,
+        json={"active": False},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_capabilities_invalid_uuid_returns_422(mock_validate, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    response = await client.get(
+        "/api/providers/not-a-uuid/capabilities",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_active_true_rejected(mock_validate, client):
+    """PATCH /providers/{id} only supports active=false."""
+    mock_validate.return_value = OPERATOR_CLAIMS
+    pid = str(uuid.uuid4())
+    response = await client.patch(
+        f"/api/providers/{pid}",
+        headers=AUTH_HEADER,
+        json={"active": True},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_register_provider_empty_name_rejected(mock_validate, client):
+    """Name field requires min_length=1."""
+    mock_validate.return_value = OPERATOR_CLAIMS
+    response = await client.post(
+        "/api/providers",
+        headers=AUTH_HEADER,
+        json={"name": "", "type": "descope"},
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary

- Add three IdP link management endpoints (`GET`, `POST`, `DELETE` under `/users/{user_id}/idp-links`) with admin role authorization (AC-4.2.1, AC-4.2.3)
- Add four provider config endpoints (`GET /providers`, `POST /providers`, `PATCH /providers/{id}`, `GET /providers/{id}/capabilities`) with operator role authorization (AC-4.2.2, AC-4.2.3)
- All error paths use `result_to_response()` for RFC 9457 problem details (AC-4.2.4)
- `config_ref` stripped from all provider responses (security)
- Add `list_all()` to provider repository and `list_providers()` to provider service

Refs #154

## Review Findings Addressed

- **3 findings fixed** (1 P0, 2 P1) in review-fix phase:
  1. **P0 IDOR** — `delete_idp_link` now verifies `link.user_id == user_id` before deletion
  2. **P1** — `DeactivateProviderRequest.active` field is now required (no unsafe default)
  3. **P1** — `_strip_config_ref` uses dict comprehension instead of in-place mutation
- 6 independent review agents ran (blind, edge, sentinel, acceptance, red-team, security)
- Out-of-scope findings from stories 3.1/3.3 noted but not actioned

## Test plan
- [x] Unit tests pass
- [x] Lint passes
- [x] Independent review agents passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)