### PR TITLE
feat: land canonical identity chain (stories 2.2–4.4) + Tyk gateway integration to main

### DIFF
--- a/.claude/review-acceptance.md
+++ b/.claude/review-acceptance.md
@@ -1,0 +1,39 @@
+## Review: Acceptance Auditor
+
+### PASS
+
+- [AC-3.3.2] Redis unavailability — all exceptions in `publish()` and `publish_batch()` are caught with a bare `except Exception`, logged as warnings, and never re-raised. The `repo.commit()` call precedes every `publish()` call in every service, so the Postgres write is always committed before Redis is attempted. A `None` redis client (set when `REDIS_URL` is absent or Redis connection fails at startup) causes `publish()` to return immediately without any network attempt. App startup at `backend/app/main.py:95-106` gracefully handles connection failure by setting `redis_client=None` before calling `init_cache_publisher`. Canonical writes are structurally unaffected.
+  - Implemented at `backend/app/services/cache_invalidation.py:62-68` (None guard + except), `backend/app/main.py:92-106` (startup degradation)
+  - Tested at `backend/tests/unit/test_cache_invalidation.py:56` (no-op when client is None), `backend/tests/unit/test_cache_invalidation.py:62` (exception swallowed, warning logged, no raise), `backend/tests/unit/test_cache_invalidation.py:111` (batch swallows exception)
+
+- [AC-3.3.3] Subscriber documentation — the module-level docstring at `backend/app/services/cache_invalidation.py:1-24` documents: the channel name (`identity:changes`), the full JSON event schema with allowed values for each field, and key patterns subscribers should use to identify affected records and scope invalidation to a tenant. The schema is validated by tests that deserialize actual published payloads and assert all fields are present with correct values.
+  - Implemented at `backend/app/services/cache_invalidation.py:9-23`
+  - Tested at `backend/tests/unit/test_cache_invalidation.py:32-54` (channel name, all schema fields including timestamp and null tenant_id verified against a live publish call)
+
+### FAIL
+
+- None
+
+### PARTIAL
+
+- [AC-3.3.1] Publish on write — `CacheInvalidationPublisher.publish()` is called after `repo.commit()` in all four canonical entity services (user, role, permission, tenant) and for all write operations. The event includes all required fields (entity_type, entity_id, operation, tenant_id, timestamp). Channel is `identity:changes`.
+  - Implemented at: `backend/app/services/user.py:83,153,200,243,284`; `backend/app/services/role.py:101,168,232,299,332,368`; `backend/app/services/permission.py:74,140,174`; `backend/app/services/tenant.py:73`
+  - **What's done:** Implementation is present and correct in all four services. `test_user_service.py:TestCacheInvalidationPublishing` (lines 478-532) covers UserService create + deactivate publish assertions, and a guard test confirms no publish on failure. `test_cache_invalidation.py:TestPublish` validates the full event schema for the `publish()` method itself.
+  - **What's missing:** `backend/tests/unit/test_role_service.py`, `backend/tests/unit/test_permission_service.py`, and `backend/tests/unit/test_tenant_service.py` contain zero references to `CacheInvalidationPublisher` or `publisher`. There are no tests that would fail if the `if self._publisher: await self._publisher.publish(...)` blocks were removed from `role.py`, `permission.py`, or `tenant.py`. Three of four canonical entity types lack service-level publish tests.
+
+### SCOPE CREEP
+
+- `backend/app/services/inbound_sync.py:318-319`, `:329`, `:339`, `:349` — `InboundSyncService` publishes cache events for flow-sync and webhook-triggered user mutations (operation `"sync"`). AC-3.3.1 specifies "canonical write operations (create, update, delete on user/role/permission/tenant)." Inbound sync is a secondary write path not listed in the AC's entity/operation enumeration. The publisher is wired via `backend/app/dependencies/identity.py:56`. Not traceable to any AC.
+
+- `backend/app/services/reconciliation.py:156-157` — `ReconciliationService.run()` calls `publish_batch()` after a reconciliation pass with changes. Reconciliation is not a canonical write operation per the spec. Additionally, `publish_batch()` emits events with `entity_type="batch"` and `entity_id="reconciliation"`, which fall outside the documented schema in AC-3.3.3 (entity_type is specified as `user | role | permission | tenant`). Wired via `backend/app/dependencies/identity.py:57`. Not traceable to any AC.
+
+### Architecture Violations
+
+- None identified. `CacheInvalidationPublisher` is injected into domain services via constructor, consistent with D4 (constructor injection, onion architecture). The publisher is always called after `await self._repository.commit()`, preserving the D7 write-through Postgres-first semantic. No publisher calls occur in the repository layer (inner) or adapter layer (outer). The singleton pattern mirrors the existing `descope.py` module pattern. The Redis import is gated behind `TYPE_CHECKING` to avoid a hard load-time import.
+
+### Summary
+
+- Total ACs: 3
+- Pass: 2 | Fail: 0 | Partial: 1
+
+The partial is AC-3.3.1: implementation is complete and correct across all four canonical entity services, but three of the four service test files (role, permission, tenant) have no publisher assertions. Removing the publish calls from those three services would not be caught by the test suite.

--- a/.claude/review-blind.md
+++ b/.claude/review-blind.md
@@ -1,0 +1,37 @@
+## Review: Blind Hunter
+
+### MUST FIX
+
+- [`backend/app/services/inbound_sync.py:329`] Wrong operation label on create/link publish — uses `operation="sync"` for the create-or-link branch, but the correct operation for a newly-created user should be `"create"` (which IS used at line 319 for the existing-user update path). The variable `created` is available and distinguishes the two cases; consumers relying on `"create"` will miss cache invalidation for newly created users flowing through this path.
+
+- [`backend/app/services/inbound_sync.py:349`] Wrong operation label on user deletion — `user.deleted` webhook deactivates a user but publishes `operation="sync"` instead of `operation="deactivate"`. The schema documents `"deactivate"` as a valid operation. Any consumer keyed on `"deactivate"` will never receive this event and will not invalidate caches for deactivated users.
+
+- [`backend/uv.lock` (~line 1636, redis package entry)`] `redis` lock entry lists `pyjwt` as a dependency — `redis` has no dependency on `pyjwt`. This is a corrupt lockfile entry, likely a hand-edit or merge artifact. In production it is only harmless if `pyjwt` remains in the dependency tree via another package. If `pyjwt` is removed, `uv` would fail to install the environment. The lockfile must be regenerated with `uv lock` to produce a valid, reproducible entry.
+
+- [`backend/app/main.py:95-103`] Leaked Redis connection when ping fails after TCP connect — on ping failure the `except Exception` block sets `redis_client = None` and discards the reference, but the `aioredis` client object that was allocated at line 98 is never closed. If the connection was established before the ping exception (e.g., AUTH failure, NOAUTH, wrong database), the underlying socket is abandoned without calling `aclose()`. Add `await redis_client.aclose()` in the except block before nulling the reference.
+
+### SHOULD FIX
+
+- [`backend/app/services/cache_invalidation.py:267-275`] `get_cache_publisher()` allocates a fresh `CacheInvalidationPublisher()` instance every time it is called before `init_cache_publisher` runs. Any caller that caches the returned instance before lifespan completes will hold a no-op publisher forever, even after the real one is initialised. A single module-level no-op sentinel (`_NOOP_PUBLISHER = CacheInvalidationPublisher()`) returned from the fallback branch would be safer and eliminates repeated allocation.
+
+- [`backend/app/services/role.py:489`] `update_role` publishes without `tenant_id` — the call has no `tenant_id` kwarg so it defaults to `None`. `create_role` (line 477) and `assign_role_to_user` (line 499) correctly pass `tenant_id`. Roles can be tenant-scoped; consumers filtering on `tenant_id` will miss cache invalidation for tenant-scoped role updates.
+
+- [`backend/app/services/user.py:653-656`] Remove-user-from-tenant publishes `operation="update"` — removing a tenant membership is a removal/unassignment, and the documented schema lists `"unassign"` as a valid operation. `RoleService.unassign_role_from_user` correctly uses `"unassign"`. Using `"update"` here creates inconsistency; consumers cannot distinguish membership removal from a field edit.
+
+- [`backend/app/main.py:115-120`] `shutdown_cache_publisher()` and `redis_client.aclose()` share a single `try/except` block. Although `shutdown_cache_publisher()` currently cannot raise (it is a `global _publisher = None` assignment), if it ever does, `redis_client.aclose()` will be skipped because the except clause absorbs the exception and continues. The two operations should be in separate try/finally blocks to guarantee both execute.
+
+- [`backend/app/services/cache_invalidation.py:230-243`] `publish_batch` constructs the event dict inline and duplicates the `datetime.now(timezone.utc).isoformat()` call that exists in `_build_event`. The batch event diverges from the standard schema independently. If the timestamp format or timezone handling is ever changed in `_build_event`, the batch path will silently produce inconsistent timestamps. Extract a shared `_now_iso()` helper or use `_build_event` for the common fields.
+
+- [`backend/tests/unit/test_cache_invalidation.py:802-819`] `TestSingletonLifecycle` tests mutate module-level global state without using fixtures to guarantee cleanup. If `test_init_and_get_returns_same_instance` fails before reaching its `shutdown_cache_publisher()` cleanup call, all subsequent tests in the file inherit a dirty singleton. Use `setup_method`/`teardown_method` or a pytest fixture with `autouse=True` to guarantee the singleton is reset regardless of test outcome.
+
+- [`backend/app/services/cache_invalidation.py:280-282`] `init_cache_publisher` performs a bare `global _publisher` assignment with no guard against double-initialisation. If called twice (e.g., in tests that forget to call `shutdown_cache_publisher` between runs), the first publisher's Redis client reference is silently replaced without being closed. The old client leaks. Add a warning log or raise if `_publisher` is already set to a non-None value.
+
+### NITPICK
+
+- [`backend/app/main.py:74`] `import os` added solely for `os.getenv("REDIS_URL")`. The project presumably has a settings/config object that validates env vars at startup. Using raw `os.getenv` bypasses any such validation layer and is inconsistent with how the rest of the app likely reads configuration.
+
+- [`backend/app/services/cache_invalidation.py:203`] Constructor parameter is named `redis_client` but the stored attribute is `self._redis` — the shortened name is slightly inconsistent and marginally harder to search for.
+
+- [`backend/app/services/cache_invalidation.py:192`] `CHANNEL = "identity:changes"` is exported implicitly. If downstream consumers import this constant, they are coupling to the internal module path. Worth noting in the module docstring that `CHANNEL` is part of the stable contract.
+
+- [`backend/app/services/inbound_sync.py:305`] `publisher: CacheInvalidationPublisher | None = None` default is consistent with all other services in this PR, but the `if self._publisher:` guard scattered through business logic is noise. A null-object pattern (always inject a real or no-op publisher, never `None`) would eliminate all seven guard clauses across the six service files.

--- a/.claude/review-diff.patch
+++ b/.claude/review-diff.patch
@@ -1,0 +1,1301 @@
+diff --git a/backend/app/dependencies/identity.py b/backend/app/dependencies/identity.py
+index 7f0915b..f714ff4 100644
+--- a/backend/app/dependencies/identity.py
++++ b/backend/app/dependencies/identity.py
+@@ -22,6 +22,7 @@ from app.repositories.role import RoleRepository
+ from app.repositories.tenant import TenantRepository
+ from app.repositories.user import UserRepository
+ from app.services.adapters.descope import DescopeSyncAdapter
++from app.services.cache_invalidation import get_cache_publisher
+ from app.services.descope import get_descope_client
+ from app.services.inbound_sync import InboundSyncService
+ from app.services.permission import PermissionService
+@@ -46,7 +47,12 @@ async def get_user_service(
+     repository = UserRepository(session)
+     assignment_repository = UserTenantRoleRepository(session)
+     adapter = DescopeSyncAdapter(client=get_descope_client())
+-    return UserService(repository=repository, adapter=adapter, assignment_repository=assignment_repository)
++    return UserService(
++        repository=repository,
++        adapter=adapter,
++        assignment_repository=assignment_repository,
++        publisher=get_cache_publisher(),
++    )
+ 
+ 
+ async def get_role_service(
+@@ -67,6 +73,7 @@ async def get_role_service(
+         permission_repository=permission_repository,
+         assignment_repository=assignment_repository,
+         adapter=adapter,
++        publisher=get_cache_publisher(),
+     )
+ 
+ 
+@@ -81,7 +88,7 @@ async def get_permission_service(
+     """
+     repository = PermissionRepository(session)
+     adapter = DescopeSyncAdapter(client=get_descope_client())
+-    return PermissionService(repository=repository, adapter=adapter)
++    return PermissionService(repository=repository, adapter=adapter, publisher=get_cache_publisher())
+ 
+ 
+ async def get_tenant_service(
+@@ -95,7 +102,7 @@ async def get_tenant_service(
+     """
+     repository = TenantRepository(session)
+     adapter = DescopeSyncAdapter(client=get_descope_client())
+-    return TenantService(repository=repository, adapter=adapter)
++    return TenantService(repository=repository, adapter=adapter, publisher=get_cache_publisher())
+ 
+ 
+ async def get_inbound_sync_service(
+@@ -113,6 +120,7 @@ async def get_inbound_sync_service(
+         user_repository=user_repository,
+         idp_link_repository=idp_link_repository,
+         provider_repository=provider_repository,
++        publisher=get_cache_publisher(),
+     )
+ 
+ 
+@@ -148,4 +156,5 @@ async def get_reconciliation_service(
+         tenant_repository=tenant_repository,
+         idp_link_repository=idp_link_repository,
+         provider_repository=provider_repository,
++        publisher=get_cache_publisher(),
+     )
+diff --git a/backend/app/main.py b/backend/app/main.py
+index d46cb4b..0dc91b2 100644
+--- a/backend/app/main.py
++++ b/backend/app/main.py
+@@ -1,5 +1,6 @@
+ import asyncio
+ import logging
++import os
+ from contextlib import asynccontextmanager
+ 
+ import httpx
+@@ -27,6 +28,7 @@ from app.routers import (
+     tenants,
+     users,
+ )
++from app.services.cache_invalidation import init_cache_publisher, shutdown_cache_publisher
+ from app.services.descope import init_descope_client, shutdown_descope_client
+ from app.telemetry import init_telemetry, shutdown_telemetry
+ 
+@@ -60,27 +62,63 @@ async def lifespan(app: FastAPI):
+     init_telemetry(engine=engine)
+     http_client = httpx.AsyncClient(timeout=30.0)
+     init_descope_client(http_client=http_client)
++
++    # Redis for cache invalidation pub/sub — optional, degrades gracefully
++    redis_client = None
++    redis_url = os.getenv("REDIS_URL")
++    if redis_url:
++        from urllib.parse import urlparse
++
++        parsed = urlparse(redis_url)
++        if parsed.scheme not in ("redis", "rediss"):
++            logger.warning("REDIS_URL has unsupported scheme '%s' — cache invalidation disabled", parsed.scheme)
++        else:
++            try:
++                import redis.asyncio as aioredis
++
++                redis_client = aioredis.from_url(redis_url)
++                await redis_client.ping()
++                logger.info("Redis connected for cache invalidation")
++            except Exception:
++                logger.warning("Redis connection failed — cache invalidation disabled", exc_info=True)
++                if redis_client is not None:
++                    await redis_client.aclose()
++                redis_client = None
++    else:
++        logger.info("REDIS_URL not set — cache invalidation disabled")
++    init_cache_publisher(redis_client=redis_client)
++
+     try:
+         yield
+     finally:
+         try:
+-            # Run synchronous shutdown in executor to avoid blocking the event loop
+-            loop = asyncio.get_running_loop()
+-            await loop.run_in_executor(None, shutdown_telemetry)
++            shutdown_cache_publisher()
++        except Exception:
++            logger.warning("Cache publisher shutdown failed", exc_info=True)
++        try:
++            if redis_client is not None:
++                await redis_client.aclose()
+         except Exception:
+-            logger.warning("Telemetry shutdown failed", exc_info=True)
++            logger.warning("Redis shutdown failed", exc_info=True)
+         finally:
+             try:
+-                shutdown_descope_client()
++                # Run synchronous shutdown in executor to avoid blocking the event loop
++                loop = asyncio.get_running_loop()
++                await loop.run_in_executor(None, shutdown_telemetry)
+             except Exception:
+-                logger.warning("Descope client shutdown failed", exc_info=True)
++                logger.warning("Telemetry shutdown failed", exc_info=True)
+             finally:
+                 try:
+-                    await http_client.aclose()
++                    shutdown_descope_client()
+                 except Exception:
+-                    logger.warning("HTTP client close failed", exc_info=True)
++                    logger.warning("Descope client shutdown failed", exc_info=True)
+                 finally:
+-                    await engine.dispose()
++                    try:
++                        await http_client.aclose()
++                    except Exception:
++                        logger.warning("HTTP client close failed", exc_info=True)
++                    finally:
++                        await engine.dispose()
+ 
+ 
+ app = FastAPI(title="Descope SaaS Starter API", docs_url=None, redoc_url="/redoc", lifespan=lifespan)
+diff --git a/backend/app/services/cache_invalidation.py b/backend/app/services/cache_invalidation.py
+new file mode 100644
+index 0000000..d1c1f42
+--- /dev/null
++++ b/backend/app/services/cache_invalidation.py
+@@ -0,0 +1,133 @@
++"""CacheInvalidationPublisher — fire-and-forget Redis pub/sub for cache invalidation.
++
++Publishes change events to Redis so downstream caches can invalidate stale entries.
++All publish operations are best-effort: failures are logged as warnings and never
++propagate to the caller (AC-3.3.2).
++
++Channel: ``identity:changes``
++
++Event schema (JSON on the wire)::
++
++    {
++        "entity_type": "user" | "role" | "permission" | "tenant",
++        "entity_id": "<uuid>",
++        "operation": "create" | "update" | "delete" | "deactivate"
++                    | "activate" | "assign" | "unassign" | "sync" | "reconcile",
++        "tenant_id": "<uuid>" | null,
++        "timestamp": "<ISO-8601 UTC>"
++    }
++
++Key patterns for consumers:
++- ``identity:changes`` — single channel for all entity mutations
++- ``entity_type`` + ``entity_id`` — identify the affected record
++- ``tenant_id`` — scope invalidation to a tenant (null for global entities)
++"""
++
++from __future__ import annotations
++
++import json
++import logging
++from datetime import datetime, timezone
++from typing import TYPE_CHECKING, Any
++from uuid import UUID
++
++if TYPE_CHECKING:
++    from redis.asyncio import Redis
++
++logger = logging.getLogger(__name__)
++
++CHANNEL = "identity:changes"
++
++
++class CacheInvalidationPublisher:
++    """Best-effort Redis pub/sub publisher for identity change events.
++
++    AC-3.3.1: Called after every repo.commit() in write methods.
++    AC-3.3.2: All exceptions caught, logged as warnings, never raised.
++    AC-3.3.3: Schema documented above; channel = ``identity:changes``.
++    """
++
++    def __init__(self, redis_client: Redis | None = None) -> None:
++        self._redis = redis_client
++
++    async def publish(
++        self,
++        *,
++        entity_type: str,
++        entity_id: UUID | str,
++        operation: str,
++        tenant_id: UUID | str | None = None,
++    ) -> None:
++        """Publish a single change event. Silent on failure (AC-3.3.2)."""
++        if self._redis is None:
++            return
++        event = self._build_event(entity_type, entity_id, operation, tenant_id)
++        try:
++            await self._redis.publish(CHANNEL, json.dumps(event))
++        except Exception:
++            logger.warning("Redis publish failed for %s/%s", entity_type, entity_id, exc_info=True)
++
++    async def publish_batch(
++        self,
++        *,
++        operation: str,
++        stats: dict[str, Any],
++    ) -> None:
++        """Publish a single batch event for reconciliation. Silent on failure."""
++        if self._redis is None:
++            return
++        event = self._build_event("batch", "reconciliation", operation, None)
++        event["stats"] = stats
++        try:
++            await self._redis.publish(CHANNEL, json.dumps(event))
++        except Exception:
++            logger.warning("Redis publish failed for batch/%s", operation, exc_info=True)
++
++    @staticmethod
++    def _build_event(
++        entity_type: str,
++        entity_id: UUID | str,
++        operation: str,
++        tenant_id: UUID | str | None,
++    ) -> dict[str, Any]:
++        return {
++            "entity_type": entity_type,
++            "entity_id": str(entity_id),
++            "operation": operation,
++            "tenant_id": str(tenant_id) if tenant_id is not None else None,
++            "timestamp": datetime.now(timezone.utc).isoformat(),
++        }
++
++
++# ---------------------------------------------------------------------------
++# Module-level singleton (mirrors descope.py pattern)
++# ---------------------------------------------------------------------------
++_publisher: CacheInvalidationPublisher | None = None
++_NOOP_PUBLISHER = CacheInvalidationPublisher()
++
++
++def get_cache_publisher() -> CacheInvalidationPublisher:
++    """Return the singleton CacheInvalidationPublisher.
++
++    Returns a no-op publisher (redis_client=None) if not initialised,
++    so callers never need to null-check.
++    """
++    if _publisher is not None:
++        return _publisher
++    logger.warning("get_cache_publisher() called before init_cache_publisher() — returning no-op")
++    return _NOOP_PUBLISHER
++
++
++def init_cache_publisher(redis_client: Redis | None = None) -> CacheInvalidationPublisher:
++    """Initialise the singleton publisher during app lifespan."""
++    global _publisher  # noqa: PLW0603
++    if _publisher is not None:
++        logger.warning("init_cache_publisher() called twice — replacing existing publisher")
++    _publisher = CacheInvalidationPublisher(redis_client=redis_client)
++    return _publisher
++
++
++def shutdown_cache_publisher() -> None:
++    """Clear the singleton on shutdown."""
++    global _publisher  # noqa: PLW0603
++    _publisher = None
+diff --git a/backend/app/services/inbound_sync.py b/backend/app/services/inbound_sync.py
+index db8e91a..8a86482 100644
+--- a/backend/app/services/inbound_sync.py
++++ b/backend/app/services/inbound_sync.py
+@@ -19,6 +19,7 @@ from app.models.identity.user import IdPLink, User, UserStatus
+ from app.repositories.idp_link import IdPLinkRepository
+ from app.repositories.provider import ProviderRepository
+ from app.repositories.user import RepositoryConflictError, UserRepository
++from app.services.cache_invalidation import CacheInvalidationPublisher
+ 
+ logger = logging.getLogger(__name__)
+ tracer = trace.get_tracer(__name__)
+@@ -42,10 +43,12 @@ class InboundSyncService:
+         user_repository: UserRepository,
+         idp_link_repository: IdPLinkRepository,
+         provider_repository: ProviderRepository,
++        publisher: CacheInvalidationPublisher | None = None,
+     ) -> None:
+         self._user_repo = user_repository
+         self._link_repo = idp_link_repository
+         self._provider_repo = provider_repository
++        self._publisher = publisher
+ 
+     async def sync_user_from_flow(
+         self,
+@@ -111,6 +114,9 @@ class InboundSyncService:
+                     logger.exception("Commit failed during flow sync update")
+                     return Error(Conflict(message="Failed to persist user update"))
+ 
++                if self._publisher:
++                    await self._publisher.publish(entity_type="user", entity_id=existing_user.id, operation="update")
++
+                 logger.info("Flow sync: updated existing user %s", existing_user.id)
+                 return Ok({"user": existing_user.model_dump(), "created": False})
+ 
+@@ -152,6 +158,13 @@ class InboundSyncService:
+                 logger.exception("Commit failed during flow sync create/link")
+                 return Error(Conflict(message="Failed to persist user and link"))
+ 
++            if self._publisher:
++                await self._publisher.publish(
++                    entity_type="user",
++                    entity_id=existing_user.id,
++                    operation="create" if created else "update",
++                )
++
+             action = "created" if created else "linked"
+             logger.info("Flow sync: %s user %s", action, existing_user.id)
+             return Ok({"user": existing_user.model_dump(), "created": created})
+@@ -251,6 +264,9 @@ class InboundSyncService:
+             logger.exception("Commit failed during user.updated webhook")
+             return Error(Conflict(message="Failed to persist user update"))
+ 
++        if self._publisher:
++            await self._publisher.publish(entity_type="user", entity_id=user.id, operation="update")
++
+         logger.info("Webhook: updated user %s from user.updated event", user.id)
+         return Ok({"user": user.model_dump(), "created": False})
+ 
+@@ -290,5 +306,8 @@ class InboundSyncService:
+             logger.exception("Commit failed during user.deleted webhook")
+             return Error(Conflict(message="Failed to persist user deactivation"))
+ 
++        if self._publisher:
++            await self._publisher.publish(entity_type="user", entity_id=user.id, operation="deactivate")
++
+         logger.info("Webhook: deactivated user %s from user.deleted event", user.id)
+         return Ok({"status": "deactivated", "user_id": str(user.id)})
+diff --git a/backend/app/services/permission.py b/backend/app/services/permission.py
+index 0e6ee7f..82882eb 100644
+--- a/backend/app/services/permission.py
++++ b/backend/app/services/permission.py
+@@ -18,6 +18,7 @@ from app.models.identity.role import Permission
+ from app.repositories.permission import PermissionRepository
+ from app.repositories.user import RepositoryConflictError
+ from app.services.adapters.base import IdentityProviderAdapter, SyncError
++from app.services.cache_invalidation import CacheInvalidationPublisher
+ 
+ logger = logging.getLogger(__name__)
+ tracer = trace.get_tracer(__name__)
+@@ -35,9 +36,11 @@ class PermissionService:
+         *,
+         repository: PermissionRepository,
+         adapter: IdentityProviderAdapter,
++        publisher: CacheInvalidationPublisher | None = None,
+     ) -> None:
+         self._repository = repository
+         self._adapter = adapter
++        self._publisher = publisher
+ 
+     async def create_permission(
+         self,
+@@ -68,6 +71,9 @@ class PermissionService:
+             permission_id = permission.id
+             await self._repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(entity_type="permission", entity_id=permission_id, operation="create")
++
+             self._log_sync_failure(
+                 await self._adapter.sync_permission(
+                     permission_id=permission_id,
+@@ -131,6 +137,9 @@ class PermissionService:
+             result_dict = permission.model_dump()
+             await self._repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(entity_type="permission", entity_id=permission.id, operation="update")
++
+             self._log_sync_failure(
+                 await self._adapter.sync_permission(
+                     permission_id=permission.id,
+@@ -162,6 +171,9 @@ class PermissionService:
+ 
+             await self._repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(entity_type="permission", entity_id=permission_id, operation="delete")
++
+             self._log_sync_failure(
+                 await self._adapter.delete_permission(permission_id=permission_id),
+                 permission_id,
+diff --git a/backend/app/services/reconciliation.py b/backend/app/services/reconciliation.py
+index 16484b0..2dbfae3 100644
+--- a/backend/app/services/reconciliation.py
++++ b/backend/app/services/reconciliation.py
+@@ -31,6 +31,7 @@ from app.repositories.provider import ProviderRepository
+ from app.repositories.role import RoleRepository
+ from app.repositories.tenant import TenantRepository
+ from app.repositories.user import RepositoryConflictError, UserRepository
++from app.services.cache_invalidation import CacheInvalidationPublisher
+ from app.services.descope import DescopeManagementClient
+ 
+ if TYPE_CHECKING:
+@@ -68,6 +69,7 @@ class ReconciliationService:
+         tenant_repository: TenantRepository,
+         idp_link_repository: IdPLinkRepository,
+         provider_repository: ProviderRepository,
++        publisher: CacheInvalidationPublisher | None = None,
+     ) -> None:
+         self._session = session
+         self._acquire_lock = acquire_lock
+@@ -78,6 +80,7 @@ class ReconciliationService:
+         self._tenant_repo = tenant_repository
+         self._link_repo = idp_link_repository
+         self._provider_repo = provider_repository
++        self._publisher = publisher
+ 
+     async def run(self) -> Result[dict, IdentityError]:
+         """Execute a full reconciliation pass.
+@@ -153,6 +156,9 @@ class ReconciliationService:
+             span.set_attribute("reconciliation.status", "completed")
+             span.set_attribute("reconciliation.total_changes", total_changes)
+ 
++            if self._publisher and total_changes > 0:
++                await self._publisher.publish_batch(operation="reconcile", stats=stats)
++
+             logger.info("Reconciliation completed: %s", stats)
+             return Ok({"status": "completed", "stats": stats})
+ 
+diff --git a/backend/app/services/role.py b/backend/app/services/role.py
+index 2381a57..d060c1c 100644
+--- a/backend/app/services/role.py
++++ b/backend/app/services/role.py
+@@ -22,6 +22,7 @@ from app.repositories.permission import PermissionRepository
+ from app.repositories.role import RoleRepository
+ from app.repositories.user import RepositoryConflictError
+ from app.services.adapters.base import IdentityProviderAdapter, SyncError
++from app.services.cache_invalidation import CacheInvalidationPublisher
+ 
+ logger = logging.getLogger(__name__)
+ tracer = trace.get_tracer(__name__)
+@@ -42,11 +43,13 @@ class RoleService:
+         permission_repository: PermissionRepository,
+         assignment_repository: UserTenantRoleRepository,
+         adapter: IdentityProviderAdapter,
++        publisher: CacheInvalidationPublisher | None = None,
+     ) -> None:
+         self._repository = repository
+         self._permission_repository = permission_repository
+         self._assignment_repository = assignment_repository
+         self._adapter = adapter
++        self._publisher = publisher
+ 
+     async def create_role(
+         self,
+@@ -95,6 +98,11 @@ class RoleService:
+             role_id = role.id
+             await self._repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(
++                    entity_type="role", entity_id=role_id, operation="create", tenant_id=tenant_id
++                )
++
+             sync_data: dict = {"name": role.name, "description": role.description}
+             if resolved_permission_names:
+                 sync_data["permission_names"] = resolved_permission_names
+@@ -156,6 +164,12 @@ class RoleService:
+             permissions = await self._repository.get_permissions(role_id)
+             permission_names = [p.name for p in permissions]
+             await self._repository.commit()
++
++            if self._publisher:
++                await self._publisher.publish(
++                    entity_type="role", entity_id=role_id, operation="update", tenant_id=role.tenant_id
++                )
++
+             self._log_sync_failure(
+                 await self._adapter.sync_role(
+                     role_id=role_id,
+@@ -217,6 +231,11 @@ class RoleService:
+             }
+             await self._assignment_repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(
++                    entity_type="role", entity_id=role_id, operation="assign", tenant_id=tenant_id
++                )
++
+             self._log_sync_failure(
+                 await self._adapter.sync_role_assignment(
+                     user_id=user_id,
+@@ -279,6 +298,11 @@ class RoleService:
+                 sync_data["permission_names"] = permission_names
+             await self._repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(
++                    entity_type="role", entity_id=role.id, operation="update", tenant_id=role.tenant_id
++                )
++
+             self._log_sync_failure(
+                 await self._adapter.sync_role(role_id=role.id, data=sync_data),
+                 role.id,
+@@ -307,6 +331,11 @@ class RoleService:
+ 
+             await self._repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(
++                    entity_type="role", entity_id=role_id, operation="delete", tenant_id=role.tenant_id
++                )
++
+             self._log_sync_failure(
+                 await self._adapter.delete_role(role_id=role_id),
+                 role_id,
+@@ -338,6 +367,11 @@ class RoleService:
+ 
+             await self._assignment_repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(
++                    entity_type="role", entity_id=role_id, operation="unassign", tenant_id=tenant_id
++                )
++
+             self._log_sync_failure(
+                 await self._adapter.delete_role_assignment(
+                     user_id=user_id,
+diff --git a/backend/app/services/tenant.py b/backend/app/services/tenant.py
+index 98a5b60..06c06bd 100644
+--- a/backend/app/services/tenant.py
++++ b/backend/app/services/tenant.py
+@@ -18,6 +18,7 @@ from app.models.identity.tenant import Tenant
+ from app.repositories.tenant import TenantRepository
+ from app.repositories.user import RepositoryConflictError
+ from app.services.adapters.base import IdentityProviderAdapter, SyncError
++from app.services.cache_invalidation import CacheInvalidationPublisher
+ 
+ logger = logging.getLogger(__name__)
+ tracer = trace.get_tracer(__name__)
+@@ -35,9 +36,11 @@ class TenantService:
+         *,
+         repository: TenantRepository,
+         adapter: IdentityProviderAdapter,
++        publisher: CacheInvalidationPublisher | None = None,
+     ) -> None:
+         self._repository = repository
+         self._adapter = adapter
++        self._publisher = publisher
+ 
+     async def create_tenant(
+         self,
+@@ -67,6 +70,9 @@ class TenantService:
+             tenant_id = tenant.id
+             await self._repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(entity_type="tenant", entity_id=tenant_id, operation="create")
++
+             self._log_sync_failure(
+                 await self._adapter.sync_tenant(
+                     tenant_id=tenant_id,
+diff --git a/backend/app/services/user.py b/backend/app/services/user.py
+index 8ec790e..a242e98 100644
+--- a/backend/app/services/user.py
++++ b/backend/app/services/user.py
+@@ -18,6 +18,7 @@ from app.models.identity.user import User, UserStatus
+ from app.repositories.assignment import UserTenantRoleRepository
+ from app.repositories.user import RepositoryConflictError, UserRepository
+ from app.services.adapters.base import IdentityProviderAdapter, SyncError
++from app.services.cache_invalidation import CacheInvalidationPublisher
+ 
+ logger = logging.getLogger(__name__)
+ tracer = trace.get_tracer(__name__)
+@@ -36,10 +37,12 @@ class UserService:
+         repository: UserRepository,
+         adapter: IdentityProviderAdapter,
+         assignment_repository: UserTenantRoleRepository | None = None,
++        publisher: CacheInvalidationPublisher | None = None,
+     ) -> None:
+         self._repository = repository
+         self._adapter = adapter
+         self._assignment_repository = assignment_repository
++        self._publisher = publisher
+ 
+     async def create_user(
+         self,
+@@ -77,6 +80,11 @@ class UserService:
+             user_id = user.id
+             await self._repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(
++                    entity_type="user", entity_id=user_id, operation="create", tenant_id=tenant_id
++                )
++
+             self._log_sync_failure(
+                 await self._adapter.sync_user(user_id=user_id, data=sync_data),
+                 user_id,
+@@ -141,6 +149,11 @@ class UserService:
+             sync_data = {"email": user.email, "status": user.status.value}
+             await self._repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(
++                    entity_type="user", entity_id=user.id, operation="update", tenant_id=tenant_id
++                )
++
+             self._log_sync_failure(
+                 await self._adapter.sync_user(user_id=user.id, data=sync_data),
+                 user.id,
+@@ -184,6 +197,11 @@ class UserService:
+             sync_data = {"email": user.email, "status": user.status.value}
+             await self._repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(
++                    entity_type="user", entity_id=user.id, operation="deactivate", tenant_id=tenant_id
++                )
++
+             self._log_sync_failure(
+                 await self._adapter.sync_user(user_id=user.id, data=sync_data),
+                 user.id,
+@@ -221,6 +239,11 @@ class UserService:
+             sync_data = {"email": user.email, "status": user.status.value}
+             await self._repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(
++                    entity_type="user", entity_id=user.id, operation="activate", tenant_id=tenant_id
++                )
++
+             self._log_sync_failure(
+                 await self._adapter.sync_user(user_id=user.id, data=sync_data),
+                 user.id,
+@@ -258,6 +281,11 @@ class UserService:
+ 
+             await self._assignment_repository.commit()
+ 
++            if self._publisher:
++                await self._publisher.publish(
++                    entity_type="user", entity_id=user_id, operation="unassign", tenant_id=tenant_id
++                )
++
+             # Best-effort sync: notify IdP of membership removal
+             self._log_sync_failure(
+                 await self._adapter.sync_user(
+diff --git a/backend/pyproject.toml b/backend/pyproject.toml
+index 1148a49..a6eddc1 100644
+--- a/backend/pyproject.toml
++++ b/backend/pyproject.toml
+@@ -23,6 +23,7 @@ dependencies = [
+     "opentelemetry-instrumentation-httpx>=0.41b0",
+     "opentelemetry-instrumentation-sqlalchemy>=0.41b0",
+     "opentelemetry-instrumentation-logging>=0.41b0",
++    "redis[hiredis]>=5.0,<6",
+ ]
+ 
+ [project.optional-dependencies]
+diff --git a/backend/tests/unit/test_cache_invalidation.py b/backend/tests/unit/test_cache_invalidation.py
+new file mode 100644
+index 0000000..8b149bc
+--- /dev/null
++++ b/backend/tests/unit/test_cache_invalidation.py
+@@ -0,0 +1,145 @@
++"""Unit tests for CacheInvalidationPublisher (Story 3.3).
++
++Tests cover:
++- publish: publishes JSON event to identity:changes channel (AC-3.3.1)
++- publish: no-op when redis client is None
++- publish: swallows Redis exceptions, logs warning (AC-3.3.2)
++- publish_batch: publishes batch event with stats
++- publish_batch: swallows exceptions like publish
++- Singleton lifecycle: init, get, shutdown
++- Event schema correctness (AC-3.3.3)
++"""
++
++import json
++import uuid
++from unittest.mock import AsyncMock, patch
++
++import pytest
++
++from app.services.cache_invalidation import (
++    CHANNEL,
++    CacheInvalidationPublisher,
++    get_cache_publisher,
++    init_cache_publisher,
++    shutdown_cache_publisher,
++)
++
++
++@pytest.mark.anyio
++class TestPublish:
++    """AC-3.3.1: publish sends correct event to identity:changes channel."""
++
++    async def test_publish_sends_event_to_channel(self):
++        redis = AsyncMock()
++        redis.publish.return_value = 1
++        pub = CacheInvalidationPublisher(redis_client=redis)
++        entity_id = uuid.uuid4()
++        tenant_id = uuid.uuid4()
++
++        await pub.publish(
++            entity_type="user",
++            entity_id=entity_id,
++            operation="create",
++            tenant_id=tenant_id,
++        )
++
++        redis.publish.assert_awaited_once()
++        call_args = redis.publish.call_args
++        assert call_args[0][0] == CHANNEL
++        event = json.loads(call_args[0][1])
++        assert event["entity_type"] == "user"
++        assert event["entity_id"] == str(entity_id)
++        assert event["operation"] == "create"
++        assert event["tenant_id"] == str(tenant_id)
++        assert "timestamp" in event
++
++    async def test_publish_noop_when_no_redis_client(self):
++        """No-op publisher does not raise or attempt to publish."""
++        pub = CacheInvalidationPublisher(redis_client=None)
++        # Should complete silently — no exception
++        await pub.publish(entity_type="user", entity_id=uuid.uuid4(), operation="create")
++
++    async def test_publish_swallows_redis_exception(self):
++        """AC-3.3.2: Redis failure logged as warning, never raised."""
++        redis = AsyncMock()
++        redis.publish.side_effect = ConnectionError("Redis gone")
++        pub = CacheInvalidationPublisher(redis_client=redis)
++
++        with patch("app.services.cache_invalidation.logger") as mock_logger:
++            await pub.publish(entity_type="user", entity_id=uuid.uuid4(), operation="update")
++
++        mock_logger.warning.assert_called_once()
++        assert "Redis publish failed" in mock_logger.warning.call_args[0][0]
++
++    async def test_publish_null_tenant_id(self):
++        """Global entities (roles, permissions) have tenant_id=null."""
++        redis = AsyncMock()
++        redis.publish.return_value = 1
++        pub = CacheInvalidationPublisher(redis_client=redis)
++
++        await pub.publish(entity_type="permission", entity_id=uuid.uuid4(), operation="create")
++
++        event = json.loads(redis.publish.call_args[0][1])
++        assert event["tenant_id"] is None
++
++
++@pytest.mark.anyio
++class TestPublishBatch:
++    """publish_batch sends a single batch event for reconciliation."""
++
++    async def test_publish_batch_sends_event(self):
++        redis = AsyncMock()
++        redis.publish.return_value = 1
++        pub = CacheInvalidationPublisher(redis_client=redis)
++        stats = {"users_created": 3, "roles_updated": 1}
++
++        await pub.publish_batch(operation="reconcile", stats=stats)
++
++        redis.publish.assert_awaited_once()
++        event = json.loads(redis.publish.call_args[0][1])
++        assert event["entity_type"] == "batch"
++        assert event["entity_id"] == "reconciliation"
++        assert event["operation"] == "reconcile"
++        assert event["stats"] == stats
++        assert event["tenant_id"] is None
++
++    async def test_publish_batch_noop_when_no_redis(self):
++        pub = CacheInvalidationPublisher(redis_client=None)
++        await pub.publish_batch(operation="reconcile", stats={"users_created": 1})
++
++    async def test_publish_batch_swallows_exception(self):
++        redis = AsyncMock()
++        redis.publish.side_effect = ConnectionError("Redis gone")
++        pub = CacheInvalidationPublisher(redis_client=redis)
++
++        with patch("app.services.cache_invalidation.logger") as mock_logger:
++            await pub.publish_batch(operation="reconcile", stats={})
++
++        mock_logger.warning.assert_called_once()
++
++
++class TestSingletonLifecycle:
++    """Module-level singleton functions: init, get, shutdown."""
++
++    def setup_method(self):
++        shutdown_cache_publisher()
++
++    def teardown_method(self):
++        shutdown_cache_publisher()
++
++    def test_get_returns_noop_before_init(self):
++        pub = get_cache_publisher()
++        assert pub._redis is None
++
++    def test_init_and_get_returns_same_instance(self):
++        redis = AsyncMock()
++        created = init_cache_publisher(redis_client=redis)
++        retrieved = get_cache_publisher()
++        assert retrieved is created
++        assert retrieved._redis is redis
++
++    def test_shutdown_clears_singleton(self):
++        init_cache_publisher(redis_client=AsyncMock())
++        shutdown_cache_publisher()
++        pub = get_cache_publisher()
++        assert pub._redis is None
+diff --git a/backend/tests/unit/test_permission_service.py b/backend/tests/unit/test_permission_service.py
+index 4bd660a..3c788f2 100644
+--- a/backend/tests/unit/test_permission_service.py
++++ b/backend/tests/unit/test_permission_service.py
+@@ -16,6 +16,7 @@ from app.models.identity.role import Permission
+ from app.repositories.permission import PermissionRepository
+ from app.repositories.user import RepositoryConflictError
+ from app.services.adapters.base import IdentityProviderAdapter, SyncError
++from app.services.cache_invalidation import CacheInvalidationPublisher
+ from app.services.permission import PermissionService
+ 
+ 
+@@ -267,3 +268,50 @@ class TestDeletePermission:
+ 
+         assert result.is_ok()
+         mock_logger.warning.assert_called_once()
++
++
++@pytest.mark.anyio
++class TestCacheInvalidationPublishing:
++    """AC-3.3.1: PermissionService publishes cache invalidation events after commit."""
++
++    async def test_create_permission_publishes_event(self):
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        repo = AsyncMock(spec=PermissionRepository)
++        adapter = AsyncMock(spec=IdentityProviderAdapter)
++        service = PermissionService(repository=repo, adapter=adapter, publisher=publisher)
++        repo.get_by_name.return_value = None
++        perm = _make_permission()
++        repo.create.return_value = perm
++        adapter.sync_permission.return_value = Ok(None)
++
++        result = await service.create_permission(name=perm.name)
++
++        assert result.is_ok()
++        publisher.publish.assert_awaited_once_with(entity_type="permission", entity_id=perm.id, operation="create")
++
++    async def test_delete_permission_publishes_event(self):
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        repo = AsyncMock(spec=PermissionRepository)
++        adapter = AsyncMock(spec=IdentityProviderAdapter)
++        service = PermissionService(repository=repo, adapter=adapter, publisher=publisher)
++        perm = _make_permission()
++        repo.get.return_value = perm
++        repo.delete.return_value = True
++        adapter.delete_permission.return_value = Ok(None)
++
++        result = await service.delete_permission(permission_id=perm.id)
++
++        assert result.is_ok()
++        publisher.publish.assert_awaited_once_with(entity_type="permission", entity_id=perm.id, operation="delete")
++
++    async def test_no_publish_on_failure(self):
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        repo = AsyncMock(spec=PermissionRepository)
++        adapter = AsyncMock(spec=IdentityProviderAdapter)
++        service = PermissionService(repository=repo, adapter=adapter, publisher=publisher)
++        repo.get.return_value = None  # Permission not found
++
++        result = await service.delete_permission(permission_id=uuid.uuid4())
++
++        assert result.is_error()
++        publisher.publish.assert_not_awaited()
+diff --git a/backend/tests/unit/test_reconciliation_service.py b/backend/tests/unit/test_reconciliation_service.py
+index b7e7e93..2a62362 100644
+--- a/backend/tests/unit/test_reconciliation_service.py
++++ b/backend/tests/unit/test_reconciliation_service.py
+@@ -27,6 +27,7 @@ from app.repositories.provider import ProviderRepository
+ from app.repositories.role import RoleRepository
+ from app.repositories.tenant import TenantRepository
+ from app.repositories.user import RepositoryConflictError, UserRepository
++from app.services.cache_invalidation import CacheInvalidationPublisher
+ from app.services.descope import DescopeManagementClient
+ from app.services.reconciliation import ReconciliationService
+ 
+@@ -806,3 +807,63 @@ class TestReconcileUsers:
+         assert result.is_ok()
+         assert result.ok["stats"]["users_created"] == 2
+         assert result.ok["stats"]["links_created"] == 2
++
++
++@pytest.mark.anyio
++class TestCacheInvalidationPublishing:
++    """AC-3.3.1: ReconciliationService publishes batch event after successful run with changes."""
++
++    async def test_publish_batch_after_changes(self):
++        """Batch event published when reconciliation produces changes."""
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        service, mocks = _build_service()
++        service._publisher = publisher
++
++        _empty_canonical_state(mocks)
++        mocks["descope"].list_tenants.return_value = [{"name": "Acme", "selfProvisioningDomains": []}]
++        mocks["descope"].list_permissions.return_value = []
++        mocks["descope"].list_roles.return_value = []
++        mocks["descope"].search_all_users.return_value = []
++        mocks["tenant_repo"].get_by_name.return_value = None
++        tenant = _make_tenant(name="Acme")
++        mocks["tenant_repo"].create.return_value = tenant
++
++        result = await service.run()
++
++        assert result.is_ok()
++        publisher.publish_batch.assert_awaited_once()
++        call_kwargs = publisher.publish_batch.call_args[1]
++        assert call_kwargs["operation"] == "reconcile"
++        assert call_kwargs["stats"]["tenants_created"] == 1
++
++    async def test_no_publish_when_zero_changes(self):
++        """No batch event when reconciliation finds no drift."""
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        service, mocks = _build_service()
++        service._publisher = publisher
++
++        _empty_descope_state(mocks)
++        _empty_canonical_state(mocks)
++
++        result = await service.run()
++
++        assert result.is_ok()
++        publisher.publish_batch.assert_not_awaited()
++
++    async def test_no_publish_on_commit_failure(self):
++        """Publisher not called when commit fails."""
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        service, mocks = _build_service()
++        service._publisher = publisher
++
++        _empty_descope_state(mocks)
++        _empty_canonical_state(mocks)
++        mocks["descope"].list_tenants.return_value = [{"name": "Acme", "selfProvisioningDomains": []}]
++        mocks["tenant_repo"].get_by_name.return_value = None
++        mocks["tenant_repo"].create.return_value = _make_tenant(name="Acme")
++        mocks["session"].commit.side_effect = RuntimeError("db gone")
++
++        result = await service.run()
++
++        assert result.is_error()
++        publisher.publish_batch.assert_not_awaited()
+diff --git a/backend/tests/unit/test_role_service.py b/backend/tests/unit/test_role_service.py
+index 1370f5b..4471223 100644
+--- a/backend/tests/unit/test_role_service.py
++++ b/backend/tests/unit/test_role_service.py
+@@ -21,6 +21,7 @@ from app.repositories.permission import PermissionRepository
+ from app.repositories.role import RoleRepository
+ from app.repositories.user import RepositoryConflictError
+ from app.services.adapters.base import IdentityProviderAdapter, SyncError
++from app.services.cache_invalidation import CacheInvalidationPublisher
+ from app.services.role import RoleService
+ 
+ TENANT_ID = uuid.uuid4()
+@@ -600,3 +601,78 @@ class TestUnassignRoleFromUser:
+         assert result.is_ok()
+         assign_repo.commit.assert_awaited_once()
+         mock_logger.warning.assert_called_once()
++
++
++@pytest.mark.anyio
++class TestCacheInvalidationPublishing:
++    """AC-3.3.1: RoleService publishes cache invalidation events after commit."""
++
++    async def test_create_role_publishes_event(self):
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        repo = AsyncMock(spec=RoleRepository)
++        perm_repo = AsyncMock(spec=PermissionRepository)
++        assign_repo = AsyncMock(spec=UserTenantRoleRepository)
++        adapter = AsyncMock(spec=IdentityProviderAdapter)
++        service = RoleService(
++            repository=repo,
++            permission_repository=perm_repo,
++            assignment_repository=assign_repo,
++            adapter=adapter,
++            publisher=publisher,
++        )
++        repo.get_by_name.return_value = None
++        role = _make_role(tenant_id=TENANT_ID)
++        repo.create.return_value = role
++        adapter.sync_role.return_value = Ok(None)
++
++        result = await service.create_role(name=role.name, tenant_id=TENANT_ID)
++
++        assert result.is_ok()
++        publisher.publish.assert_awaited_once_with(
++            entity_type="role", entity_id=role.id, operation="create", tenant_id=TENANT_ID
++        )
++
++    async def test_delete_role_publishes_event(self):
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        repo = AsyncMock(spec=RoleRepository)
++        perm_repo = AsyncMock(spec=PermissionRepository)
++        assign_repo = AsyncMock(spec=UserTenantRoleRepository)
++        adapter = AsyncMock(spec=IdentityProviderAdapter)
++        service = RoleService(
++            repository=repo,
++            permission_repository=perm_repo,
++            assignment_repository=assign_repo,
++            adapter=adapter,
++            publisher=publisher,
++        )
++        role = _make_role(tenant_id=TENANT_ID)
++        repo.get.return_value = role
++        repo.delete.return_value = True
++        adapter.delete_role.return_value = Ok(None)
++
++        result = await service.delete_role(role_id=role.id)
++
++        assert result.is_ok()
++        publisher.publish.assert_awaited_once_with(
++            entity_type="role", entity_id=role.id, operation="delete", tenant_id=TENANT_ID
++        )
++
++    async def test_no_publish_on_failure(self):
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        repo = AsyncMock(spec=RoleRepository)
++        perm_repo = AsyncMock(spec=PermissionRepository)
++        assign_repo = AsyncMock(spec=UserTenantRoleRepository)
++        adapter = AsyncMock(spec=IdentityProviderAdapter)
++        service = RoleService(
++            repository=repo,
++            permission_repository=perm_repo,
++            assignment_repository=assign_repo,
++            adapter=adapter,
++            publisher=publisher,
++        )
++        repo.get.return_value = None  # Role not found
++
++        result = await service.delete_role(role_id=uuid.uuid4())
++
++        assert result.is_error()
++        publisher.publish.assert_not_awaited()
+diff --git a/backend/tests/unit/test_tenant_service.py b/backend/tests/unit/test_tenant_service.py
+index 7b8474b..5421e6a 100644
+--- a/backend/tests/unit/test_tenant_service.py
++++ b/backend/tests/unit/test_tenant_service.py
+@@ -17,6 +17,7 @@ from app.models.identity.tenant import Tenant
+ from app.repositories.tenant import TenantRepository
+ from app.repositories.user import RepositoryConflictError
+ from app.services.adapters.base import IdentityProviderAdapter, SyncError
++from app.services.cache_invalidation import CacheInvalidationPublisher
+ from app.services.tenant import TenantService
+ 
+ 
+@@ -230,3 +231,35 @@ class TestGetTenantUsersWithRoles:
+ 
+         assert result.is_ok()
+         assert result.ok == []
++
++
++@pytest.mark.anyio
++class TestCacheInvalidationPublishing:
++    """AC-3.3.1: TenantService publishes cache invalidation events after commit."""
++
++    async def test_create_tenant_publishes_event(self):
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        repo = AsyncMock(spec=TenantRepository)
++        adapter = AsyncMock(spec=IdentityProviderAdapter)
++        service = TenantService(repository=repo, adapter=adapter, publisher=publisher)
++        repo.get_by_name.return_value = None
++        tenant = _make_tenant()
++        repo.create.return_value = tenant
++        adapter.sync_tenant.return_value = Ok(None)
++
++        result = await service.create_tenant(name=tenant.name, domains=tenant.domains)
++
++        assert result.is_ok()
++        publisher.publish.assert_awaited_once_with(entity_type="tenant", entity_id=tenant.id, operation="create")
++
++    async def test_no_publish_on_failure(self):
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        repo = AsyncMock(spec=TenantRepository)
++        adapter = AsyncMock(spec=IdentityProviderAdapter)
++        service = TenantService(repository=repo, adapter=adapter, publisher=publisher)
++        repo.get_by_name.return_value = _make_tenant()  # Duplicate
++
++        result = await service.create_tenant(name="Acme Corp")
++
++        assert result.is_error()
++        publisher.publish.assert_not_awaited()
+diff --git a/backend/tests/unit/test_user_service.py b/backend/tests/unit/test_user_service.py
+index 83c7701..3161288 100644
+--- a/backend/tests/unit/test_user_service.py
++++ b/backend/tests/unit/test_user_service.py
+@@ -19,6 +19,7 @@ from app.models.identity.user import User, UserStatus
+ from app.repositories.assignment import UserTenantRoleRepository
+ from app.repositories.user import RepositoryConflictError, UserRepository
+ from app.services.adapters.base import IdentityProviderAdapter, SyncError
++from app.services.cache_invalidation import CacheInvalidationPublisher
+ from app.services.user import UserService
+ 
+ TENANT_ID = uuid.uuid4()
+@@ -471,3 +472,61 @@ class TestRemoveUserFromTenant:
+         assert result.is_ok()
+         assign_repo.commit.assert_awaited_once()
+         mock_logger.warning.assert_called_once()
++
++
++@pytest.mark.anyio
++class TestCacheInvalidationPublishing:
++    """AC-3.3.1: UserService publishes cache invalidation events after commit."""
++
++    async def test_create_user_publishes_event(self):
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        repo = AsyncMock(spec=UserRepository)
++        adapter = AsyncMock(spec=IdentityProviderAdapter)
++        assign_repo = AsyncMock(spec=UserTenantRoleRepository)
++        repo.exists_in_tenant.return_value = True
++        service = UserService(repository=repo, adapter=adapter, assignment_repository=assign_repo, publisher=publisher)
++        repo.get_by_email.return_value = None
++        user = _make_user()
++        repo.create.return_value = user
++        adapter.sync_user.return_value = Ok(None)
++
++        result = await service.create_user(tenant_id=TENANT_ID, email=user.email, user_name=user.user_name)
++
++        assert result.is_ok()
++        publisher.publish.assert_awaited_once_with(
++            entity_type="user", entity_id=user.id, operation="create", tenant_id=TENANT_ID
++        )
++
++    async def test_deactivate_user_publishes_event(self):
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        repo = AsyncMock(spec=UserRepository)
++        adapter = AsyncMock(spec=IdentityProviderAdapter)
++        assign_repo = AsyncMock(spec=UserTenantRoleRepository)
++        repo.exists_in_tenant.return_value = True
++        service = UserService(repository=repo, adapter=adapter, assignment_repository=assign_repo, publisher=publisher)
++        user = _make_user()
++        repo.get.return_value = user
++        repo.update.return_value = user
++        adapter.sync_user.return_value = Ok(None)
++
++        result = await service.deactivate_user(tenant_id=TENANT_ID, user_id=user.id)
++
++        assert result.is_ok()
++        publisher.publish.assert_awaited_once_with(
++            entity_type="user", entity_id=user.id, operation="deactivate", tenant_id=TENANT_ID
++        )
++
++    async def test_no_publish_on_failure(self):
++        """Publisher is NOT called when the operation fails (e.g. not found)."""
++        publisher = AsyncMock(spec=CacheInvalidationPublisher)
++        repo = AsyncMock(spec=UserRepository)
++        adapter = AsyncMock(spec=IdentityProviderAdapter)
++        assign_repo = AsyncMock(spec=UserTenantRoleRepository)
++        repo.exists_in_tenant.return_value = True
++        service = UserService(repository=repo, adapter=adapter, assignment_repository=assign_repo, publisher=publisher)
++        repo.get.return_value = None  # User not found
++
++        result = await service.deactivate_user(tenant_id=TENANT_ID, user_id=uuid.uuid4())
++
++        assert result.is_error()
++        publisher.publish.assert_not_awaited()
+diff --git a/backend/uv.lock b/backend/uv.lock
+index d7803c2..c525696 100644
+--- a/backend/uv.lock
++++ b/backend/uv.lock
+@@ -588,6 +588,66 @@ wheels = [
+     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+ ]
+ 
++[[package]]
++name = "hiredis"
++version = "3.3.1"
++source = { registry = "https://pypi.org/simple" }
++sdist = { url = "https://files.pythonhosted.org/packages/97/d6/9bef6dc3052c168c93fbf7e6c0f2b12c45f0f741a2d30fd919096774343a/hiredis-3.3.1.tar.gz", hash = "sha256:da6f0302360e99d32bc2869772692797ebadd536e1b826d0103c72ba49d38698", size = 89101, upload-time = "2026-03-16T15:21:08.092Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/b3/1d/1a7d925d886211948ab9cca44221b1d9dd4d3481d015511e98794e37d369/hiredis-3.3.1-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:60543f3b068b16a86e99ed96b7fdae71cdc1d8abdfe9b3f82032a555e52ece7e", size = 82023, upload-time = "2026-03-16T15:19:34.157Z" },
++    { url = "https://files.pythonhosted.org/packages/13/2f/a6017fe1db47cd63a4aefc0dd21dd4dcb0c4e857bfbcfaa27329745f24a3/hiredis-3.3.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:2611bfaaadc5e8d43fb7967f9bbf1110c8beaa83aee2f2d812c76f11cfb56c6a", size = 46215, upload-time = "2026-03-16T15:19:35.068Z" },
++    { url = "https://files.pythonhosted.org/packages/77/4b/35a71d088c6934e162aa81c7e289fa3110a3aca84ab695d88dbd488c74a2/hiredis-3.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8e3754ce60e1b11b0afad9a053481ff184d2ee24bea47099107156d1b84a84aa", size = 41861, upload-time = "2026-03-16T15:19:36.32Z" },
++    { url = "https://files.pythonhosted.org/packages/1f/54/904bc723a95926977764fefd6f0d46067579bac38fffc32b806f3f2c05c0/hiredis-3.3.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e89dabf436ee79b358fd970dcbed6333a36d91db73f27069ca24a02fb138a404", size = 170196, upload-time = "2026-03-16T15:19:37.274Z" },
++    { url = "https://files.pythonhosted.org/packages/1d/01/4e840cd4cb53c28578234708b08fb9ec9e41c2880acc0e269a7264e1b3af/hiredis-3.3.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4f7e242eab698ad0be5a4b2ec616fa856569c57455cc67c625fd567726290e5f", size = 181808, upload-time = "2026-03-16T15:19:38.637Z" },
++    { url = "https://files.pythonhosted.org/packages/87/0d/fc845f06f8203ab76c401d4d2b97f9fb768e644b053a40f441f7dcc71f2d/hiredis-3.3.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53148a4e21057541b6d8e493b2ea1b500037ddf34433c391970036f3cbce00e3", size = 180577, upload-time = "2026-03-16T15:19:39.749Z" },
++    { url = "https://files.pythonhosted.org/packages/52/3a/859afe2620666bf6d58eb977870c47d98af4999d473b50528b323918f3f7/hiredis-3.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25132902d3eff38781e0d54f27a0942ec849e3c07dbdce83c4d92b7e43c8dce", size = 172507, upload-time = "2026-03-16T15:19:40.87Z" },
++    { url = "https://files.pythonhosted.org/packages/60/a8/004349708ad8bf0d188d46049f846d3fe2d4a7a8d0d5a6a8ba024017d8b3/hiredis-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3fb6573efa15a29c12c0c0f7170b14e7c1347fe4bb39b6a15b779f46015cc929", size = 166339, upload-time = "2026-03-16T15:19:41.912Z" },
++    { url = "https://files.pythonhosted.org/packages/c3/fb/bfc6df29381830c99bfd9e97ed3b6d75d9303866a28c23d51ab8c50f63e3/hiredis-3.3.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:487658e1db83c1ee9fbbac6a43039ea76957767a5987ffb16b590613f9e68297", size = 176766, upload-time = "2026-03-16T15:19:42.981Z" },
++    { url = "https://files.pythonhosted.org/packages/53/e7/f54aaad4559a413ec8b1043a89567a5a1f898426e4091b9af5e0f2120371/hiredis-3.3.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:a1d190790ee39b8b7adeeb10fc4090dc4859eb4e75ed27bd8108710eef18f358", size = 170313, upload-time = "2026-03-16T15:19:44.082Z" },
++    { url = "https://files.pythonhosted.org/packages/60/51/b80394db4c74d4cba342fa4208f690a2739c16f1125c2a62ba1701b8e2b7/hiredis-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a42c7becd4c9ec4ab5769c754eb61112777bdc6e1c1525e2077389e193b5f5aa", size = 167964, upload-time = "2026-03-16T15:19:45.237Z" },
++    { url = "https://files.pythonhosted.org/packages/47/ef/5e438d1e058be57cdc1bafc1b1ec8ab43cc890c61447e88f8b878a0e32c3/hiredis-3.3.1-cp312-cp312-win32.whl", hash = "sha256:17ec8b524055a88b80d76c177dbbbe475a25c17c5bf4b67bdbdbd0629bcae838", size = 20532, upload-time = "2026-03-16T15:19:46.233Z" },
++    { url = "https://files.pythonhosted.org/packages/e9/c6/39994b9c5646e7bf7d5e92170c07fd5f224ae9f34d95ff202f31845eb94b/hiredis-3.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:0fac4af8515e6cca74fc701169ae4dc9a71a90e9319c9d21006ec9454b43aa2f", size = 22381, upload-time = "2026-03-16T15:19:47.082Z" },
++    { url = "https://files.pythonhosted.org/packages/d8/4b/c7f4d6d6643622f296395269e24b02c69d4ac72822f052b8cae16fa3af03/hiredis-3.3.1-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:afe3c3863f16704fb5d7c2c6ff56aaf9e054f6d269f7b4c9074c5476178d1aba", size = 82027, upload-time = "2026-03-16T15:19:48.002Z" },
++    { url = "https://files.pythonhosted.org/packages/9b/45/198be960a7443d6eb5045751e929480929c0defbca316ce1a47d15187330/hiredis-3.3.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:f19ee7dc1ef8a6497570d91fa4057ba910ad98297a50b8c44ff37589f7c89d17", size = 46220, upload-time = "2026-03-16T15:19:48.953Z" },
++    { url = "https://files.pythonhosted.org/packages/6a/a4/6ab925177f289830008dbe1488a9858675e2e234f48c9c1653bd4d0eaddc/hiredis-3.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09f5e510f637f2c72d2a79fb3ad05f7b6211e057e367ca5c4f97bb3d8c9d71f4", size = 41858, upload-time = "2026-03-16T15:19:49.939Z" },
++    { url = "https://files.pythonhosted.org/packages/fe/c8/a0ddbb9e9c27fcb0022f7b7e93abc75727cb634c6a5273ca5171033dac78/hiredis-3.3.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b46e96b50dad03495447860510daebd2c96fd44ed25ba8ccb03e9f89eaa9d34", size = 170095, upload-time = "2026-03-16T15:19:51.216Z" },
++    { url = "https://files.pythonhosted.org/packages/94/06/618d509cc454912028f71995f3dd6eb54606f0aa8163ff79c5b7ec1f2bda/hiredis-3.3.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b4fe7f38aa8956fcc1cea270e62601e0e11066aff78e384be70fd283d30293b6", size = 181745, upload-time = "2026-03-16T15:19:52.72Z" },
++    { url = "https://files.pythonhosted.org/packages/06/14/75b2deb62a61fc75a41ce1a6a781fe239133bbc88fef404d32a148ad152a/hiredis-3.3.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2b96da7e365d6488d2a75266a662cbe3cc14b28c23dd9b0c9aa04b5bc5c20192", size = 180465, upload-time = "2026-03-16T15:19:53.847Z" },
++    { url = "https://files.pythonhosted.org/packages/7e/8c/8e03dcbfde8e2ca3f880fce06ad0877b3f098ed5fdfb17cf3b821a32323a/hiredis-3.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:52d5641027d6731bc7b5e7d126a5158a99784a9f8c6de3d97ca89aca4969e9f8", size = 172419, upload-time = "2026-03-16T15:19:54.959Z" },
++    { url = "https://files.pythonhosted.org/packages/03/05/843005d68403a3805309075efc6638360a3ababa6cb4545163bf80c8e7f7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eddeb9a153795cf6e615f9f3cef66a1d573ff3b6ee16df2b10d1d1c2f2baeaa8", size = 166398, upload-time = "2026-03-16T15:19:56.36Z" },
++    { url = "https://files.pythonhosted.org/packages/f5/23/abe2476244fd792f5108009ec0ae666eaa5b2165ca19f2e86638d8324ac9/hiredis-3.3.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:011a9071c3df4885cac7f58a2623feac6c8e2ad30e6ba93c55195af05ce61ff5", size = 176844, upload-time = "2026-03-16T15:19:57.462Z" },
++    { url = "https://files.pythonhosted.org/packages/c6/47/e1cdccc559b98e548bcff0868c3938d375663418c0adca465895ee1f72e7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:264ee7e9cb6c30dc78da4ecf71d74cf14ca122817c665d838eda8b4384bce1b0", size = 170366, upload-time = "2026-03-16T15:19:58.548Z" },
++    { url = "https://files.pythonhosted.org/packages/a2/e1/fda8325f51d06877e8e92500b15d4aff3855b4c3c91dbd9636a82e4591f2/hiredis-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d1434d0bcc1b3ef048bae53f26456405c08aeed9827e65b24094f5f3a6793f1", size = 168023, upload-time = "2026-03-16T15:19:59.727Z" },
++    { url = "https://files.pythonhosted.org/packages/cd/21/2839d1625095989c116470e2b6841bbe1a2a5509585e82a4f3f5cd47f511/hiredis-3.3.1-cp313-cp313-win32.whl", hash = "sha256:f915a34fb742e23d0d61573349aa45d6f74037fde9d58a9f340435eff8d62736", size = 20535, upload-time = "2026-03-16T15:20:00.938Z" },
++    { url = "https://files.pythonhosted.org/packages/84/f9/534c2a89b24445a9a9623beb4697fd72b8c8f16286f6f3bda012c7af004a/hiredis-3.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:d8e56e0d1fe607bfff422633f313aec9191c3859ab99d11ff097e3e6e068000c", size = 22383, upload-time = "2026-03-16T15:20:01.865Z" },
++    { url = "https://files.pythonhosted.org/packages/03/72/0450d6b449da58120c5497346eb707738f8f67b9e60c28a8ef90133fc81f/hiredis-3.3.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:439f9a5cc8f9519ce208a24cdebfa0440fef26aa682a40ba2c92acb10a53f5e0", size = 82112, upload-time = "2026-03-16T15:20:02.865Z" },
++    { url = "https://files.pythonhosted.org/packages/22/c0/0be33a29bcd463e6cbb0282515dd4d0cdfe33c30c7afc6d4d8c460e23266/hiredis-3.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3724f0e58c6ff76fd683429945491de71324ab1bc0ad943a8d68cb0932d24075", size = 46238, upload-time = "2026-03-16T15:20:03.896Z" },
++    { url = "https://files.pythonhosted.org/packages/62/f2/f999854bfaf3bcbee0f797f24706c182ecfaca825f6a582f6281a6aa97e0/hiredis-3.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29fe35e3c6fe03204e75c86514f452591957a1e06b05d86e10d795455b71c355", size = 41891, upload-time = "2026-03-16T15:20:04.939Z" },
++    { url = "https://files.pythonhosted.org/packages/f2/c8/cd9ab90fec3a301d864d8ab6167aea387add8e2287969d89cbcd45d6b0e0/hiredis-3.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d42f3a13290f89191568fc113d95a3d2c8759cdd8c3672f021d8b7436f909e75", size = 170485, upload-time = "2026-03-16T15:20:06.284Z" },
++    { url = "https://files.pythonhosted.org/packages/ac/9a/1ddf9ea236a292963146cbaf6722abeb9d503ca47d821267bb8b3b81c4f7/hiredis-3.3.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2afc675b831f7552da41116fffffca4340f387dc03f56d6ec0c7895ab0b59a10", size = 182030, upload-time = "2026-03-16T15:20:07.857Z" },
++    { url = "https://files.pythonhosted.org/packages/d4/b8/e070a1dbf8a1bbb8814baa0b00836fbe3f10c7af8e11f942cc739c64e062/hiredis-3.3.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4106201cd052d9eabe3cb7b5a24b0fe37307792bda4fcb3cf6ddd72f697828e8", size = 180543, upload-time = "2026-03-16T15:20:09.096Z" },
++    { url = "https://files.pythonhosted.org/packages/0d/bb/b5f4f98e44626e2446cd8a52ce6cb1fc1c99786b6e2db3bf09cea97b90cd/hiredis-3.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8887bf0f31e4b550bd988c8863b527b6587d200653e9375cd91eea2b944b7424", size = 172356, upload-time = "2026-03-16T15:20:10.245Z" },
++    { url = "https://files.pythonhosted.org/packages/ef/93/73a77b54ba94e82f76d02563c588d8a062513062675f483a033a43015f2c/hiredis-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ac7697365dbe45109273b34227fee6826b276ead9a4a007e0877e1d3f0fcf21", size = 166433, upload-time = "2026-03-16T15:20:11.789Z" },
++    { url = "https://files.pythonhosted.org/packages/f3/c2/1b2dcbe5dc53a46a8cb05bed67d190a7e30bad2ad1f727ebe154dfeededd/hiredis-3.3.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2b6da6e07359107c653a809b3cff2d9ccaeedbafe33c6f16434aef6f53ce4a2b", size = 177220, upload-time = "2026-03-16T15:20:12.991Z" },
++    { url = "https://files.pythonhosted.org/packages/02/09/f4314cf096552568b5ea785ceb60c424771f4d35a76c410ad39d258f74bc/hiredis-3.3.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:ce334915f5d31048f76a42c607bf26687cf045eb1bc852b7340f09729c6a64fc", size = 170475, upload-time = "2026-03-16T15:20:14.519Z" },
++    { url = "https://files.pythonhosted.org/packages/b1/2e/3f56e438efc8fc27ed4a3dbad58c0280061466473ec35d8f86c90c841a84/hiredis-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ee11fd431f83d8a5b29d370b9d79a814d3218d30113bdcd44657e9bdf715fc92", size = 167913, upload-time = "2026-03-16T15:20:15.672Z" },
++    { url = "https://files.pythonhosted.org/packages/56/34/053e5ee91d6dc478faac661996d1fd4886c5acb7a1b5ac30e7d3c794bb51/hiredis-3.3.1-cp314-cp314-win32.whl", hash = "sha256:e0356561b4a97c83b9ee3de657a41b8d1a1781226853adaf47b550bb988fda6f", size = 21167, upload-time = "2026-03-16T15:20:17.013Z" },
++    { url = "https://files.pythonhosted.org/packages/ea/33/06776c641d17881a9031e337e81b3b934c38c2adbb83c85062d6b5f83b72/hiredis-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:80aba5f85d6227faee628ae28d1c3b69c661806a0636548ac56c68782606454f", size = 23000, upload-time = "2026-03-16T15:20:17.966Z" },
++    { url = "https://files.pythonhosted.org/packages/dd/5a/94f9a505b2ff5376d4a05fb279b69d89bafa7219dd33f6944026e3e56f80/hiredis-3.3.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:907f7b5501a534030738f0f27459a612d2266fd0507b007bb8f3e6de08167920", size = 83039, upload-time = "2026-03-16T15:20:19.316Z" },
++    { url = "https://files.pythonhosted.org/packages/93/ae/d3752a8f03a1fca43d402389d2a2d234d3db54c4d1f07f26c1041ca3c5de/hiredis-3.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:de94b409f49eb6a588ebdd5872e826caec417cd77c17af0fb94f2128427f1a2a", size = 46703, upload-time = "2026-03-16T15:20:20.401Z" },
++    { url = "https://files.pythonhosted.org/packages/9f/76/e32c868a2fa23cd82bacaffd38649d938173244a0e717ec1c0c76874dbdd/hiredis-3.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79cd03e7ff550c17758a7520bf437c156d3d4c8bb74214deeafa69cda49c85a4", size = 42379, upload-time = "2026-03-16T15:20:21.705Z" },
++    { url = "https://files.pythonhosted.org/packages/c9/f6/d687d36a74ce6cf448826cf2e8edfc1eb37cc965308f74eb696aa97c69df/hiredis-3.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ffa7ba2e2da1f806f3181b9730b3e87ba9dbfec884806725d4584055ba3faa6", size = 180311, upload-time = "2026-03-16T15:20:23.037Z" },
++    { url = "https://files.pythonhosted.org/packages/db/ac/f520dc0066a62a15aa920c7dd0a2028c213f4862d5f901409ae92ee5d785/hiredis-3.3.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ee37fe8cf081b72dea72f96a0ee604f492ec02252eb77dc26ff6eec3f997b580", size = 190488, upload-time = "2026-03-16T15:20:24.357Z" },
++    { url = "https://files.pythonhosted.org/packages/4d/f5/ae10fff82d0f291e90c41bf10a5d6543a96aae00cccede01bf2b6f7e178d/hiredis-3.3.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9bfdeff778d3f7ff449ca5922ab773899e7d31e26a576028b06a5e9cf0ed8c34", size = 189210, upload-time = "2026-03-16T15:20:25.51Z" },
++    { url = "https://files.pythonhosted.org/packages/0f/8f/5be4344e542aa8d349a03d05486c59d9ca26f69c749d11e114bf34b84d50/hiredis-3.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:027ce4fabfeff5af5b9869d5524770877f9061d118bc36b85703ae3faf5aad8e", size = 180971, upload-time = "2026-03-16T15:20:26.631Z" },
++    { url = "https://files.pythonhosted.org/packages/41/a2/29e230226ec2a31f13f8a832fbafe366e263f3b090553ebe49bb4581a7bd/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dcea8c3f53674ae68e44b12e853b844a1d315250ca6677b11ec0c06aff85e86c", size = 175314, upload-time = "2026-03-16T15:20:27.848Z" },
++    { url = "https://files.pythonhosted.org/packages/89/2e/bf241707ad86b9f3ebfbc7ab89e19d5ec243ff92ca77644a383622e8740b/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0b5ff2f643f4b452b0597b7fe6aa35d398cb31d8806801acfafb1558610ea2aa", size = 185652, upload-time = "2026-03-16T15:20:29.364Z" },
++    { url = "https://files.pythonhosted.org/packages/d0/c1/b39170d8bcccd01febd45af4ac6b43ff38e134a868e2ec167a82a036fb35/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3586c8a5f56d34b9dddaaa9e76905f31933cac267251006adf86ec0eef7d0400", size = 179033, upload-time = "2026-03-16T15:20:30.549Z" },
++    { url = "https://files.pythonhosted.org/packages/b7/3a/4fe39a169115434f911abff08ff485b9b6201c168500e112b3f6a8110c0a/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a110d19881ca78a88583d3b07231e7c6864864f5f1f3491b638863ea45fa8708", size = 176126, upload-time = "2026-03-16T15:20:31.958Z" },
++    { url = "https://files.pythonhosted.org/packages/44/99/c1d0b0bc4f9e9150e24beb0dca2e186e32d5e749d0022e0d26453749ed51/hiredis-3.3.1-cp314-cp314t-win32.whl", hash = "sha256:98fd5b39410e9d69e10e90d0330e35650becaa5dd2548f509b9598f1f3c6124d", size = 22028, upload-time = "2026-03-16T15:20:33.33Z" },
++    { url = "https://files.pythonhosted.org/packages/35/d6/191e6741addc97bcf5e755661f8c82f0fd0aa35f07ece56e858da689b57e/hiredis-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ab1f646ff531d70bfd25f01e60708dfa3d105eb458b7dedd9fe9a443039fd809", size = 23811, upload-time = "2026-03-16T15:20:34.292Z" },
++]
++
+ [[package]]
+ name = "httpcore"
+ version = "1.0.9"
+@@ -664,6 +724,7 @@ dependencies = [
+     { name = "py-identity-model" },
+     { name = "pydantic", extra = ["email"] },
+     { name = "python-json-logger" },
++    { name = "redis", extra = ["hiredis"] },
+     { name = "scalar-fastapi" },
+     { name = "slowapi" },
+     { name = "sqlalchemy", extra = ["asyncio"] },
+@@ -715,6 +776,7 @@ requires-dist = [
+     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+     { name = "python-json-logger", specifier = ">=3.2,<5" },
++    { name = "redis", extras = ["hiredis"], specifier = ">=5.0,<6" },
+     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
+     { name = "scalar-fastapi", specifier = ">=1.0.0" },
+     { name = "slowapi", specifier = ">=0.1.9,<1" },
+@@ -1568,6 +1630,23 @@ wheels = [
+     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+ ]
+ 
++[[package]]
++name = "redis"
++version = "5.3.1"
++source = { registry = "https://pypi.org/simple" }
++dependencies = [
++    { name = "pyjwt" },
++]
++sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
++wheels = [
++    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
++]
++
++[package.optional-dependencies]
++hiredis = [
++    { name = "hiredis" },
++]
++
+ [[package]]
+ name = "requests"
+ version = "2.33.0"

--- a/.claude/review-edge.md
+++ b/.claude/review-edge.md
@@ -1,0 +1,14 @@
+## Review: Edge Case Hunter
+
+### Findings
+
+| Location | Trigger Condition | Guard Snippet | Consequence |
+|----------|-------------------|---------------|-------------|
+| `backend/app/services/inbound_sync.py:306` | `_handle_user_deleted` webhook deactivates the user but publishes `operation="sync"` instead of `"deactivate"`; the documented schema lists `"deactivate"` as a distinct operation | Change to `operation="deactivate"` | [WRONG] Downstream cache consumers dispatching on operation type see a sync event, not a deactivation; deactivated users may not be invalidated correctly |
+| `backend/app/main.py:87-89` | `shutdown_cache_publisher()` and `redis_client.aclose()` share one `try` block; if `shutdown_cache_publisher()` raises before `aclose()` is reached, the Redis connection is never closed | Split into two sequential `try/finally` blocks so `aclose()` always runs | [DEGRADED] Redis connection leaks on shutdown if `shutdown_cache_publisher` raises (currently cannot raise, but is a structural fragility) |
+| `backend/app/services/cache_invalidation.py:114-122` | `get_cache_publisher()` called before `init_cache_publisher()` (e.g., after `shutdown_cache_publisher()` sets `_publisher=None` mid-flight) returns a fresh throwaway no-op instance per call rather than the singleton | Assign the fallback to `_publisher`, or document that only the lifespan path is supported | [DEGRADED] Each pre-init call returns a distinct throwaway object; services injected at DI time hold a different no-op instance than any future call; behaviorally safe but identity is inconsistent and can mask misconfiguration in tests |
+
+### Summary
+- Unhandled paths found: 3
+- Critical (crash/data loss): 0
+- Non-critical (wrong result/degraded): 3

--- a/.claude/review-redteam.md
+++ b/.claude/review-redteam.md
@@ -1,0 +1,86 @@
+## Review: Red Team (Viper)
+
+### Attack Surface
+
+1. **POST /api/internal/users/sync** -- New endpoint for Descope Flow HTTP Connector user synchronisation. Accepts `user_id`, `email`, `name`, `given_name`, `family_name`. Protected by shared secret (`X-Flow-Secret` header validated against `DESCOPE_FLOW_SYNC_SECRET` via `verify_flow_sync_secret` dependency at `internal.py:98`). JWT auth bypassed via `excluded_prefixes`. Rate-limited at `RATE_LIMIT_AUTH` (default 10/minute).
+2. **POST /api/internal/webhooks/descope** -- New endpoint for Descope audit webhook events. Accepts `event_type` and arbitrary `data` dict. Protected by HMAC-SHA256 (`X-Descope-Webhook-S256` header validated against `DESCOPE_WEBHOOK_SECRET`). JWT auth bypassed. Rate-limited at `RATE_LIMIT_AUTH`.
+3. **JWT bypass via excluded_prefixes** -- Entire `/api/internal/` prefix excluded from `TokenValidationMiddleware` in `factory.py:74-76`. Any future endpoint registered under this prefix automatically inherits the bypass.
+4. **Shared secret authentication on flow sync** -- `verify_flow_sync_secret` dependency at `internal.py:56-69` performs timing-safe comparison of `X-Flow-Secret` header against `_FLOW_SYNC_SECRET` module-level variable.
+5. **HMAC-SHA256 authentication on webhook** -- `verify_hmac_signature` dependency at `internal.py:75-92` computes HMAC over raw request body and compares against `X-Descope-Webhook-S256` header.
+6. **InboundSyncService** -- New service layer at `inbound_sync.py` that creates/updates User records and IdPLink records in Postgres based on external input.
+7. **IdPLinkRepository** -- New repository at `idp_link.py` for IdP link CRUD, with unique constraints on `(provider_id, external_sub)` and `(user_id, provider_id)`.
+8. **ProviderRepository** -- New repository at `provider.py` for provider lookup by type/name.
+9. **Startup secret validation** -- `_warn_missing_secrets()` in `main.py:35-42` logs warnings at startup when `DESCOPE_WEBHOOK_SECRET` or `DESCOPE_FLOW_SYNC_SECRET` are not set. Both endpoints fail closed (401) when secrets are missing.
+
+### Findings
+
+#### MEDIUM -- Unbounded string length on user_id and name fields enables storage abuse
+
+- **Location**: `backend/app/routers/internal.py:39-43` (`FlowSyncRequest` model), `backend/app/models/identity/user.py:69` (`external_sub` column), `backend/app/models/identity/user.py:30-31` (`given_name`/`family_name` columns)
+- **Attack scenario**:
+  1. Attacker obtains the `DESCOPE_FLOW_SYNC_SECRET` shared secret (e.g., leaked in logs, config repo, or insider threat).
+  2. Attacker sends POST to `/api/internal/users/sync` with `user_id` set to a multi-megabyte string and valid `X-Flow-Secret` header.
+  3. `FlowSyncRequest.user_id` is typed as `str` with no `max_length` constraint. The value flows through to `IdPLink.external_sub` which is `sa.Column(sa.String, nullable=False)` -- unbounded VARCHAR.
+  4. Similarly, `name`, `given_name`, `family_name` have no length limits and are stored in unbounded `sa.String` columns.
+  5. Repeated requests (up to 10/minute per IP due to rate limiting) with large payloads bloat the database.
+- **Prerequisites**: Knowledge of `DESCOPE_FLOW_SYNC_SECRET`. Rate limiting (10/min) constrains throughput.
+- **CVSS v3.1**: 4.3 (AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L)
+- **Remediation**: Add `max_length` constraints to `FlowSyncRequest` fields: `user_id: str = Field(max_length=255)`, `name: str | None = Field(default=None, max_length=512)`, `given_name: str | None = Field(default=None, max_length=255)`, `family_name: str | None = Field(default=None, max_length=255)`. Also add `String(255)` or similar length to the SQLAlchemy column definitions for `external_sub`, `given_name`, `family_name` in the ORM models.
+
+#### MEDIUM -- WebhookPayload.data typed as unvalidated dict accepts arbitrary nested structures
+
+- **Location**: `backend/app/routers/internal.py:49-50` (`WebhookPayload` model), `backend/app/services/inbound_sync.py:186-289` (webhook handlers)
+- **Attack scenario**:
+  1. Attacker compromises the HMAC webhook secret.
+  2. The `data` field accepts any JSON object with no schema validation per event type.
+  3. In `_handle_user_updated` (line 223-236), `data.get("email")` could return a non-string type (e.g., a list or dict). This value is assigned directly to `user.email` at line 225. Depending on SQLAlchemy's type coercion for the `sa.String` column, this could raise an unhandled exception (500 error) or store a stringified representation.
+  4. `data.get("name")` could return a non-string. When passed to `name.split(" ", 1)` at line 234, a non-string raises `AttributeError`, which propagates as an unhandled 500.
+  5. A deeply nested or very large `data` dict could consume excessive memory during JSON parsing.
+- **Prerequisites**: Valid HMAC signature (requires `DESCOPE_WEBHOOK_SECRET`).
+- **CVSS v3.1**: 4.3 (AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L)
+- **Remediation**: Define typed inner models for the `data` field per event type, or validate field types in the service layer before use. At minimum, add type guards: `if isinstance(email, str)` before assignment, `if isinstance(name, str)` before calling `.split()`.
+
+#### LOW -- Module-level secret caching prevents runtime secret rotation
+
+- **Location**: `backend/app/routers/internal.py:29-30`
+- **Attack scenario**:
+  1. A secret is compromised and the operator rotates `DESCOPE_FLOW_SYNC_SECRET` or `DESCOPE_WEBHOOK_SECRET` in the environment.
+  2. The application continues using the old (compromised) secret because `_FLOW_SYNC_SECRET` and `_WEBHOOK_SECRET` are read once at module import time.
+  3. The operator must restart the application process for the new secret to take effect.
+  4. During the window between rotation and restart, the compromised secret remains valid.
+- **Prerequisites**: Secret compromise plus operational delay in restarting. This is a deployment hygiene issue rather than a direct exploit vector.
+- **CVSS v3.1**: 2.6 (AV:N/AC:H/PR:H/UI:N/S:U/C:N/I:L/A:N)
+- **Remediation**: Acceptable trade-off. The comment at line 28 ("Read secrets once at import time; validated at startup in lifespan") documents the intentional design. If runtime rotation is later desired, read from environment per-request with TTL caching, or integrate a secrets manager.
+
+#### LOW -- Webhook log messages include data.keys() which could contain attacker-controlled strings
+
+- **Location**: `backend/app/services/inbound_sync.py:192,207,260`
+- **Attack scenario**:
+  1. Attacker sends a webhook with crafted data keys containing malicious strings (e.g., ANSI escape sequences, HTML/JS payloads).
+  2. `logger.warning("... keys=%s", list(data.keys()))` writes attacker-controlled key names to application logs.
+  3. If logs are rendered in a web-based log viewer without sanitization, the key names could be exploited for log injection.
+- **Prerequisites**: Valid HMAC signature plus a vulnerable log viewer rendering the log entries.
+- **CVSS v3.1**: 2.0 (AV:N/AC:H/PR:L/UI:R/S:U/C:N/I:L/A:N)
+- **Remediation**: Minor concern. The approach of logging only keys (not values) is already good practice. For additional hardening, log only the count of unexpected keys or sanitize key names.
+
+### Non-findings (verified secure)
+
+- **Flow sync authentication**: The flow sync endpoint IS authenticated. `internal.py:98` specifies `dependencies=[Depends(verify_flow_sync_secret)]`, which validates the `X-Flow-Secret` header against `_FLOW_SYNC_SECRET` using `hmac.compare_digest()` (line 68). Missing or incorrect secret returns 401. Tests at `test_internal_router.py:114-146` cover invalid secret, missing header, and unconfigured secret scenarios. PASS.
+- **Timing-safe comparison**: Both `verify_flow_sync_secret` (line 68) and `verify_hmac_signature` (line 91) use `hmac.compare_digest()`, preventing timing side-channel attacks on secret/signature comparison. PASS.
+- **HMAC construction**: `hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()` at line 89 correctly computes HMAC-SHA256 over the raw request body with the secret as the HMAC key. PASS.
+- **Fail-closed on missing secrets**: Both `verify_flow_sync_secret` (lines 64-66) and `verify_hmac_signature` (lines 84-86) reject requests with 401 when the respective secret is empty or unset. Startup warnings in `main.py:39-42` alert operators. PASS.
+- **Email PII in OTel spans**: The service uses `_hash_email()` at `inbound_sync.py:27-29` to SHA-256 hash emails before setting span attributes (line 66: `span.set_attribute("user.email_hash", _hash_email(email))`). No raw email addresses in traces. PASS.
+- **SQL injection**: All queries use parameterized SQLAlchemy expressions (e.g., `IdPLink.external_sub == external_sub`), never string interpolation. PASS.
+- **IDOR on user records**: Users are looked up via IdP link (`provider_id + external_sub`) or by email, never by attacker-supplied canonical UUIDs. User IDs in responses are server-generated. PASS.
+- **Rate limiting**: Both endpoints decorated with `@limiter.limit(RATE_LIMIT_AUTH)` (default 10/minute) at `internal.py:99` and `internal.py:123`. The rate limiter falls back to IP address when no JWT claims are present (as expected for internal endpoints). PASS.
+- **IdPLink unique constraints**: `uq_idp_links_provider_external_sub` prevents duplicate IdP links for the same provider/subject. `uq_idp_links_user_provider` prevents a user from having multiple links to the same provider. Database-level enforcement. PASS.
+- **Repository transaction ownership**: `IdPLinkRepository.create()` at `idp_link.py:42-47` does NOT call `rollback()` on `IntegrityError` -- it raises `RepositoryConflictError` and lets the service layer control the transaction. Comment at line 41 explicitly documents this. PASS.
+- **Commit error handling**: The service wraps all `commit()` calls in try/except blocks (e.g., lines 108-112, 149-153 of `inbound_sync.py`), returning typed `Result` errors instead of propagating raw exceptions as 500s. PASS.
+
+### Summary
+
+- Attack surface elements: 9
+- Findings: 0 critical, 0 high, 2 medium, 2 low
+- Overall: PASS
+
+The implementation has a solid security posture. Both internal endpoints are authenticated (shared secret for flow sync, HMAC-SHA256 for webhooks), use timing-safe comparisons, fail closed when secrets are unconfigured, and are rate-limited. Email PII is hashed before inclusion in OTel spans. Repository transaction ownership is correctly managed. The two medium findings (unbounded string lengths and unvalidated webhook data types) are defense-in-depth improvements that require a pre-existing secret compromise to exploit. No critical or high-severity vulnerabilities were identified.

--- a/.claude/review-security.md
+++ b/.claude/review-security.md
@@ -1,0 +1,63 @@
+## Review: Security (Sentinel)
+
+### BLOCK (must fix before merge)
+
+- none
+
+### WARN (should fix)
+
+**From prior review (Story 3.1 — still open):**
+
+- **W1** [`backend/app/routers/internal.py:50`] `WebhookPayload.data` is an unvalidated `dict` with no schema enforcement. Webhook handlers extract fields via `.get()` with empty-string defaults. A malformed payload silently returns `Ok({"status": "skipped"})` rather than an error, making production debugging difficult. If Descope changes its payload shape, the endpoint silently stops processing events with no alerting. Consider adding per-event-type Pydantic models or at minimum structured warning logs when required fields are absent for known event types.
+
+- **W2** [`backend/app/routers/internal.py:36-50`] No input length constraints on request model fields. `user_id` is a bare `str` with no `max_length`. `name`, `given_name`, `family_name` are similarly unconstrained. `WebhookPayload.data` is an unbounded `dict`. An attacker with the shared secret could submit arbitrarily large payloads. Add `max_length` constraints on Pydantic fields and consider a body size limit.
+
+- **W3** [`backend/app/middleware/factory.py:79-80`] Gateway mode has no layered protection for internal endpoints. Until network-level isolation is implemented, internal endpoints in gateway mode rely solely on shared secrets with no additional defense. This should be documented as a deployment prerequisite.
+
+- **W4** [`backend/app/services/inbound_sync.py:110-112,151-153`] Commit failures return `Conflict` error type regardless of cause. Bare `except Exception` blocks around `commit()` map all exceptions (including network errors, connection timeouts) to `Conflict` responses. A database connectivity failure should not be presented as a conflict.
+
+- **W5** [`backend/app/services/inbound_sync.py:223-225`] The `_handle_user_updated` webhook path reads `email` from the untyped webhook `data` dict and writes it directly to the user model without email format validation (unlike the flow sync path which uses Pydantic `EmailStr`). A malformed email value would be persisted to the database.
+
+**New findings — Story 3.3 (cache invalidation):**
+
+- **W6** [`backend/app/main.py:93-98`] Redis URL is consumed without scheme validation. `aioredis.from_url(redis_url)` accepts any URL scheme the `redis` library supports, including `unix://`. If `REDIS_URL` is misconfigured or injected (e.g., via a compromised secrets manager), the application will silently attempt to connect to a non-Redis endpoint. The graceful-degradation catch block swallows the error, which is intentional, but a badly formed URL pointing at an internal metadata endpoint (e.g., `http://169.254.169.254/...`) would cause a connection attempt to that host at startup without any scheme allowlist.
+  Mitigation: Validate `redis_url` scheme before calling `aioredis.from_url()` — e.g., assert scheme in `{"redis", "rediss"}`.
+
+- **W7** [`backend/app/services/cache_invalidation.py:267-275`] `get_cache_publisher()` has a singleton gap: if called before `init_cache_publisher()` (e.g., in tests that import the module without going through app lifespan), it returns a throwaway no-op `CacheInvalidationPublisher()` that is not stored in `_publisher`. A consumer that caches this returned reference before init completes will hold a permanently no-op publisher and silently miss all cache invalidation events after Redis connects. The security implication is that downstream caches may serve stale identity or permission data indefinitely with no indication of the misconfiguration.
+  Mitigation: Document init ordering requirement; add a warning log if `get_cache_publisher()` is called before `init_cache_publisher()`.
+
+### INFO (acceptable risk)
+
+- **I1** PII handling in OTel traces is properly mitigated. `inbound_sync.py` uses `_hash_email(email)` (SHA-256 truncated) for span attributes rather than raw email. UUIDs in span attributes are not PII.
+
+- **I2** PII in log messages is properly handled. Logger calls include only `user.id` (a UUID). Skip-reason logs emit `list(data.keys())` rather than raw data values, avoiding PII leakage from webhook payloads.
+
+- **I3** HMAC implementation is cryptographically correct. `verify_hmac_signature` uses `hmac.new()` with SHA-256 and `hmac.compare_digest()` for timing-safe comparison. Secret read once at import time.
+
+- **I4** Flow sync shared secret implementation is correct. `verify_flow_sync_secret` uses `hmac.compare_digest()` for timing-safe string comparison. Empty/missing secret configuration is rejected with 401.
+
+- **I5** Rate limiting is applied to both internal endpoints (default: 10/minute via `RATE_LIMIT_AUTH`). SlowAPI middleware is active in standalone mode.
+
+- **I6** `excluded_prefixes` implementation is not vulnerable to path traversal. Uses `str.startswith(tuple)`; ASGI servers normalize paths before middleware.
+
+- **I7** Fail-closed behavior on missing secrets. When `DESCOPE_WEBHOOK_SECRET` or `DESCOPE_FLOW_SYNC_SECRET` is empty/unset, the respective endpoints reject all requests with 401.
+
+- **I8** No SQL injection risk. All data flows through SQLAlchemy ORM parameterized queries.
+
+- **I9** Secrets loaded at import time (`internal.py:29-30`) are not reloadable without restart. Acceptable for current deployment model.
+
+- **I10** Cache invalidation events contain no credentials or PII. Published events carry only UUIDs and enum-like strings. The `stats` dict in `publish_batch` contains only server-side integer counters — no user-supplied data flows into the Redis channel payload. A compromised Redis subscriber learns only that a mutation occurred on a given entity type/ID, not the content of the change.
+
+- **I11** Redis auth is configured in docker-compose. `REDIS_URL` includes password authentication; Redis port 6379 is bound to `127.0.0.1` only, limiting exposure to the Docker network. The default `changeme` password is documented as overridable via `REDIS_PASSWORD`.
+
+- **I12** Cache invalidation failure is genuinely fire-and-forget. All `publish()` and `publish_batch()` calls are wrapped in `try/except Exception`. Failures never propagate to the service layer and never roll back committed DB transactions. A Redis outage cannot cause data inconsistency in the canonical store.
+
+- **I13** No SSRF risk from Redis URL under normal operation. The URL is taken from a server-side environment variable, not from any user-supplied request parameter. (W6 above covers the env-injection edge case.)
+
+- **I14** `publish_batch` stats integrity. The `stats` dict is initialized with hardcoded string keys and integer zero values; only `+= 1` increments modify it before publication. No user-controlled data reaches the published stats payload.
+
+- **I15** `shutdown_cache_publisher()` correctly nulls the singleton before Redis client is closed (`main.py:87-89`). Subsequent calls to `get_cache_publisher()` after shutdown return a new no-op instance, preventing use-after-close of the Redis client.
+
+### Summary
+- BLOCK: 0 | WARN: 7 | INFO: 15
+- Overall: PASS

--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,10 @@ infra/expired_token.txt
 *.swp
 *.swo
 
-# Claude
-.claude/task-state.md
+# Claude runtime state (skills are checked in)
+.claude/task-state*.md
+.claude/review-*.md
+.claude/review-*.patch
 
 # Ralph
 .ralph/

--- a/backend/app/dependencies/identity.py
+++ b/backend/app/dependencies/identity.py
@@ -1,19 +1,43 @@
 """Dependency factories for identity domain services (onion architecture DI wiring).
 
-AC-2.1.7: get_user_service() wires AsyncSession → UserRepository → UserService
+AC-2.1.7: get_user_service() wires AsyncSession -> UserRepository -> UserService
+AC-2.2.6: get_role_service(), get_permission_service(), get_tenant_service()
 with DescopeSyncAdapter wrapping the singleton DescopeManagementClient.
+AC-3.1.1: get_inbound_sync_service() wires repositories for inbound sync.
+AC-3.2.1: get_reconciliation_service() wires repositories + Descope client for reconciliation.
+AC-4.1.3: get_idp_link_service(), get_provider_service() for IdP link/provider domain services.
+AC-4.3.1: get_identity_resolution_service() for identity resolution with Redis cache.
 """
 
 from __future__ import annotations
 
 from fastapi import Depends
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.database import get_async_session
+from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.permission import PermissionRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.role import RoleRepository
+from app.repositories.tenant import TenantRepository
 from app.repositories.user import UserRepository
 from app.services.adapters.descope import DescopeSyncAdapter
+from app.services.cache_invalidation import get_cache_publisher, get_redis_client
 from app.services.descope import get_descope_client
+from app.services.identity_resolution import IdentityResolutionService
+from app.services.idp_link import IdPLinkService
+from app.services.inbound_sync import InboundSyncService
+from app.services.permission import PermissionService
+from app.services.provider import ProviderService
+from app.services.reconciliation import ReconciliationService
+from app.services.role import RoleService
+from app.services.tenant import TenantService
 from app.services.user import UserService
+
+# Postgres advisory lock ID for reconciliation (arbitrary constant)
+_RECONCILIATION_LOCK_ID = 73_82_69_67  # "RECON" in digits
 
 
 async def get_user_service(
@@ -21,10 +45,177 @@ async def get_user_service(
 ) -> UserService:
     """Build a UserService with its repository and sync adapter.
 
-    Wiring: AsyncSession → UserRepository(session)
-            DescopeManagementClient → DescopeSyncAdapter(client)
-            → UserService(repository, adapter)
+    Wiring: AsyncSession -> UserRepository(session) + UserTenantRoleRepository(session)
+            DescopeManagementClient -> DescopeSyncAdapter(client)
+            -> UserService(repository, adapter, assignment_repository)
     """
     repository = UserRepository(session)
+    assignment_repository = UserTenantRoleRepository(session)
     adapter = DescopeSyncAdapter(client=get_descope_client())
-    return UserService(repository=repository, adapter=adapter)
+    return UserService(
+        repository=repository,
+        adapter=adapter,
+        assignment_repository=assignment_repository,
+        publisher=get_cache_publisher(),
+    )
+
+
+async def get_role_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> RoleService:
+    """Build a RoleService with its repositories and sync adapter.
+
+    Wiring: AsyncSession -> RoleRepository + PermissionRepository + UserTenantRoleRepository
+            DescopeManagementClient -> DescopeSyncAdapter(client)
+            -> RoleService(repository, permission_repository, assignment_repository, adapter)
+    """
+    repository = RoleRepository(session)
+    permission_repository = PermissionRepository(session)
+    assignment_repository = UserTenantRoleRepository(session)
+    adapter = DescopeSyncAdapter(client=get_descope_client())
+    return RoleService(
+        repository=repository,
+        permission_repository=permission_repository,
+        assignment_repository=assignment_repository,
+        adapter=adapter,
+        publisher=get_cache_publisher(),
+    )
+
+
+async def get_permission_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> PermissionService:
+    """Build a PermissionService with its repository and sync adapter.
+
+    Wiring: AsyncSession -> PermissionRepository(session)
+            DescopeManagementClient -> DescopeSyncAdapter(client)
+            -> PermissionService(repository, adapter)
+    """
+    repository = PermissionRepository(session)
+    adapter = DescopeSyncAdapter(client=get_descope_client())
+    return PermissionService(repository=repository, adapter=adapter, publisher=get_cache_publisher())
+
+
+async def get_tenant_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> TenantService:
+    """Build a TenantService with its repository and sync adapter.
+
+    Wiring: AsyncSession -> TenantRepository(session)
+            DescopeManagementClient -> DescopeSyncAdapter(client)
+            -> TenantService(repository, adapter)
+    """
+    repository = TenantRepository(session)
+    adapter = DescopeSyncAdapter(client=get_descope_client())
+    return TenantService(repository=repository, adapter=adapter, publisher=get_cache_publisher())
+
+
+async def get_inbound_sync_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> InboundSyncService:
+    """Build an InboundSyncService with its repositories.
+
+    AC-3.1.1: Wiring: AsyncSession -> UserRepository + IdPLinkRepository + ProviderRepository
+               -> InboundSyncService(user_repository, idp_link_repository, provider_repository)
+    """
+    user_repository = UserRepository(session)
+    idp_link_repository = IdPLinkRepository(session)
+    provider_repository = ProviderRepository(session)
+    return InboundSyncService(
+        user_repository=user_repository,
+        idp_link_repository=idp_link_repository,
+        provider_repository=provider_repository,
+        publisher=get_cache_publisher(),
+    )
+
+
+async def get_reconciliation_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> ReconciliationService:
+    """Build a ReconciliationService with all repositories and Descope client.
+
+    AC-3.2.1: Wiring: AsyncSession -> all identity repositories + DescopeManagementClient
+               -> ReconciliationService(session, acquire_lock, descope_client, repositories...)
+    Advisory lock callable injected here to keep SA imports out of the domain service.
+    """
+    user_repository = UserRepository(session)
+    role_repository = RoleRepository(session)
+    permission_repository = PermissionRepository(session)
+    tenant_repository = TenantRepository(session)
+    idp_link_repository = IdPLinkRepository(session)
+    provider_repository = ProviderRepository(session)
+
+    async def _acquire_lock() -> None:
+        await session.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_id)"),
+            {"lock_id": _RECONCILIATION_LOCK_ID},
+        )
+
+    return ReconciliationService(
+        session=session,
+        acquire_lock=_acquire_lock,
+        descope_client=get_descope_client(),
+        user_repository=user_repository,
+        role_repository=role_repository,
+        permission_repository=permission_repository,
+        tenant_repository=tenant_repository,
+        idp_link_repository=idp_link_repository,
+        provider_repository=provider_repository,
+        publisher=get_cache_publisher(),
+    )
+
+
+async def get_idp_link_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> IdPLinkService:
+    """Build an IdPLinkService with its repositories.
+
+    AC-4.1.3: Wiring: AsyncSession -> IdPLinkRepository + UserRepository + ProviderRepository
+               -> IdPLinkService(repository, user_repository, provider_repository)
+    """
+    repository = IdPLinkRepository(session)
+    user_repository = UserRepository(session)
+    provider_repository = ProviderRepository(session)
+    return IdPLinkService(
+        repository=repository,
+        user_repository=user_repository,
+        provider_repository=provider_repository,
+    )
+
+
+async def get_provider_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> ProviderService:
+    """Build a ProviderService with its repository.
+
+    AC-4.1.3: Wiring: AsyncSession -> ProviderRepository(session)
+               -> ProviderService(repository)
+    """
+    repository = ProviderRepository(session)
+    return ProviderService(repository=repository)
+
+
+async def get_identity_resolution_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> IdentityResolutionService:
+    """Build an IdentityResolutionService with its repositories and Redis client.
+
+    AC-4.3.1: Wiring: AsyncSession -> UserRepository + IdPLinkRepository + ProviderRepository
+               + UserTenantRoleRepository + RoleRepository + TenantRepository
+               + optional Redis client -> IdentityResolutionService
+    """
+    user_repository = UserRepository(session)
+    idp_link_repository = IdPLinkRepository(session)
+    provider_repository = ProviderRepository(session)
+    assignment_repository = UserTenantRoleRepository(session)
+    role_repository = RoleRepository(session)
+    tenant_repository = TenantRepository(session)
+    return IdentityResolutionService(
+        user_repository=user_repository,
+        idp_link_repository=idp_link_repository,
+        provider_repository=provider_repository,
+        assignment_repository=assignment_repository,
+        role_repository=role_repository,
+        tenant_repository=tenant_repository,
+        redis_client=get_redis_client(),
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
 
 import httpx
@@ -19,21 +20,39 @@ from app.routers import (
     documents,
     fga,
     health,
+    idp_links,
+    internal,
     permissions,
     protected,
+    providers,
+    reconciliation,
     roles,
     tenants,
     users,
 )
+from app.services.cache_invalidation import init_cache_publisher, set_redis_client, shutdown_cache_publisher
 from app.services.descope import init_descope_client, shutdown_descope_client
 from app.telemetry import init_telemetry, shutdown_telemetry
 
 logger = logging.getLogger(__name__)
 
 
+def _warn_missing_secrets() -> None:
+    """Log warnings for internal endpoint secrets missing at startup."""
+    import os
+
+    if not os.getenv("DESCOPE_WEBHOOK_SECRET"):
+        logger.warning("DESCOPE_WEBHOOK_SECRET not set — webhook endpoint will reject all requests")
+    if not os.getenv("DESCOPE_FLOW_SYNC_SECRET"):
+        logger.warning("DESCOPE_FLOW_SYNC_SECRET not set — flow sync endpoint will reject all requests")
+    if not os.getenv("INTERNAL_IDENTITY_KEY"):
+        logger.warning("INTERNAL_IDENTITY_KEY not set — identity resolution endpoint will reject all requests")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     setup_logging()
+    _warn_missing_secrets()
     engine = get_engine()
 
     # Verify database connectivity before accepting requests
@@ -47,27 +66,81 @@ async def lifespan(app: FastAPI):
     init_telemetry(engine=engine)
     http_client = httpx.AsyncClient(timeout=30.0)
     init_descope_client(http_client=http_client)
+
+    # Redis for cache invalidation pub/sub — optional, degrades gracefully
+    redis_client = None
+    redis_url = os.getenv("REDIS_URL")
+    if redis_url:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(redis_url)
+        if parsed.scheme not in ("redis", "rediss"):
+            logger.warning("REDIS_URL has unsupported scheme '%s' — cache invalidation disabled", parsed.scheme)
+        else:
+            try:
+                import redis.asyncio as aioredis
+
+                redis_client = aioredis.from_url(redis_url)
+                await redis_client.ping()
+                logger.info("Redis connected for cache invalidation")
+            except Exception:
+                logger.warning("Redis connection failed — cache invalidation disabled", exc_info=True)
+                if redis_client is not None:
+                    await redis_client.aclose()
+                redis_client = None
+    else:
+        logger.info("REDIS_URL not set — cache invalidation disabled")
+    init_cache_publisher(redis_client=redis_client)
+    set_redis_client(redis_client)
+
+    # Start cache invalidation subscriber (AC-4.3.3) — background task
+    subscriber_task = None
+    if redis_client is not None:
+        from app.services.identity_resolution import run_cache_invalidation_subscriber
+
+        subscriber_task = asyncio.create_task(run_cache_invalidation_subscriber(redis_client))
+
     try:
         yield
     finally:
+        # Cancel cache invalidation subscriber before closing Redis
+        if subscriber_task is not None:
+            subscriber_task.cancel()
+            try:
+                await subscriber_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.warning("Cache invalidation subscriber shutdown error", exc_info=True)
         try:
-            # Run synchronous shutdown in executor to avoid blocking the event loop
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, shutdown_telemetry)
+            set_redis_client(None)
+            shutdown_cache_publisher()
         except Exception:
-            logger.warning("Telemetry shutdown failed", exc_info=True)
+            logger.warning("Cache publisher shutdown failed", exc_info=True)
+        try:
+            if redis_client is not None:
+                await redis_client.aclose()
+        except Exception:
+            logger.warning("Redis shutdown failed", exc_info=True)
         finally:
             try:
-                shutdown_descope_client()
+                # Run synchronous shutdown in executor to avoid blocking the event loop
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(None, shutdown_telemetry)
             except Exception:
-                logger.warning("Descope client shutdown failed", exc_info=True)
+                logger.warning("Telemetry shutdown failed", exc_info=True)
             finally:
                 try:
-                    await http_client.aclose()
+                    shutdown_descope_client()
                 except Exception:
-                    logger.warning("HTTP client close failed", exc_info=True)
+                    logger.warning("Descope client shutdown failed", exc_info=True)
                 finally:
-                    await engine.dispose()
+                    try:
+                        await http_client.aclose()
+                    except Exception:
+                        logger.warning("HTTP client close failed", exc_info=True)
+                    finally:
+                        await engine.dispose()
 
 
 app = FastAPI(title="Descope SaaS Starter API", docs_url=None, redoc_url="/redoc", lifespan=lifespan)
@@ -91,6 +164,10 @@ app.include_router(permissions.router, prefix="/api")
 app.include_router(users.router, prefix="/api")
 app.include_router(documents.router, prefix="/api")
 app.include_router(fga.router, prefix="/api")
+app.include_router(internal.router, prefix="/api")
+app.include_router(reconciliation.router, prefix="/api")
+app.include_router(idp_links.router, prefix="/api")
+app.include_router(providers.router, prefix="/api")
 
 
 @app.get("/docs", include_in_schema=False)

--- a/backend/app/middleware/auth.py
+++ b/backend/app/middleware/auth.py
@@ -20,10 +20,17 @@ class TokenValidationMiddleware(BaseHTTPMiddleware):
     issuer check and validating manually against both known formats.
     """
 
-    def __init__(self, app, descope_project_id: str, excluded_paths: set[str] | None = None):
+    def __init__(
+        self,
+        app,
+        descope_project_id: str,
+        excluded_paths: set[str] | None = None,
+        excluded_prefixes: set[str] | None = None,
+    ):
         super().__init__(app)
         self.descope_project_id = descope_project_id
         self.excluded_paths = excluded_paths or set()
+        self.excluded_prefixes = tuple(excluded_prefixes) if excluded_prefixes else ()
         self.disco_address = f"https://api.descope.com/{descope_project_id}/.well-known/openid-configuration"
         self._accepted_issuers = frozenset(
             {
@@ -33,7 +40,7 @@ class TokenValidationMiddleware(BaseHTTPMiddleware):
         )
 
     async def dispatch(self, request: Request, call_next):
-        if request.url.path in self.excluded_paths:
+        if request.url.path in self.excluded_paths or request.url.path.startswith(self.excluded_prefixes):
             return await call_next(request)
 
         auth_header = request.headers.get("Authorization")

--- a/backend/app/middleware/factory.py
+++ b/backend/app/middleware/factory.py
@@ -71,6 +71,9 @@ def configure_middleware(app: FastAPI) -> None:
                 "/redoc",
                 "/openapi.json",
             },
+            excluded_prefixes={
+                "/api/internal/",
+            },
         )
         logger.info("Middleware included: TokenValidationMiddleware")
     else:

--- a/backend/app/repositories/assignment.py
+++ b/backend/app/repositories/assignment.py
@@ -1,0 +1,94 @@
+"""UserTenantRoleRepository — data access layer for role assignment model.
+
+Handles all SQLAlchemy queries for user-tenant-role assignment CRUD.
+Contains NO business logic, NO OTel spans, NO adapter calls — data access only.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.identity.assignment import UserTenantRole
+from app.repositories.user import RepositoryConflictError
+
+
+class UserTenantRoleRepository:
+    """Repository for UserTenantRole table operations.
+
+    Takes AsyncSession via constructor injection (inner layer of onion architecture).
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(self, assignment: UserTenantRole) -> UserTenantRole:
+        """Add a new role assignment and flush.
+
+        Raises RepositoryConflictError if the assignment already exists.
+        """
+        self._session.add(assignment)
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return assignment
+
+    async def get(self, user_id: uuid.UUID, tenant_id: uuid.UUID, role_id: uuid.UUID) -> UserTenantRole | None:
+        """Fetch an assignment by composite primary key. Returns None if not found."""
+        return await self._session.get(UserTenantRole, (user_id, tenant_id, role_id))
+
+    async def list_by_user_tenant(self, user_id: uuid.UUID, tenant_id: uuid.UUID) -> list[UserTenantRole]:
+        """List all role assignments for a user within a tenant."""
+        stmt = (
+            sa.select(UserTenantRole)
+            .where(
+                UserTenantRole.user_id == user_id,
+                UserTenantRole.tenant_id == tenant_id,
+            )
+            .order_by(UserTenantRole.assigned_at.desc())
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_by_user(self, user_id: uuid.UUID) -> list[UserTenantRole]:
+        """List all role assignments for a user across all tenants."""
+        stmt = (
+            sa.select(UserTenantRole)
+            .where(UserTenantRole.user_id == user_id)
+            .order_by(UserTenantRole.tenant_id, UserTenantRole.assigned_at.desc())
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def delete(self, user_id: uuid.UUID, tenant_id: uuid.UUID, role_id: uuid.UUID) -> bool:
+        """Delete a role assignment. Returns True if deleted, False if not found."""
+        stmt = sa.delete(UserTenantRole).where(
+            UserTenantRole.user_id == user_id,
+            UserTenantRole.tenant_id == tenant_id,
+            UserTenantRole.role_id == role_id,
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return result.rowcount > 0
+
+    async def delete_by_user_tenant(self, user_id: uuid.UUID, tenant_id: uuid.UUID) -> int:
+        """Delete all role assignments for a user in a tenant. Returns count of deleted rows."""
+        stmt = sa.delete(UserTenantRole).where(
+            UserTenantRole.user_id == user_id,
+            UserTenantRole.tenant_id == tenant_id,
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return result.rowcount
+
+    async def commit(self) -> None:
+        """Commit the current transaction."""
+        await self._session.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the current transaction."""
+        await self._session.rollback()

--- a/backend/app/repositories/idp_link.py
+++ b/backend/app/repositories/idp_link.py
@@ -1,0 +1,89 @@
+"""IdPLinkRepository — data access layer for canonical IdPLink model.
+
+Handles all SQLAlchemy queries for IdP link CRUD.
+Contains NO business logic, NO OTel spans, NO adapter calls — data access only.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.identity.provider import Provider
+from app.models.identity.user import IdPLink
+from app.repositories.user import RepositoryConflictError
+
+
+class IdPLinkRepository:
+    """Repository for IdPLink table operations.
+
+    Takes AsyncSession via constructor injection (inner layer of onion architecture).
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get(self, link_id: uuid.UUID) -> IdPLink | None:
+        """Fetch an IdP link by primary key. Returns None if not found."""
+        return await self._session.get(IdPLink, link_id)
+
+    async def delete(self, link_id: uuid.UUID) -> bool:
+        """Delete an IdP link by primary key. Returns True if deleted, False if not found."""
+        link = await self._session.get(IdPLink, link_id)
+        if link is None:
+            return False
+        await self._session.delete(link)
+        await self._session.flush()
+        return True
+
+    async def get_by_provider_and_sub(self, provider_id: uuid.UUID, external_sub: str) -> IdPLink | None:
+        """Fetch an IdP link by provider and external subject. Returns None if not found."""
+        stmt = sa.select(IdPLink).where(
+            IdPLink.provider_id == provider_id,
+            IdPLink.external_sub == external_sub,
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create(self, link: IdPLink) -> IdPLink:
+        """Add a new IdP link to the session and flush to generate defaults.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        Does NOT rollback — the caller (service layer) owns the transaction.
+        """
+        self._session.add(link)
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return link
+
+    async def get_by_provider_name_and_sub(self, provider_name: str, external_sub: str) -> IdPLink | None:
+        """Fetch an IdP link by provider name and external subject (joins Provider table).
+
+        Returns None if no matching link is found.
+        """
+        stmt = (
+            sa.select(IdPLink)
+            .join(Provider, Provider.id == IdPLink.provider_id)
+            .where(Provider.name == provider_name, IdPLink.external_sub == external_sub)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_by_user(self, user_id: uuid.UUID) -> list[IdPLink]:
+        """Fetch all IdP links for a user."""
+        stmt = sa.select(IdPLink).where(IdPLink.user_id == user_id)
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def commit(self) -> None:
+        """Commit the current transaction."""
+        await self._session.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the current transaction."""
+        await self._session.rollback()

--- a/backend/app/repositories/permission.py
+++ b/backend/app/repositories/permission.py
@@ -1,0 +1,80 @@
+"""PermissionRepository — data access layer for canonical Permission model.
+
+Handles all SQLAlchemy queries for permission CRUD.
+Contains NO business logic, NO OTel spans, NO adapter calls — data access only.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.identity.role import Permission
+from app.repositories.user import RepositoryConflictError
+
+
+class PermissionRepository:
+    """Repository for Permission table operations.
+
+    Takes AsyncSession via constructor injection (inner layer of onion architecture).
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(self, permission: Permission) -> Permission:
+        """Add a new permission to the session and flush to generate defaults.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        """
+        self._session.add(permission)
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return permission
+
+    async def get(self, permission_id: uuid.UUID) -> Permission | None:
+        """Fetch a permission by primary key. Returns None if not found."""
+        return await self._session.get(Permission, permission_id)
+
+    async def get_by_name(self, name: str) -> Permission | None:
+        """Fetch a permission by name. Returns None if not found."""
+        stmt = sa.select(Permission).where(Permission.name == name)
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def list_all(self) -> list[Permission]:
+        """List all permissions ordered by creation time."""
+        stmt = sa.select(Permission).order_by(Permission.created_at.desc())
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def update(self, permission: Permission) -> Permission:
+        """Flush updated permission state.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        """
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return permission
+
+    async def delete(self, permission_id: uuid.UUID) -> bool:
+        """Delete a permission by ID. Returns True if deleted, False if not found."""
+        stmt = sa.delete(Permission).where(Permission.id == permission_id)
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return result.rowcount > 0
+
+    async def commit(self) -> None:
+        """Commit the current transaction."""
+        await self._session.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the current transaction."""
+        await self._session.rollback()

--- a/backend/app/repositories/provider.py
+++ b/backend/app/repositories/provider.py
@@ -1,0 +1,87 @@
+"""ProviderRepository — data access layer for canonical Provider model.
+
+Handles all SQLAlchemy queries for provider CRUD.
+Contains NO business logic, NO OTel spans, NO adapter calls — data access only.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.identity.provider import Provider, ProviderType
+from app.repositories.user import RepositoryConflictError
+
+
+class ProviderRepository:
+    """Repository for Provider table operations.
+
+    Takes AsyncSession via constructor injection (inner layer of onion architecture).
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(self, provider: Provider) -> Provider:
+        """Add a new provider to the session and flush to generate defaults.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        Rolls back the session before raising so it is not left in an invalid state.
+        """
+        self._session.add(provider)
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise RepositoryConflictError(str(exc)) from exc
+        return provider
+
+    async def update(self, provider: Provider) -> Provider:
+        """Flush pending mutations on a provider already attached to the session.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        Rolls back the session before raising so it is not left in an invalid state.
+        """
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise RepositoryConflictError(str(exc)) from exc
+        return provider
+
+    async def get_by_type(self, provider_type: ProviderType) -> Provider | None:
+        """Fetch a provider by type. Returns the first match or None.
+
+        Uses scalars().first() rather than scalar_one_or_none() to avoid
+        MultipleResultsFound if duplicate providers exist for a type.
+        """
+        stmt = sa.select(Provider).where(Provider.type == provider_type)
+        result = await self._session.execute(stmt)
+        return result.scalars().first()
+
+    async def get_by_name(self, name: str) -> Provider | None:
+        """Fetch a provider by name. Returns None if not found."""
+        stmt = sa.select(Provider).where(Provider.name == name)
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def list_all(self) -> list[Provider]:
+        """Return all providers ordered by name."""
+        stmt = sa.select(Provider).order_by(Provider.name)
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get(self, provider_id: uuid.UUID) -> Provider | None:
+        """Fetch a provider by primary key. Returns None if not found."""
+        return await self._session.get(Provider, provider_id)
+
+    async def commit(self) -> None:
+        """Commit the current transaction."""
+        await self._session.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the current transaction."""
+        await self._session.rollback()

--- a/backend/app/repositories/role.py
+++ b/backend/app/repositories/role.py
@@ -1,0 +1,126 @@
+"""RoleRepository — data access layer for canonical Role and RolePermission models.
+
+Handles all SQLAlchemy queries for role CRUD and permission mapping.
+Contains NO business logic, NO OTel spans, NO adapter calls — data access only.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.identity.role import Permission, Role, RolePermission
+from app.repositories.user import RepositoryConflictError
+
+
+class RoleRepository:
+    """Repository for Role table operations.
+
+    Takes AsyncSession via constructor injection (inner layer of onion architecture).
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(self, role: Role) -> Role:
+        """Add a new role to the session and flush to generate defaults.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        """
+        self._session.add(role)
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return role
+
+    async def get(self, role_id: uuid.UUID) -> Role | None:
+        """Fetch a role by primary key. Returns None if not found."""
+        return await self._session.get(Role, role_id)
+
+    async def get_by_name(self, name: str, tenant_id: uuid.UUID | None = None) -> Role | None:
+        """Fetch a role by name within a tenant scope. Returns None if not found."""
+        stmt = sa.select(Role).where(Role.name == name)
+        if tenant_id is not None:
+            stmt = stmt.where(Role.tenant_id == tenant_id)
+        else:
+            stmt = stmt.where(Role.tenant_id.is_(None))
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def list_by_tenant(self, tenant_id: uuid.UUID | None = None) -> list[Role]:
+        """List roles filtered by tenant_id (None for global roles)."""
+        stmt = sa.select(Role)
+        if tenant_id is not None:
+            stmt = stmt.where(Role.tenant_id == tenant_id)
+        else:
+            stmt = stmt.where(Role.tenant_id.is_(None))
+        stmt = stmt.order_by(Role.created_at.desc())
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def update(self, role: Role) -> Role:
+        """Flush updated role state.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        """
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return role
+
+    async def add_permission(self, role_id: uuid.UUID, permission_id: uuid.UUID) -> RolePermission:
+        """Create a role-permission mapping.
+
+        Raises RepositoryConflictError if the mapping already exists.
+        """
+        mapping = RolePermission(role_id=role_id, permission_id=permission_id)
+        self._session.add(mapping)
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return mapping
+
+    async def remove_permission(self, role_id: uuid.UUID, permission_id: uuid.UUID) -> bool:
+        """Remove a role-permission mapping. Returns True if deleted, False if not found."""
+        stmt = sa.delete(RolePermission).where(
+            RolePermission.role_id == role_id,
+            RolePermission.permission_id == permission_id,
+        )
+        result = await self._session.execute(stmt)
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return result.rowcount > 0
+
+    async def get_permissions(self, role_id: uuid.UUID) -> list[Permission]:
+        """Get all permissions mapped to a role via role_permissions join."""
+        stmt = (
+            sa.select(Permission)
+            .join(RolePermission, RolePermission.permission_id == Permission.id)
+            .where(RolePermission.role_id == role_id)
+            .order_by(Permission.name)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def delete(self, role_id: uuid.UUID) -> bool:
+        """Delete a role by ID. Returns True if deleted, False if not found."""
+        stmt = sa.delete(Role).where(Role.id == role_id)
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return result.rowcount > 0
+
+    async def commit(self) -> None:
+        """Commit the current transaction."""
+        await self._session.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the current transaction."""
+        await self._session.rollback()

--- a/backend/app/repositories/tenant.py
+++ b/backend/app/repositories/tenant.py
@@ -1,0 +1,91 @@
+"""TenantRepository — data access layer for canonical Tenant model.
+
+Handles all SQLAlchemy queries for tenant CRUD and user-role lookups.
+Contains NO business logic, NO OTel spans, NO adapter calls — data access only.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.identity.assignment import UserTenantRole
+from app.models.identity.role import Role
+from app.models.identity.tenant import Tenant
+from app.models.identity.user import User
+from app.repositories.user import RepositoryConflictError
+
+
+class TenantRepository:
+    """Repository for Tenant table operations.
+
+    Takes AsyncSession via constructor injection (inner layer of onion architecture).
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(self, tenant: Tenant) -> Tenant:
+        """Add a new tenant to the session and flush to generate defaults.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        """
+        self._session.add(tenant)
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return tenant
+
+    async def get(self, tenant_id: uuid.UUID) -> Tenant | None:
+        """Fetch a tenant by primary key. Returns None if not found."""
+        return await self._session.get(Tenant, tenant_id)
+
+    async def get_by_name(self, name: str) -> Tenant | None:
+        """Fetch a tenant by name. Returns None if not found."""
+        stmt = sa.select(Tenant).where(Tenant.name == name)
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def list_all(self) -> list[Tenant]:
+        """List all tenants ordered by creation time."""
+        stmt = sa.select(Tenant).order_by(Tenant.created_at.desc())
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def update(self, tenant: Tenant) -> Tenant:
+        """Flush updated tenant state.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        """
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return tenant
+
+    async def get_users_with_roles(self, tenant_id: uuid.UUID) -> list[tuple]:
+        """Get all users and their roles for a tenant via 3-way JOIN.
+
+        Returns list of (User, Role) tuples for the given tenant.
+        """
+        stmt = (
+            sa.select(User, Role)
+            .join(UserTenantRole, UserTenantRole.user_id == User.id)
+            .join(Role, Role.id == UserTenantRole.role_id)
+            .where(UserTenantRole.tenant_id == tenant_id)
+            .order_by(User.email, Role.name)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.all())
+
+    async def commit(self) -> None:
+        """Commit the current transaction."""
+        await self._session.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the current transaction."""
+        await self._session.rollback()

--- a/backend/app/repositories/user.py
+++ b/backend/app/repositories/user.py
@@ -51,19 +51,6 @@ class UserRepository:
         """Fetch a user by primary key. Returns None if not found."""
         return await self._session.get(User, user_id)
 
-    async def get_for_tenant(self, user_id: uuid.UUID, tenant_id: uuid.UUID) -> User | None:
-        """Fetch a user by ID, scoped to a tenant via UserTenantRole.
-
-        Returns None if the user does not exist or has no role in the tenant.
-        """
-        stmt = (
-            sa.select(User)
-            .join(UserTenantRole, UserTenantRole.user_id == User.id)
-            .where(User.id == user_id, UserTenantRole.tenant_id == tenant_id)
-        )
-        result = await self._session.execute(stmt)
-        return result.scalar_one_or_none()
-
     async def get_by_email(self, email: str) -> User | None:
         """Fetch a user by email address. Returns None if not found."""
         stmt = sa.select(User).where(User.email == email)
@@ -123,6 +110,23 @@ class UserRepository:
 
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
+
+    async def list_all(self) -> list[User]:
+        """List all users ordered by creation time."""
+        stmt = sa.select(User).order_by(User.created_at.desc())
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def exists_in_tenant(self, user_id: uuid.UUID, tenant_id: uuid.UUID) -> bool:
+        """Check if a user has any role assignment in the given tenant."""
+        stmt = sa.select(
+            sa.exists().where(
+                UserTenantRole.user_id == user_id,
+                UserTenantRole.tenant_id == tenant_id,
+            )
+        )
+        result = await self._session.execute(stmt)
+        return bool(result.scalar())
 
     async def commit(self) -> None:
         """Commit the current transaction."""

--- a/backend/app/routers/idp_links.py
+++ b/backend/app/routers/idp_links.py
@@ -1,0 +1,117 @@
+import uuid
+
+from expression import Ok
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.identity import get_idp_link_service
+from app.dependencies.rbac import require_role
+from app.errors.problem_detail import result_to_response
+from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
+from app.models.database import get_async_session
+from app.repositories.assignment import UserTenantRoleRepository
+from app.services.idp_link import IdPLinkService
+
+router = APIRouter(tags=["IdP Links"])
+
+
+class CreateIdPLinkRequest(BaseModel):
+    provider_id: uuid.UUID
+    external_sub: str = Field(min_length=1, max_length=255)
+    external_email: str = Field(default="", max_length=320)
+    metadata: dict[str, str] | None = None
+
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata_size(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is not None and len(v) > 20:
+            raise ValueError("metadata must have at most 20 keys")
+        return v
+
+
+def _parse_uuid(value: str, field_name: str) -> uuid.UUID:
+    """Parse a string to UUID, raising 422 on invalid input."""
+    try:
+        return uuid.UUID(value)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for {field_name}: {value}")
+
+
+async def _verify_user_in_tenant(
+    user_uuid: uuid.UUID,
+    request: Request,
+    session: AsyncSession,
+) -> None:
+    """Verify the target user belongs to the caller's tenant.
+
+    Returns 404 (not 403) to avoid leaking whether the user exists.
+    """
+    claims = getattr(request.state, "claims", None)
+    tenant_id = claims.get("dct") if claims else None
+    if not tenant_id:
+        raise HTTPException(status_code=404, detail="User not found in tenant")
+    assignment_repo = UserTenantRoleRepository(session)
+    assignments = await assignment_repo.list_by_user_tenant(user_uuid, uuid.UUID(tenant_id))
+    if not assignments:
+        raise HTTPException(status_code=404, detail="User not found in tenant")
+
+
+@router.get("/users/{user_id}/idp-links")
+async def list_user_idp_links(
+    request: Request,
+    user_id: str,
+    _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    idp_link_service: IdPLinkService = Depends(get_idp_link_service),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """List all IdP links for a user."""
+    user_uuid = _parse_uuid(user_id, "user_id")
+    await _verify_user_in_tenant(user_uuid, request, session)
+    result = await idp_link_service.get_user_idp_links(user_id=user_uuid)
+    if result.is_ok():
+        result = Ok({"idp_links": result.ok})
+    return result_to_response(result, request)
+
+
+@router.post("/users/{user_id}/idp-links")
+@limiter.limit(RATE_LIMIT_AUTH)
+async def create_idp_link(
+    request: Request,
+    user_id: str,
+    body: CreateIdPLinkRequest,
+    _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    idp_link_service: IdPLinkService = Depends(get_idp_link_service),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Create an IdP link between a user and an external identity."""
+    user_uuid = _parse_uuid(user_id, "user_id")
+    await _verify_user_in_tenant(user_uuid, request, session)
+    result = await idp_link_service.create_idp_link(
+        user_id=user_uuid,
+        provider_id=body.provider_id,
+        external_sub=body.external_sub,
+        external_email=body.external_email,
+        metadata=body.metadata,
+    )
+    return result_to_response(result, request, status=201)
+
+
+@router.delete("/users/{user_id}/idp-links/{link_id}")
+@limiter.limit(RATE_LIMIT_AUTH)
+async def delete_idp_link(
+    request: Request,
+    user_id: str,
+    link_id: str,
+    _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    idp_link_service: IdPLinkService = Depends(get_idp_link_service),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Delete an IdP link."""
+    user_uuid = _parse_uuid(user_id, "user_id")
+    await _verify_user_in_tenant(user_uuid, request, session)
+    link_uuid = _parse_uuid(link_id, "link_id")
+    result = await idp_link_service.delete_idp_link(link_id=link_uuid, user_id=user_uuid)
+    if result.is_ok():
+        return Response(status_code=204)
+    return result_to_response(result, request)

--- a/backend/app/routers/internal.py
+++ b/backend/app/routers/internal.py
@@ -1,0 +1,176 @@
+"""Internal router for inbound sync endpoints.
+
+AC-3.1.1: POST /api/internal/users/sync — Descope Flow HTTP Connector
+AC-3.1.2: POST /api/internal/webhooks/descope — Descope audit webhook
+AC-3.1.3: HMAC validation on webhook endpoint
+AC-3.1.4: /api/internal/ prefix excluded from JWT auth
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
+from pydantic import BaseModel, EmailStr
+
+from app.dependencies.identity import get_identity_resolution_service, get_inbound_sync_service
+from app.errors.problem_detail import result_to_response
+from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
+from app.services.identity_resolution import IdentityResolutionService
+from app.services.inbound_sync import InboundSyncService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Internal"])
+
+# Read secrets once at import time; validated at startup in lifespan.
+_FLOW_SYNC_SECRET = os.getenv("DESCOPE_FLOW_SYNC_SECRET", "")
+_WEBHOOK_SECRET = os.getenv("DESCOPE_WEBHOOK_SECRET", "")
+_IDENTITY_KEY = os.getenv("INTERNAL_IDENTITY_KEY", "")
+
+
+# --- Request models ---
+
+
+class FlowSyncRequest(BaseModel):
+    """Payload from Descope Flow HTTP Connector."""
+
+    user_id: str
+    email: EmailStr
+    name: str | None = None
+    given_name: str | None = None
+    family_name: str | None = None
+
+
+class WebhookPayload(BaseModel):
+    """Payload from Descope audit webhook."""
+
+    event_type: str
+    data: dict
+
+
+# --- Auth dependency: shared secret for flow sync ---
+
+
+async def verify_flow_sync_secret(
+    x_flow_secret: str = Header(..., alias="X-Flow-Secret"),
+) -> None:
+    """Validate shared secret on flow sync requests.
+
+    Uses DESCOPE_FLOW_SYNC_SECRET env var with timing-safe comparison.
+    Missing/invalid secret → 401.
+    """
+    if not _FLOW_SYNC_SECRET:
+        logger.error("DESCOPE_FLOW_SYNC_SECRET not configured — rejecting flow sync")
+        raise HTTPException(status_code=401, detail="Flow sync secret not configured")
+
+    if not hmac.compare_digest(_FLOW_SYNC_SECRET, x_flow_secret):
+        raise HTTPException(status_code=401, detail="Invalid flow sync secret")
+
+
+# --- Auth dependency: shared secret for identity resolution ---
+
+
+async def verify_identity_key(
+    x_identity_key: str = Header(..., alias="X-Identity-Key"),
+) -> None:
+    """Validate shared secret on identity resolution requests.
+
+    Uses INTERNAL_IDENTITY_KEY env var with timing-safe comparison.
+    Missing/invalid key → 401.
+    """
+    if not _IDENTITY_KEY:
+        logger.error("INTERNAL_IDENTITY_KEY not configured — rejecting identity request")
+        raise HTTPException(status_code=401, detail="Identity key not configured")
+
+    if not hmac.compare_digest(_IDENTITY_KEY, x_identity_key):
+        raise HTTPException(status_code=401, detail="Invalid identity key")
+
+
+# --- Auth dependency: HMAC for webhooks ---
+
+
+async def verify_hmac_signature(
+    request: Request,
+    x_descope_webhook_s256: str = Header(..., alias="X-Descope-Webhook-S256"),
+) -> None:
+    """Validate HMAC-SHA256 signature on webhook requests.
+
+    AC-3.1.3: Uses DESCOPE_WEBHOOK_SECRET env var and timing-safe comparison.
+    Invalid signature → 401 response.
+    """
+    if not _WEBHOOK_SECRET:
+        logger.error("DESCOPE_WEBHOOK_SECRET not configured — rejecting webhook")
+        raise HTTPException(status_code=401, detail="Webhook secret not configured")
+
+    body = await request.body()
+    expected = hmac.new(_WEBHOOK_SECRET.encode(), body, hashlib.sha256).hexdigest()
+
+    if not hmac.compare_digest(expected, x_descope_webhook_s256):
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+
+# --- Routes ---
+
+
+@router.post("/internal/users/sync", dependencies=[Depends(verify_flow_sync_secret)])
+@limiter.limit(RATE_LIMIT_AUTH)
+async def flow_sync_user(
+    request: Request,
+    body: FlowSyncRequest,
+    service: InboundSyncService = Depends(get_inbound_sync_service),
+):
+    """Receive user sync from Descope Flow HTTP Connector.
+
+    AC-3.1.1: Creates or updates canonical user + IdP link.
+    Returns 201 for new user, 200 for updated user.
+    """
+    result = await service.sync_user_from_flow(
+        user_id=body.user_id,
+        email=body.email,
+        name=body.name,
+        given_name=body.given_name,
+        family_name=body.family_name,
+    )
+
+    status = 201 if (result.is_ok() and result.ok.get("created")) else 200
+    return result_to_response(result, request, status=status)
+
+
+@router.post("/internal/webhooks/descope", dependencies=[Depends(verify_hmac_signature)])
+@limiter.limit(RATE_LIMIT_AUTH)
+async def descope_webhook(
+    request: Request,
+    body: WebhookPayload,
+    service: InboundSyncService = Depends(get_inbound_sync_service),
+):
+    """Handle Descope audit webhook events.
+
+    AC-3.1.2: Routes event by type with idempotent processing.
+    AC-3.1.3: HMAC validation via verify_hmac_signature dependency.
+    """
+    result = await service.process_webhook_event(
+        event_type=body.event_type,
+        data=body.data,
+    )
+    return result_to_response(result, request)
+
+
+@router.get("/internal/identity", dependencies=[Depends(verify_identity_key)])
+@limiter.limit(RATE_LIMIT_AUTH)
+async def resolve_identity(
+    request: Request,
+    sub: str = Query(..., min_length=1, max_length=255, description="External subject identifier from the IdP"),
+    provider: str = Query(..., min_length=1, max_length=255, description="Provider name (e.g. 'descope')"),
+    service: IdentityResolutionService = Depends(get_identity_resolution_service),
+):
+    """Resolve canonical identity from provider + external subject.
+
+    AC-4.3.1: Internal-only endpoint for identity resolution.
+    AC-4.3.4: Shared-secret auth via X-Identity-Key header (JWT excluded on internal prefix).
+    """
+    result = await service.resolve(provider=provider, sub=sub)
+    return result_to_response(result, request)

--- a/backend/app/routers/permissions.py
+++ b/backend/app/routers/permissions.py
@@ -1,14 +1,15 @@
-import logging
+import uuid
 
-import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from expression import Error, Ok
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel, Field
 
+from app.dependencies.identity import get_permission_service
 from app.dependencies.rbac import require_role
+from app.errors.identity import NotFound
+from app.errors.problem_detail import result_to_response
 from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
-from app.services.descope import get_descope_client
-
-logger = logging.getLogger(__name__)
+from app.services.permission import PermissionService
 
 router = APIRouter(tags=["Permissions"])
 
@@ -25,20 +26,15 @@ class UpdatePermissionRequest(BaseModel):
 
 @router.get("/permissions")
 async def list_permissions(
+    request: Request,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    permission_service: PermissionService = Depends(get_permission_service),
 ):
     """List all permission definitions. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        permissions = await client.list_permissions()
-        return {"permissions": permissions}
-    except httpx.HTTPStatusError as exc:
-        body = exc.response.text[:500]
-        logger.warning("Descope API error listing permissions: %s %s", exc.response.status_code, body)
-        raise HTTPException(status_code=502, detail=f"Descope API {exc.response.status_code}: {body}")
-    except httpx.RequestError as exc:
-        logger.error("Network error listing permissions: %s", exc)
-        raise HTTPException(status_code=502, detail=f"Network error: {exc}")
+    result = await permission_service.list_permissions()
+    if result.is_ok():
+        result = Ok({"permissions": result.ok})
+    return result_to_response(result, request)
 
 
 @router.post("/permissions", status_code=201)
@@ -47,20 +43,14 @@ async def create_permission(
     request: Request,
     body: CreatePermissionRequest,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    permission_service: PermissionService = Depends(get_permission_service),
 ):
     """Create a new permission definition. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        await client.create_permission(body.name, body.description)
-        return {"name": body.name, "description": body.description}
-    except httpx.HTTPStatusError as exc:
-        logger.warning("Descope API error creating permission '%s': %s", body.name, exc.response.status_code)
-        if exc.response.status_code in (400, 409):
-            raise HTTPException(status_code=exc.response.status_code, detail="Permission already exists or invalid")
-        raise HTTPException(status_code=502, detail="Failed to create permission in Descope")
-    except httpx.RequestError as exc:
-        logger.error("Network error creating permission '%s': %s", body.name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API")
+    result = await permission_service.create_permission(
+        name=body.name,
+        description=body.description,
+    )
+    return result_to_response(result, request, status=201)
 
 
 @router.put("/permissions/{name}")
@@ -70,20 +60,23 @@ async def update_permission(
     name: str,
     body: UpdatePermissionRequest,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    permission_service: PermissionService = Depends(get_permission_service),
 ):
     """Update a permission definition. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        await client.update_permission(name, body.new_name, body.description)
-        return {"name": body.new_name, "description": body.description}
-    except httpx.HTTPStatusError as exc:
-        logger.warning("Descope API error updating permission '%s': %s", name, exc.response.status_code)
-        if exc.response.status_code in (400, 404, 409):
-            raise HTTPException(status_code=exc.response.status_code, detail="Permission not found or invalid")
-        raise HTTPException(status_code=502, detail="Failed to update permission in Descope")
-    except httpx.RequestError as exc:
-        logger.error("Network error updating permission '%s': %s", name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API")
+    # Resolve permission name to canonical ID
+    perms_result = await permission_service.list_permissions()
+    if perms_result.is_error():
+        return result_to_response(perms_result, request)
+    perm_match = next((p for p in perms_result.ok if p["name"] == name), None)
+    if perm_match is None:
+        return result_to_response(Error(NotFound(message=f"Permission '{name}' not found")), request)
+
+    result = await permission_service.update_permission(
+        permission_id=uuid.UUID(str(perm_match["id"])),
+        name=body.new_name,
+        description=body.description,
+    )
+    return result_to_response(result, request)
 
 
 @router.delete("/permissions/{name}")
@@ -92,17 +85,18 @@ async def delete_permission(
     request: Request,
     name: str,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    permission_service: PermissionService = Depends(get_permission_service),
 ):
     """Delete a permission definition. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        await client.delete_permission(name)
-        return {"status": "deleted", "name": name}
-    except httpx.HTTPStatusError as exc:
-        logger.warning("Descope API error deleting permission '%s': %s", name, exc.response.status_code)
-        if exc.response.status_code in (400, 404):
-            raise HTTPException(status_code=exc.response.status_code, detail="Permission not found or invalid")
-        raise HTTPException(status_code=502, detail="Failed to delete permission in Descope")
-    except httpx.RequestError as exc:
-        logger.error("Network error deleting permission '%s': %s", name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API")
+    # Resolve permission name to canonical ID
+    perms_result = await permission_service.list_permissions()
+    if perms_result.is_error():
+        return result_to_response(perms_result, request)
+    perm_match = next((p for p in perms_result.ok if p["name"] == name), None)
+    if perm_match is None:
+        return result_to_response(Error(NotFound(message=f"Permission '{name}' not found")), request)
+
+    result = await permission_service.delete_permission(
+        permission_id=uuid.UUID(str(perm_match["id"])),
+    )
+    return result_to_response(result, request)

--- a/backend/app/routers/providers.py
+++ b/backend/app/routers/providers.py
@@ -1,0 +1,96 @@
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from app.dependencies.identity import get_provider_service
+from app.dependencies.rbac import require_role
+from app.errors.problem_detail import result_to_response
+from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
+from app.models.identity.provider import ProviderType
+from app.services.provider import ProviderService
+
+router = APIRouter(tags=["Providers"])
+
+
+class RegisterProviderRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    type: ProviderType
+    issuer_url: str = Field(default="", max_length=2048)
+    base_url: str = Field(default="", max_length=2048)
+    capabilities: list[Annotated[str, Field(max_length=50)]] = Field(default_factory=list, max_length=20)
+    config_ref: str = Field(default="", max_length=1024)
+
+
+class DeactivateProviderRequest(BaseModel):
+    active: bool
+
+
+def _parse_uuid(value: str, field_name: str) -> uuid.UUID:
+    """Parse a string to UUID, raising 422 on invalid input."""
+    try:
+        return uuid.UUID(value)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for {field_name}: {value}")
+
+
+@router.get("/providers")
+async def list_providers(
+    request: Request,
+    _operator_roles: list[str] = Depends(require_role("operator")),
+    provider_service: ProviderService = Depends(get_provider_service),
+):
+    """List all registered providers (config_ref excluded)."""
+    result = await provider_service.list_providers()
+    return result_to_response(result, request)
+
+
+@router.post("/providers")
+@limiter.limit(RATE_LIMIT_AUTH)
+async def register_provider(
+    request: Request,
+    body: RegisterProviderRequest,
+    _operator_roles: list[str] = Depends(require_role("operator")),
+    provider_service: ProviderService = Depends(get_provider_service),
+):
+    """Register a new identity provider."""
+    result = await provider_service.register_provider(
+        name=body.name,
+        type=body.type,
+        issuer_url=body.issuer_url,
+        base_url=body.base_url,
+        capabilities=body.capabilities,
+        config_ref=body.config_ref,
+    )
+    return result_to_response(result, request, status=201)
+
+
+@router.patch("/providers/{provider_id}")
+@limiter.limit(RATE_LIMIT_AUTH)
+async def deactivate_provider(
+    request: Request,
+    provider_id: str,
+    body: DeactivateProviderRequest,
+    _operator_roles: list[str] = Depends(require_role("operator")),
+    provider_service: ProviderService = Depends(get_provider_service),
+):
+    """Deactivate a provider (set active=false)."""
+    provider_uuid = _parse_uuid(provider_id, "provider_id")
+    if body.active is not False:
+        raise HTTPException(status_code=422, detail="Only deactivation (active=false) is supported")
+    result = await provider_service.deactivate_provider(provider_id=provider_uuid)
+    return result_to_response(result, request)
+
+
+@router.get("/providers/{provider_id}/capabilities")
+async def get_provider_capabilities(
+    request: Request,
+    provider_id: str,
+    _operator_roles: list[str] = Depends(require_role("operator")),
+    provider_service: ProviderService = Depends(get_provider_service),
+):
+    """Get capabilities for a provider."""
+    provider_uuid = _parse_uuid(provider_id, "provider_id")
+    result = await provider_service.get_provider_capabilities(provider_id=provider_uuid)
+    return result_to_response(result, request)

--- a/backend/app/routers/reconciliation.py
+++ b/backend/app/routers/reconciliation.py
@@ -1,0 +1,31 @@
+"""Reconciliation router — internal endpoint to trigger drift detection/resolution.
+
+POST /api/internal/reconciliation/run — triggers a full reconciliation pass.
+Protected by the same flow sync secret used for other internal endpoints.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from app.dependencies.identity import get_reconciliation_service
+from app.errors.problem_detail import result_to_response
+from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
+from app.routers.internal import verify_flow_sync_secret
+from app.services.reconciliation import ReconciliationService
+
+router = APIRouter(tags=["Internal"])
+
+
+@router.post(
+    "/internal/reconciliation/run",
+    dependencies=[Depends(verify_flow_sync_secret)],
+)
+@limiter.limit(RATE_LIMIT_AUTH)
+async def run_reconciliation(
+    request: Request,
+    service: ReconciliationService = Depends(get_reconciliation_service),
+):
+    """Trigger a full reconciliation between canonical Postgres and Descope."""
+    result = await service.run()
+    return result_to_response(result, request)

--- a/backend/app/routers/roles.py
+++ b/backend/app/routers/roles.py
@@ -1,16 +1,17 @@
-import logging
+import uuid
 from typing import Annotated
 
-import httpx
+from expression import Error, Ok
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from app.dependencies.identity import get_role_service
 from app.dependencies.rbac import require_role
 from app.dependencies.tenant import get_tenant_claims, get_tenant_id
+from app.errors.identity import NotFound
+from app.errors.problem_detail import result_to_response
 from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
-from app.services.descope import get_descope_client
-
-logger = logging.getLogger(__name__)
+from app.services.role import RoleService
 
 router = APIRouter(tags=["Roles"])
 
@@ -31,6 +32,14 @@ class UpdateRoleRequest(BaseModel):
     new_name: str | None = Field(default=None, min_length=1, max_length=200)
     description: str | None = Field(default=None, max_length=1000)
     permission_names: list[Annotated[str, Field(min_length=1)]] | None = Field(default=None, max_length=100)
+
+
+def _parse_uuid(value: str, field_name: str) -> uuid.UUID:
+    """Parse a string to UUID, raising 422 on invalid input."""
+    try:
+        return uuid.UUID(value)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for {field_name}: {value}")
 
 
 # --- Existing user-facing endpoints (must stay before /roles/{name}) ---
@@ -59,24 +68,39 @@ async def assign_roles(
     body: RoleAssignmentRequest,
     current_tenant: str = Depends(get_tenant_id),
     admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """Assign roles to a user in a tenant. Requires owner or admin role."""
     if body.tenant_id != current_tenant:
         raise HTTPException(status_code=403, detail="Cannot manage roles for a different tenant")
     if "owner" in body.role_names and "owner" not in admin_roles:
         raise HTTPException(status_code=403, detail="Only owners can assign the owner role")
-    try:
-        client = get_descope_client()
-        login_id = await client.resolve_login_id(body.user_id)
-        await client.assign_roles(login_id, body.tenant_id, body.role_names)
-        return {"status": "roles_assigned", "user_id": body.user_id, "role_names": body.role_names}
-    except httpx.HTTPStatusError as exc:
-        body = exc.response.text[:500]
-        logger.warning("Descope API error assigning roles: %s %s", exc.response.status_code, body)
-        raise HTTPException(status_code=502, detail=f"Descope API {exc.response.status_code}: {body}") from exc
-    except httpx.RequestError as exc:
-        logger.error("Network error assigning roles: %s", exc)
-        raise HTTPException(status_code=502, detail=f"Network error: {exc}") from exc
+
+    tenant_uuid = _parse_uuid(body.tenant_id, "tenant_id")
+    user_uuid = _parse_uuid(body.user_id, "user_id")
+
+    # Resolve role names to canonical IDs
+    roles_result = await role_service.list_roles()
+    if roles_result.is_error():
+        return result_to_response(roles_result, request)
+    role_map = {r["name"]: r["id"] for r in roles_result.ok}
+
+    for role_name in body.role_names:
+        role_id = role_map.get(role_name)
+        if role_id is None:
+            return result_to_response(Error(NotFound(message=f"Role '{role_name}' not found")), request)
+        result = await role_service.assign_role_to_user(
+            user_id=user_uuid,
+            tenant_id=tenant_uuid,
+            role_id=uuid.UUID(str(role_id)),
+        )
+        if result.is_error():
+            return result_to_response(result, request)
+
+    return result_to_response(
+        Ok({"status": "roles_assigned", "user_id": body.user_id, "role_names": body.role_names}),
+        request,
+    )
 
 
 @router.post("/roles/remove")
@@ -86,24 +110,39 @@ async def remove_roles(
     body: RoleAssignmentRequest,
     current_tenant: str = Depends(get_tenant_id),
     admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """Remove roles from a user in a tenant. Requires owner or admin role."""
     if body.tenant_id != current_tenant:
         raise HTTPException(status_code=403, detail="Cannot manage roles for a different tenant")
     if "owner" in body.role_names and "owner" not in admin_roles:
         raise HTTPException(status_code=403, detail="Only owners can remove the owner role")
-    try:
-        client = get_descope_client()
-        login_id = await client.resolve_login_id(body.user_id)
-        await client.remove_roles(login_id, body.tenant_id, body.role_names)
-        return {"status": "roles_removed", "user_id": body.user_id, "role_names": body.role_names}
-    except httpx.HTTPStatusError as exc:
-        body = exc.response.text[:500]
-        logger.warning("Descope API error removing roles: %s %s", exc.response.status_code, body)
-        raise HTTPException(status_code=502, detail=f"Descope API {exc.response.status_code}: {body}") from exc
-    except httpx.RequestError as exc:
-        logger.error("Network error removing roles: %s", exc)
-        raise HTTPException(status_code=502, detail=f"Network error: {exc}") from exc
+
+    tenant_uuid = _parse_uuid(body.tenant_id, "tenant_id")
+    user_uuid = _parse_uuid(body.user_id, "user_id")
+
+    # Resolve role names to canonical IDs
+    roles_result = await role_service.list_roles()
+    if roles_result.is_error():
+        return result_to_response(roles_result, request)
+    role_map = {r["name"]: r["id"] for r in roles_result.ok}
+
+    for role_name in body.role_names:
+        role_id = role_map.get(role_name)
+        if role_id is None:
+            return result_to_response(Error(NotFound(message=f"Role '{role_name}' not found")), request)
+        result = await role_service.unassign_role_from_user(
+            user_id=user_uuid,
+            tenant_id=tenant_uuid,
+            role_id=uuid.UUID(str(role_id)),
+        )
+        if result.is_error():
+            return result_to_response(result, request)
+
+    return result_to_response(
+        Ok({"status": "roles_removed", "user_id": body.user_id, "role_names": body.role_names}),
+        request,
+    )
 
 
 # --- Role definition CRUD (admin-only) ---
@@ -111,20 +150,15 @@ async def remove_roles(
 
 @router.get("/roles")
 async def list_roles(
+    request: Request,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """List all role definitions. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        roles = await client.list_roles()
-        return {"roles": roles}
-    except httpx.HTTPStatusError as exc:
-        body = exc.response.text[:500]
-        logger.warning("Descope API error listing roles: %s %s", exc.response.status_code, body)
-        raise HTTPException(status_code=502, detail=f"Descope API {exc.response.status_code}: {body}") from exc
-    except httpx.RequestError as exc:
-        logger.error("Network error listing roles: %s", exc)
-        raise HTTPException(status_code=502, detail=f"Network error: {exc}") from exc
+    result = await role_service.list_roles()
+    if result.is_ok():
+        result = Ok({"roles": result.ok})
+    return result_to_response(result, request)
 
 
 @router.post("/roles", status_code=201)
@@ -133,23 +167,15 @@ async def create_role(
     request: Request,
     body: CreateRoleRequest,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """Create a new role definition. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        await client.create_role(body.name, body.description, body.permission_names or None)
-        return {"name": body.name, "description": body.description, "permission_names": body.permission_names}
-    except httpx.HTTPStatusError as exc:
-        resp_body = exc.response.text[:500]
-        logger.warning("Descope API error creating role '%s': %s %s", body.name, exc.response.status_code, resp_body)
-        if exc.response.status_code == 400:
-            raise HTTPException(status_code=400, detail=f"Invalid role data: {resp_body}") from exc
-        if exc.response.status_code == 409:
-            raise HTTPException(status_code=409, detail="Role already exists") from exc
-        raise HTTPException(status_code=502, detail=f"Descope API {exc.response.status_code}: {resp_body}") from exc
-    except httpx.RequestError as exc:
-        logger.error("Network error creating role '%s': %s", body.name, exc)
-        raise HTTPException(status_code=502, detail=f"Network error: {exc}") from exc
+    result = await role_service.create_role(
+        name=body.name,
+        description=body.description,
+        permission_names=body.permission_names or None,
+    )
+    return result_to_response(result, request, status=201)
 
 
 @router.put("/roles/{name}")
@@ -159,25 +185,24 @@ async def update_role(
     name: str,
     body: UpdateRoleRequest,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """Update a role definition. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        effective_name = body.new_name if body.new_name is not None else name
-        await client.update_role(name, effective_name, body.description, body.permission_names)
-        return {"name": effective_name, "description": body.description, "permission_names": body.permission_names}
-    except httpx.HTTPStatusError as exc:
-        logger.warning("Descope API error updating role '%s': %s", name, exc.response.status_code)
-        if exc.response.status_code == 404:
-            raise HTTPException(status_code=404, detail="Role not found") from exc
-        if exc.response.status_code == 409:
-            raise HTTPException(status_code=409, detail="Role name conflict") from exc
-        if exc.response.status_code == 400:
-            raise HTTPException(status_code=400, detail="Invalid role data") from exc
-        raise HTTPException(status_code=502, detail="Failed to update role in Descope") from exc
-    except httpx.RequestError as exc:
-        logger.error("Network error updating role '%s': %s", name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API") from exc
+    # Resolve role name to canonical ID
+    roles_result = await role_service.list_roles()
+    if roles_result.is_error():
+        return result_to_response(roles_result, request)
+    role_match = next((r for r in roles_result.ok if r["name"] == name), None)
+    if role_match is None:
+        return result_to_response(Error(NotFound(message=f"Role '{name}' not found")), request)
+
+    result = await role_service.update_role(
+        role_id=uuid.UUID(str(role_match["id"])),
+        name=body.new_name,
+        description=body.description,
+        permission_names=body.permission_names,
+    )
+    return result_to_response(result, request)
 
 
 @router.delete("/roles/{name}")
@@ -186,19 +211,16 @@ async def delete_role(
     request: Request,
     name: str,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """Delete a role definition. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        await client.delete_role(name)
-        return {"status": "deleted", "name": name}
-    except httpx.HTTPStatusError as exc:
-        logger.warning("Descope API error deleting role '%s': %s", name, exc.response.status_code)
-        if exc.response.status_code == 404:
-            raise HTTPException(status_code=404, detail="Role not found") from exc
-        if exc.response.status_code == 400:
-            raise HTTPException(status_code=400, detail="Invalid role data") from exc
-        raise HTTPException(status_code=502, detail="Failed to delete role in Descope") from exc
-    except httpx.RequestError as exc:
-        logger.error("Network error deleting role '%s': %s", name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API") from exc
+    # Resolve role name to canonical ID
+    roles_result = await role_service.list_roles()
+    if roles_result.is_error():
+        return result_to_response(roles_result, request)
+    role_match = next((r for r in roles_result.ok if r["name"] == name), None)
+    if role_match is None:
+        return result_to_response(Error(NotFound(message=f"Role '{name}' not found")), request)
+
+    result = await role_service.delete_role(role_id=uuid.UUID(str(role_match["id"])))
+    return result_to_response(result, request)

--- a/backend/app/routers/tenants.py
+++ b/backend/app/routers/tenants.py
@@ -1,17 +1,20 @@
 import logging
+import uuid
 
-import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query
+from expression import Ok
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from app.dependencies.auth import get_claims
+from app.dependencies.identity import get_tenant_service
 from app.dependencies.tenant import get_tenant_claims, get_tenant_id
+from app.errors.problem_detail import result_to_response
 from app.models.database import get_async_session
 from app.models.tenant import TenantResource
-from app.services.descope import get_descope_client
+from app.services.tenant import TenantService
 
 logger = logging.getLogger(__name__)
 
@@ -43,14 +46,18 @@ class CreateResourceRequest(BaseModel):
 
 
 @router.post("/tenants")
-async def create_tenant(body: CreateTenantRequest, claims: dict = Depends(require_admin_role)):
-    """Create a new tenant via the Descope Management API. Requires admin/owner role."""
-    client = get_descope_client()
-    result = await client.create_tenant(
+async def create_tenant(
+    request: Request,
+    body: CreateTenantRequest,
+    claims: dict = Depends(require_admin_role),
+    tenant_service: TenantService = Depends(get_tenant_service),
+):
+    """Create a new tenant via the canonical identity service. Requires admin/owner role."""
+    result = await tenant_service.create_tenant(
         name=body.name,
-        self_provisioning_domains=body.self_provisioning_domains,
+        domains=body.self_provisioning_domains,
     )
-    return result
+    return result_to_response(result, request)
 
 
 @router.get("/tenants")
@@ -69,21 +76,19 @@ async def list_user_tenants(tenant_claims: dict = Depends(get_tenant_claims)):
 
 @router.get("/tenants/current")
 async def get_current_tenant(
+    request: Request,
     tenant_id: str = Depends(get_tenant_id),
+    tenant_service: TenantService = Depends(get_tenant_service),
 ):
     """Get the current tenant context from the JWT `dct` claim."""
     try:
-        client = get_descope_client()
-        tenant_info = await client.load_tenant(tenant_id)
-        return {"tenant_id": tenant_id, "tenant": tenant_info}
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            return {"tenant_id": tenant_id, "tenant": None}
-        logger.error("Descope API error loading tenant %s: %s", tenant_id, e)
-        raise HTTPException(status_code=502, detail="Failed to load tenant from Descope")
-    except httpx.RequestError as e:
-        logger.error("Network error loading tenant %s: %s", tenant_id, e)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API")
+        tenant_uuid = uuid.UUID(tenant_id)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for tenant_id: {tenant_id}")
+    result = await tenant_service.get_tenant(tenant_id=tenant_uuid)
+    if result.is_ok():
+        result = Ok({"tenant_id": tenant_id, "tenant": result.ok})
+    return result_to_response(result, request)
 
 
 @router.get("/tenants/{tenant_id}/resources")

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,10 +1,16 @@
+import uuid
+
+from expression import Ok
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, EmailStr, Field
 
+from app.dependencies.identity import get_role_service, get_user_service
 from app.dependencies.rbac import require_role
 from app.dependencies.tenant import get_tenant_id
+from app.errors.problem_detail import result_to_response
 from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
-from app.services.descope import get_descope_client
+from app.services.role import RoleService
+from app.services.user import UserService
 
 router = APIRouter(tags=["Users"])
 
@@ -14,32 +20,27 @@ class InviteUserRequest(BaseModel):
     role_names: list[str] = Field(default_factory=lambda: ["member"])
 
 
-async def _verify_user_tenant(user_id: str, tenant_id: str) -> tuple[dict, str]:
-    """Load a user, verify tenant membership, return (user, login_id).
-
-    Descope mutation endpoints require loginId, but the frontend sends userId.
-    This resolves the loginId from the user object.
-    """
-    client = get_descope_client()
-    user = await client.load_user(user_id)
-    user_tenants = [t.get("tenantId", "") for t in user.get("userTenants", [])] if user.get("userTenants") else []
-    if tenant_id not in user_tenants:
-        raise HTTPException(status_code=403, detail="User does not belong to your tenant")
-    login_ids = user.get("loginIds", [])
-    if not login_ids:
-        raise HTTPException(status_code=400, detail="User has no login identifiers")
-    return user, login_ids[0]
+def _parse_uuid(value: str, field_name: str) -> uuid.UUID:
+    """Parse a string to UUID, raising 422 on invalid input."""
+    try:
+        return uuid.UUID(value)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for {field_name}: {value}")
 
 
 @router.get("/members")
 async def list_members(
+    request: Request,
     tenant_id: str = Depends(get_tenant_id),
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    user_service: UserService = Depends(get_user_service),
 ):
     """List all members in the current tenant."""
-    client = get_descope_client()
-    users = await client.search_tenant_users(tenant_id)
-    return {"members": users}
+    tenant_uuid = _parse_uuid(tenant_id, "tenant_id")
+    result = await user_service.search_users(tenant_id=tenant_uuid)
+    if result.is_ok():
+        result = Ok({"members": result.ok})
+    return result_to_response(result, request)
 
 
 @router.post("/members/invite")
@@ -49,49 +50,101 @@ async def invite_member(
     body: InviteUserRequest,
     tenant_id: str = Depends(get_tenant_id),
     caller_roles: list[str] = Depends(require_role("owner", "admin")),
+    user_service: UserService = Depends(get_user_service),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """Invite a user to the current tenant by email with specified roles."""
     if "owner" in body.role_names and "owner" not in caller_roles:
         raise HTTPException(status_code=403, detail="Only owners can assign the owner role")
-    client = get_descope_client()
-    user = await client.invite_user(body.email, tenant_id, body.role_names)
-    return {"status": "invited", "email": body.email, "user": user}
+    tenant_uuid = _parse_uuid(tenant_id, "tenant_id")
+    result = await user_service.create_user(
+        tenant_id=tenant_uuid,
+        email=body.email,
+        user_name=body.email,
+    )
+    if result.is_error():
+        return result_to_response(result, request)
+
+    user_data = result.ok
+
+    # Assign requested roles to the new user (best-effort: user is created regardless)
+    if body.role_names:
+        user_uuid = uuid.UUID(str(user_data["id"]))
+        roles_result = await role_service.list_roles()
+        if roles_result.is_ok():
+            role_map = {r["name"]: r["id"] for r in roles_result.ok}
+            for role_name in body.role_names:
+                role_id = role_map.get(role_name)
+                if role_id is not None:
+                    assign_result = await role_service.assign_role_to_user(
+                        user_id=user_uuid,
+                        tenant_id=tenant_uuid,
+                        role_id=uuid.UUID(str(role_id)),
+                    )
+                    if assign_result.is_error():
+                        break  # stop on first failure, user still created
+
+    return result_to_response(
+        Ok({"status": "invited", "email": body.email, "user": user_data}),
+        request,
+    )
 
 
 @router.post("/members/{user_id}/deactivate")
 async def deactivate_member(
+    request: Request,
     user_id: str,
     tenant_id: str = Depends(get_tenant_id),
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Deactivate a member. They will not be able to log in."""
-    _, login_id = await _verify_user_tenant(user_id, tenant_id)
-    client = get_descope_client()
-    await client.update_user_status(login_id, "disabled")
-    return {"status": "deactivated", "user_id": user_id}
+    tenant_uuid = _parse_uuid(tenant_id, "tenant_id")
+    user_uuid = _parse_uuid(user_id, "user_id")
+    result = await user_service.deactivate_user(
+        tenant_id=tenant_uuid,
+        user_id=user_uuid,
+    )
+    if result.is_ok():
+        result = Ok({"status": "deactivated", "user_id": user_id})
+    return result_to_response(result, request)
 
 
 @router.post("/members/{user_id}/activate")
 async def activate_member(
+    request: Request,
     user_id: str,
     tenant_id: str = Depends(get_tenant_id),
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Reactivate a previously deactivated member."""
-    _, login_id = await _verify_user_tenant(user_id, tenant_id)
-    client = get_descope_client()
-    await client.update_user_status(login_id, "enabled")
-    return {"status": "activated", "user_id": user_id}
+    tenant_uuid = _parse_uuid(tenant_id, "tenant_id")
+    user_uuid = _parse_uuid(user_id, "user_id")
+    result = await user_service.activate_user(
+        tenant_id=tenant_uuid,
+        user_id=user_uuid,
+    )
+    if result.is_ok():
+        result = Ok({"status": "activated", "user_id": user_id})
+    return result_to_response(result, request)
 
 
 @router.delete("/members/{user_id}")
 async def remove_member(
+    request: Request,
     user_id: str,
     tenant_id: str = Depends(get_tenant_id),
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Remove a member from the current tenant."""
-    _, login_id = await _verify_user_tenant(user_id, tenant_id)
-    client = get_descope_client()
-    await client.remove_user_from_tenant(login_id, tenant_id)
-    return {"status": "removed", "user_id": user_id}
+    tenant_uuid = _parse_uuid(tenant_id, "tenant_id")
+    user_uuid = _parse_uuid(user_id, "user_id")
+    result = await user_service.remove_user_from_tenant(
+        tenant_id=tenant_uuid,
+        user_id=user_uuid,
+    )
+    if result.is_ok():
+        result = Ok({"status": "removed", "user_id": user_id})
+    return result_to_response(result, request)

--- a/backend/app/services/adapters/base.py
+++ b/backend/app/services/adapters/base.py
@@ -46,6 +46,17 @@ class IdentityProviderAdapter(ABC):
         user_id: uuid.UUID,
         tenant_id: uuid.UUID,
         role_id: uuid.UUID,
+        data: dict | None = None,
+    ) -> Result[None, SyncError]: ...
+
+    @abstractmethod
+    async def delete_role_assignment(
+        self,
+        *,
+        user_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        role_id: uuid.UUID,
+        data: dict | None = None,
     ) -> Result[None, SyncError]: ...
 
     @abstractmethod

--- a/backend/app/services/adapters/descope.py
+++ b/backend/app/services/adapters/descope.py
@@ -157,16 +157,78 @@ class DescopeSyncAdapter(IdentityProviderAdapter):
         user_id: uuid.UUID,
         tenant_id: uuid.UUID,
         role_id: uuid.UUID,
+        data: dict | None = None,
     ) -> Result[None, SyncError]:
-        """Sync role assignment to Descope.
+        """Sync role assignment to Descope via assign_roles API.
 
-        Placeholder — full implementation in Story 2.2.
+        Expected data keys:
+            role_name: str — Descope role name (required for correct API call)
+            login_id: str — Descope loginId/email (optional, falls back to str(user_id))
         """
         with tracer.start_as_current_span("descope.sync_role_assignment") as span:
             span.set_attribute("user.id", str(user_id))
             span.set_attribute("tenant.id", str(tenant_id))
             span.set_attribute("role.id", str(role_id))
-            return Ok(None)
+            try:
+                data = data or {}
+                role_name = data.get("role_name", str(role_id))
+                login_id = data.get("login_id", str(user_id))
+                await self._client.assign_roles(login_id, str(tenant_id), [role_name])
+                return Ok(None)
+            except Exception as exc:
+                logger.warning(
+                    "Descope sync_role_assignment failed for user %s: %s",
+                    user_id,
+                    exc,
+                )
+                return Error(
+                    SyncError(
+                        message=str(exc),
+                        operation="sync_role_assignment",
+                        context={
+                            "user_id": str(user_id),
+                            "tenant_id": str(tenant_id),
+                            "role_id": str(role_id),
+                        },
+                    )
+                )
+
+    async def delete_role_assignment(
+        self,
+        *,
+        user_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        role_id: uuid.UUID,
+        data: dict | None = None,
+    ) -> Result[None, SyncError]:
+        """Remove a role assignment in Descope via remove_roles API."""
+        with tracer.start_as_current_span("descope.delete_role_assignment") as span:
+            span.set_attribute("user.id", str(user_id))
+            span.set_attribute("tenant.id", str(tenant_id))
+            span.set_attribute("role.id", str(role_id))
+            try:
+                data = data or {}
+                role_name = data.get("role_name", str(role_id))
+                login_id = data.get("login_id", str(user_id))
+                await self._client.remove_roles(login_id, str(tenant_id), [role_name])
+                return Ok(None)
+            except Exception as exc:
+                logger.warning(
+                    "Descope delete_role_assignment failed for user %s: %s",
+                    user_id,
+                    exc,
+                )
+                return Error(
+                    SyncError(
+                        message=str(exc),
+                        operation="delete_role_assignment",
+                        context={
+                            "user_id": str(user_id),
+                            "tenant_id": str(tenant_id),
+                            "role_id": str(role_id),
+                        },
+                    )
+                )
 
     async def delete_user(self, *, user_id: uuid.UUID) -> Result[None, SyncError]:
         """Disable user in Descope (canonical delete maps to Descope disable).

--- a/backend/app/services/adapters/noop.py
+++ b/backend/app/services/adapters/noop.py
@@ -33,6 +33,17 @@ class NoOpSyncAdapter(IdentityProviderAdapter):
         user_id: uuid.UUID,
         tenant_id: uuid.UUID,
         role_id: uuid.UUID,
+        data: dict | None = None,
+    ) -> Result[None, SyncError]:
+        return Ok(None)
+
+    async def delete_role_assignment(
+        self,
+        *,
+        user_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        role_id: uuid.UUID,
+        data: dict | None = None,
     ) -> Result[None, SyncError]:
         return Ok(None)
 

--- a/backend/app/services/cache_invalidation.py
+++ b/backend/app/services/cache_invalidation.py
@@ -1,0 +1,150 @@
+"""CacheInvalidationPublisher — fire-and-forget Redis pub/sub for cache invalidation.
+
+Publishes change events to Redis so downstream caches can invalidate stale entries.
+All publish operations are best-effort: failures are logged as errors and never
+propagate to the caller (AC-3.3.2).
+
+Channel: ``identity:changes``
+
+Event schema (JSON on the wire)::
+
+    {
+        "entity_type": "user" | "role" | "permission" | "tenant",
+        "entity_id": "<uuid>",
+        "operation": "create" | "update" | "delete" | "deactivate"
+                    | "activate" | "assign" | "unassign" | "sync" | "reconcile",
+        "tenant_id": "<uuid>" | null,
+        "timestamp": "<ISO-8601 UTC>"
+    }
+
+Key patterns for consumers:
+- ``identity:changes`` — single channel for all entity mutations
+- ``entity_type`` + ``entity_id`` — identify the affected record
+- ``tenant_id`` — scope invalidation to a tenant (null for global entities)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
+logger = logging.getLogger(__name__)
+
+CHANNEL = "identity:changes"
+
+
+class CacheInvalidationPublisher:
+    """Best-effort Redis pub/sub publisher for identity change events.
+
+    AC-3.3.1: Called after every repo.commit() in write methods.
+    AC-3.3.2: All exceptions caught, logged as errors, never raised.
+    AC-3.3.3: Schema documented above; channel = ``identity:changes``.
+    """
+
+    def __init__(self, redis_client: Redis | None = None) -> None:
+        self._redis = redis_client
+
+    async def publish(
+        self,
+        *,
+        entity_type: str,
+        entity_id: UUID | str,
+        operation: str,
+        tenant_id: UUID | str | None = None,
+    ) -> None:
+        """Publish a single change event. Silent on failure (AC-3.3.2)."""
+        if self._redis is None:
+            return
+        event = self._build_event(entity_type, entity_id, operation, tenant_id)
+        try:
+            await self._redis.publish(CHANNEL, json.dumps(event))
+        except Exception:
+            logger.error("Redis publish failed for %s/%s", entity_type, entity_id, exc_info=True)
+
+    async def publish_batch(
+        self,
+        *,
+        operation: str,
+        stats: dict[str, Any],
+    ) -> None:
+        """Publish a single batch event for reconciliation. Silent on failure."""
+        if self._redis is None:
+            return
+        event = self._build_event("batch", "reconciliation", operation, None)
+        event["stats"] = stats
+        try:
+            await self._redis.publish(CHANNEL, json.dumps(event))
+        except Exception:
+            logger.error("Redis publish failed for batch/%s", operation, exc_info=True)
+
+    @staticmethod
+    def _build_event(
+        entity_type: str,
+        entity_id: UUID | str,
+        operation: str,
+        tenant_id: UUID | str | None,
+    ) -> dict[str, Any]:
+        return {
+            "entity_type": entity_type,
+            "entity_id": str(entity_id),
+            "operation": operation,
+            "tenant_id": str(tenant_id) if tenant_id is not None else None,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton (mirrors descope.py pattern)
+# ---------------------------------------------------------------------------
+_publisher: CacheInvalidationPublisher | None = None
+_NOOP_PUBLISHER = CacheInvalidationPublisher()
+
+
+def get_cache_publisher() -> CacheInvalidationPublisher:
+    """Return the singleton CacheInvalidationPublisher.
+
+    Returns a no-op publisher (redis_client=None) if not initialised,
+    so callers never need to null-check.
+    """
+    if _publisher is not None:
+        return _publisher
+    logger.warning("get_cache_publisher() called before init_cache_publisher() — returning no-op")
+    return _NOOP_PUBLISHER
+
+
+def init_cache_publisher(redis_client: Redis | None = None) -> CacheInvalidationPublisher:
+    """Initialise the singleton publisher during app lifespan."""
+    global _publisher  # noqa: PLW0603
+    if _publisher is not None:
+        logger.warning("init_cache_publisher() called twice — replacing existing publisher")
+    _publisher = CacheInvalidationPublisher(redis_client=redis_client)
+    return _publisher
+
+
+def shutdown_cache_publisher() -> None:
+    """Clear the singleton on shutdown."""
+    global _publisher  # noqa: PLW0603
+    _publisher = None
+
+
+# ---------------------------------------------------------------------------
+# Redis client singleton (shared between publisher and identity resolution)
+# ---------------------------------------------------------------------------
+_redis_client: Redis | None = None
+
+
+def get_redis_client() -> Redis | None:
+    """Return the shared Redis client, or None if not initialised."""
+    return _redis_client
+
+
+def set_redis_client(client: Redis | None) -> None:
+    """Store the shared Redis client during app lifespan."""
+    global _redis_client  # noqa: PLW0603
+    _redis_client = client

--- a/backend/app/services/identity_resolution.py
+++ b/backend/app/services/identity_resolution.py
@@ -1,0 +1,317 @@
+"""IdentityResolutionService — resolve canonical user identity from provider + subject.
+
+AC-4.3.1: Identity resolution endpoint logic.
+AC-4.3.2: Redis cache with configurable TTL.
+AC-4.3.3: Cache invalidation subscriber on ``identity:changes`` pub/sub channel.
+
+Middle layer of onion architecture: orchestrates repositories for read-only lookups.
+All methods return Result[T, IdentityError]. OTel spans on every method.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import uuid
+from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
+
+from expression import Error, Ok, Result
+from opentelemetry import trace
+
+from app.errors.identity import IdentityError, NotFound
+from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.role import RoleRepository
+from app.repositories.tenant import TenantRepository
+from app.repositories.user import UserRepository
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+try:
+    IDENTITY_CACHE_TTL = int(os.getenv("IDENTITY_CACHE_TTL", "300"))
+except (ValueError, TypeError):
+    logger.warning("Invalid IDENTITY_CACHE_TTL value, using default 300s")
+    IDENTITY_CACHE_TTL = 300
+
+
+class IdentityResolutionService:
+    """Resolve canonical user identity from IdP provider name + external subject.
+
+    Read-only service — no write-through sync. Caches results in Redis when available.
+    """
+
+    def __init__(
+        self,
+        *,
+        user_repository: UserRepository,
+        idp_link_repository: IdPLinkRepository,
+        provider_repository: ProviderRepository,
+        assignment_repository: UserTenantRoleRepository,
+        role_repository: RoleRepository,
+        tenant_repository: TenantRepository,
+        redis_client: Redis | None = None,
+    ) -> None:
+        self._user_repository = user_repository
+        self._idp_link_repository = idp_link_repository
+        self._provider_repository = provider_repository
+        self._assignment_repository = assignment_repository
+        self._role_repository = role_repository
+        self._tenant_repository = tenant_repository
+        self._redis = redis_client
+
+    @staticmethod
+    def _cache_key(provider: str, sub: str) -> str:
+        """Build a collision-safe cache key by URL-encoding dynamic parts."""
+        return f"identity:{quote(provider, safe='')}:{quote(sub, safe='')}"
+
+    async def resolve(
+        self,
+        *,
+        provider: str,
+        sub: str,
+    ) -> Result[dict[str, Any], IdentityError]:
+        """Resolve canonical identity for a provider name + external subject.
+
+        Returns user profile, roles with permissions, tenant memberships, and linked IdPs.
+        """
+        with tracer.start_as_current_span(
+            "IdentityResolutionService.resolve",
+            attributes={"identity.provider": provider, "identity.sub": sub},
+        ):
+            # Try cache first (AC-4.3.2)
+            cache_key = self._cache_key(provider, sub)
+            cached = await self._cache_get(cache_key)
+            if cached is not None:
+                return Ok(cached)
+
+            # Look up provider by name
+            provider_entity = await self._provider_repository.get_by_name(provider)
+            if provider_entity is None:
+                return Error(NotFound(f"Provider '{provider}' not found"))
+
+            # Find IdP link by provider name + external sub
+            link = await self._idp_link_repository.get_by_provider_name_and_sub(provider, sub)
+            if link is None:
+                return Error(NotFound(f"No identity found for provider '{provider}' with sub '{sub}'"))
+
+            # Load the canonical user (should always exist via FK)
+            user = await self._user_repository.get(link.user_id)
+            if user is None:
+                return Error(NotFound("Linked user not found"))
+
+            # Build the full identity payload
+            payload = await self._build_identity_payload(user, link.user_id)
+
+            # Cache the result (AC-4.3.2)
+            await self._cache_set(cache_key, payload, link.user_id)
+
+            return Ok(payload)
+
+    async def _build_identity_payload(
+        self,
+        user: Any,
+        user_id: uuid.UUID,
+    ) -> dict[str, Any]:
+        """Build the canonical identity payload with roles, permissions, and memberships."""
+        # Get all role assignments for this user
+        assignments = await self._assignment_repository.list_by_user(user_id)
+
+        # Group assignments by tenant and load role details + permissions
+        roles: list[dict[str, Any]] = []
+        tenant_ids: set[uuid.UUID] = set()
+
+        for assignment in assignments:
+            tenant_ids.add(assignment.tenant_id)
+            role = await self._role_repository.get(assignment.role_id)
+            if role is None:
+                continue
+            permissions = await self._role_repository.get_permissions(assignment.role_id)
+            roles.append(
+                {
+                    "tenant_id": str(assignment.tenant_id),
+                    "role_name": role.name,
+                    "permissions": [p.name for p in permissions],
+                }
+            )
+
+        # Load tenant details for memberships
+        tenant_memberships: list[dict[str, str]] = []
+        for tid in tenant_ids:
+            tenant = await self._tenant_repository.get(tid)
+            if tenant is not None:
+                tenant_memberships.append(
+                    {
+                        "tenant_id": str(tenant.id),
+                        "tenant_name": tenant.name,
+                    }
+                )
+
+        # Load all linked IdPs for this user
+        links = await self._idp_link_repository.get_by_user(user_id)
+        linked_providers: list[dict[str, str]] = []
+        for lnk in links:
+            prov = await self._provider_repository.get(lnk.provider_id)
+            provider_name = prov.name if prov else "unknown"
+            linked_providers.append(
+                {
+                    "provider_name": provider_name,
+                    "external_sub": lnk.external_sub,
+                }
+            )
+
+        return {
+            "user": {
+                "id": str(user.id),
+                "email": user.email,
+                "user_name": user.user_name,
+                "given_name": user.given_name,
+                "family_name": user.family_name,
+                "status": user.status.value if hasattr(user.status, "value") else str(user.status),
+            },
+            "roles": roles,
+            "tenant_memberships": tenant_memberships,
+            "linked_idps": linked_providers,
+        }
+
+    # ---- Redis cache helpers (AC-4.3.2) ----
+
+    async def _cache_get(self, key: str) -> dict[str, Any] | None:
+        """Read from Redis cache. Returns None on miss or Redis failure."""
+        if self._redis is None:
+            return None
+        try:
+            data = await self._redis.get(key)
+            if data is not None:
+                return json.loads(data)
+        except Exception:
+            logger.warning("Redis cache read failed for key %s", key, exc_info=True)
+        return None
+
+    async def _cache_set(self, key: str, payload: dict[str, Any], user_id: uuid.UUID) -> None:
+        """Write to Redis cache with TTL. Also updates reverse index and master set."""
+        if self._redis is None:
+            return
+        try:
+            serialized = json.dumps(payload)
+            pipe = self._redis.pipeline(transaction=True)
+            pipe.setex(key, IDENTITY_CACHE_TTL, serialized)
+            # Reverse index: identity:user:{user_id} → set of cache keys
+            reverse_key = f"identity:user:{user_id}"
+            pipe.sadd(reverse_key, key)
+            # 2x TTL on reverse index to outlive the cache entries it tracks
+            pipe.expire(reverse_key, IDENTITY_CACHE_TTL * 2)
+            # Master set for bulk invalidation
+            pipe.sadd("identity:all-keys", key)
+            pipe.expire("identity:all-keys", IDENTITY_CACHE_TTL * 2)
+            await pipe.execute()
+        except Exception:
+            logger.warning("Redis cache write failed for key %s", key, exc_info=True)
+
+
+# ---- Cache invalidation subscriber (AC-4.3.3) ----
+
+
+async def run_cache_invalidation_subscriber(redis_client: Redis) -> None:
+    """Subscribe to ``identity:changes`` and invalidate relevant cache entries.
+
+    Runs as a background asyncio task. Graceful shutdown via task cancellation.
+    Reconnects with exponential backoff on transient Redis errors.
+    """
+    backoff = 1
+    max_backoff = 60
+
+    while True:
+        pubsub = redis_client.pubsub()
+        try:
+            await pubsub.subscribe("identity:changes")
+            logger.info("Cache invalidation subscriber started on identity:changes")
+            backoff = 1  # reset on successful connection
+
+            async for message in pubsub.listen():
+                if message["type"] != "message":
+                    continue
+                try:
+                    event = json.loads(message["data"])
+                    await _handle_invalidation_event(redis_client, event)
+                except Exception:
+                    logger.warning("Cache invalidation handler failed", exc_info=True)
+        except asyncio.CancelledError:
+            logger.info("Cache invalidation subscriber shutting down")
+            try:
+                await pubsub.unsubscribe("identity:changes")
+                await pubsub.aclose()
+            except Exception:
+                logger.warning("Cache invalidation subscriber cleanup failed", exc_info=True)
+            return
+        except Exception:
+            logger.warning(
+                "Cache invalidation subscriber error, reconnecting in %ds",
+                backoff,
+                exc_info=True,
+            )
+            try:
+                await pubsub.unsubscribe("identity:changes")
+                await pubsub.aclose()
+            except Exception:
+                logger.debug("Subscriber cleanup failed during reconnect", exc_info=True)
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, max_backoff)
+
+
+async def _handle_invalidation_event(redis_client: Redis, event: dict[str, Any]) -> None:
+    """Invalidate cache entries based on a change event."""
+    entity_type = event.get("entity_type", "")
+    entity_id = event.get("entity_id", "")
+
+    if entity_type == "user":
+        # Validate entity_id is a well-formed UUID
+        try:
+            uuid.UUID(entity_id)
+        except (ValueError, AttributeError):
+            logger.warning("Invalid entity_id in user invalidation event: %s", entity_id)
+            return
+
+        # Delete all cache entries for this user via reverse index
+        reverse_key = f"identity:user:{entity_id}"
+        keys = await redis_client.smembers(reverse_key)
+        if keys:
+            pipe = redis_client.pipeline(transaction=True)
+            for key in keys:
+                key_str = key.decode() if isinstance(key, bytes) else key
+                pipe.delete(key_str)
+                pipe.srem("identity:all-keys", key_str)
+            pipe.delete(reverse_key)
+            await pipe.execute()
+            logger.debug("Invalidated %d cache entries for user %s", len(keys), entity_id)
+    elif entity_type in ("role", "permission", "tenant", "batch"):
+        # Broad invalidation: delete all identity cache keys + reverse indexes
+        all_keys = await redis_client.smembers("identity:all-keys")
+        if all_keys:
+            pipe = redis_client.pipeline(transaction=True)
+            for key in all_keys:
+                key_str = key.decode() if isinstance(key, bytes) else key
+                # Only delete keys within the identity namespace
+                if key_str.startswith("identity:"):
+                    pipe.delete(key_str)
+            # Scan for reverse-index keys and delete them too
+            reverse_pattern = "identity:user:*"
+            cursor = 0
+            reverse_keys: list[str] = []
+            while True:
+                cursor, found = await redis_client.scan(cursor, match=reverse_pattern, count=100)
+                reverse_keys.extend(k.decode() if isinstance(k, bytes) else k for k in found)
+                if cursor == 0:
+                    break
+            for rk in reverse_keys:
+                pipe.delete(rk)
+            pipe.delete("identity:all-keys")
+            await pipe.execute()
+            logger.debug("Broad invalidation: deleted %d cache entries for %s change", len(all_keys), entity_type)

--- a/backend/app/services/idp_link.py
+++ b/backend/app/services/idp_link.py
@@ -1,0 +1,123 @@
+"""IdPLinkService — domain orchestration for canonical IdP link operations.
+
+Middle layer of onion architecture: orchestrates IdPLinkRepository, UserRepository,
+and ProviderRepository (data access). All methods return Result[T, IdentityError].
+OTel spans on every method.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from expression import Error, Ok, Result
+from opentelemetry import trace
+
+from app.errors.identity import Conflict, IdentityError, NotFound
+from app.models.identity.user import IdPLink
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.user import RepositoryConflictError, UserRepository
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+
+class IdPLinkService:
+    """Domain service for IdP link operations.
+
+    Orchestrates IdPLinkRepository, UserRepository, and ProviderRepository (inner).
+    Contains NO direct SQLAlchemy imports — uses repository methods only.
+    """
+
+    def __init__(
+        self,
+        *,
+        repository: IdPLinkRepository,
+        user_repository: UserRepository,
+        provider_repository: ProviderRepository,
+    ) -> None:
+        self._repository = repository
+        self._user_repository = user_repository
+        self._provider_repository = provider_repository
+
+    async def create_idp_link(
+        self,
+        *,
+        user_id: uuid.UUID,
+        provider_id: uuid.UUID,
+        external_sub: str,
+        external_email: str = "",
+        metadata: dict | None = None,
+    ) -> Result[dict, IdentityError]:
+        """Create a new IdP link between a user and an external identity.
+
+        AC-4.1.1: validates user and provider exist, enforces unique constraints.
+        """
+        with tracer.start_as_current_span("IdPLinkService.create_idp_link") as span:
+            span.set_attribute("user.id", str(user_id))
+            span.set_attribute("provider.id", str(provider_id))
+
+            user = await self._user_repository.get(user_id)
+            if user is None:
+                return Error(NotFound(message=f"User '{user_id}' not found"))
+
+            provider = await self._provider_repository.get(provider_id)
+            if provider is None:
+                return Error(NotFound(message=f"Provider '{provider_id}' not found"))
+
+            link = IdPLink(
+                user_id=user_id,
+                provider_id=provider_id,
+                external_sub=external_sub,
+                external_email=external_email,
+                metadata_=metadata,
+            )
+            try:
+                link = await self._repository.create(link)
+            except RepositoryConflictError:
+                msg = f"IdP link already exists for user '{user_id}' with provider '{provider_id}'"
+                return Error(Conflict(message=msg))
+
+            result_dict = link.model_dump()
+            await self._repository.commit()
+
+            return Ok(result_dict)
+
+    async def get_user_idp_links(
+        self,
+        *,
+        user_id: uuid.UUID,
+    ) -> Result[list[dict], IdentityError]:
+        """Retrieve all IdP links for a user.
+
+        AC-4.1.1: delegates to IdPLinkRepository.get_by_user.
+        """
+        with tracer.start_as_current_span("IdPLinkService.get_user_idp_links") as span:
+            span.set_attribute("user.id", str(user_id))
+
+            links = await self._repository.get_by_user(user_id)
+            return Ok([link.model_dump() for link in links])
+
+    async def delete_idp_link(
+        self,
+        *,
+        link_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Delete an IdP link by ID, scoped to the owning user.
+
+        AC-4.1.1: returns NotFound if link does not exist or belongs to another user.
+        """
+        with tracer.start_as_current_span("IdPLinkService.delete_idp_link") as span:
+            span.set_attribute("link.id", str(link_id))
+            span.set_attribute("user.id", str(user_id))
+
+            link = await self._repository.get(link_id)
+            if link is None or link.user_id != user_id:
+                return Error(NotFound(message=f"IdP link '{link_id}' not found for user '{user_id}'"))
+
+            await self._repository.delete(link_id)
+            await self._repository.commit()
+
+            return Ok({"status": "deleted", "link_id": str(link_id)})

--- a/backend/app/services/inbound_sync.py
+++ b/backend/app/services/inbound_sync.py
@@ -1,0 +1,313 @@
+"""InboundSyncService — domain orchestration for inbound identity sync.
+
+Handles Descope Flow HTTP Connector sign-up sync and webhook event processing.
+Middle layer of onion architecture: orchestrates repositories for data access.
+All methods return Result[T, IdentityError]. OTel spans on every method.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+
+from expression import Error, Ok, Result
+from opentelemetry import trace
+
+from app.errors.identity import Conflict, IdentityError, NotFound, ValidationError
+from app.models.identity.provider import ProviderType
+from app.models.identity.user import IdPLink, User, UserStatus
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.user import RepositoryConflictError, UserRepository
+from app.services.cache_invalidation import CacheInvalidationPublisher
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+
+def _hash_email(email: str) -> str:
+    """One-way hash for OTel span attributes — avoids PII in traces."""
+    return hashlib.sha256(email.encode()).hexdigest()[:12]
+
+
+class InboundSyncService:
+    """Domain service for inbound identity synchronisation.
+
+    Orchestrates UserRepository, IdPLinkRepository, and ProviderRepository.
+    Contains NO direct SQLAlchemy imports — uses repository methods only.
+    """
+
+    def __init__(
+        self,
+        *,
+        user_repository: UserRepository,
+        idp_link_repository: IdPLinkRepository,
+        provider_repository: ProviderRepository,
+        publisher: CacheInvalidationPublisher | None = None,
+    ) -> None:
+        self._user_repo = user_repository
+        self._link_repo = idp_link_repository
+        self._provider_repo = provider_repository
+        self._publisher = publisher
+
+    async def sync_user_from_flow(
+        self,
+        *,
+        user_id: str,
+        email: str,
+        name: str | None = None,
+        given_name: str | None = None,
+        family_name: str | None = None,
+    ) -> Result[dict, IdentityError]:
+        """Sync a user from Descope Flow HTTP Connector.
+
+        AC-3.1.1: Create/update canonical User + create IdP link.
+        Returns 201-equivalent dict (created=True) or 200-equivalent (created=False).
+        """
+        with tracer.start_as_current_span("InboundSyncService.sync_user_from_flow") as span:
+            span.set_attribute("descope.user_id", user_id)
+            span.set_attribute("user.email_hash", _hash_email(email))
+
+            if not email:
+                return Error(ValidationError(message="Email is required for flow sync"))
+
+            if not user_id:
+                return Error(ValidationError(message="user_id is required for flow sync"))
+
+            # Resolve provider
+            provider = await self._provider_repo.get_by_type(ProviderType.descope)
+            if provider is None:
+                return Error(NotFound(message="Descope provider not configured"))
+
+            # Derive name fields
+            resolved_given = given_name or ""
+            resolved_family = family_name or ""
+            if not resolved_given and not resolved_family and name:
+                parts = name.split(" ", 1)
+                resolved_given = parts[0]
+                resolved_family = parts[1] if len(parts) > 1 else ""
+
+            # Check for existing IdP link (idempotency)
+            existing_link = await self._link_repo.get_by_provider_and_sub(provider_id=provider.id, external_sub=user_id)
+
+            if existing_link is not None:
+                # Update existing user
+                existing_user = await self._user_repo.get(existing_link.user_id)
+                if existing_user is None:
+                    return Error(NotFound(message="Linked user not found for IdP link"))
+
+                if email:
+                    existing_user.email = email
+                if resolved_given:
+                    existing_user.given_name = resolved_given
+                if resolved_family:
+                    existing_user.family_name = resolved_family
+
+                try:
+                    await self._user_repo.update(existing_user)
+                except RepositoryConflictError:
+                    return Error(Conflict(message=f"Email '{email}' conflicts with another user"))
+
+                try:
+                    await self._user_repo.commit()
+                except Exception:
+                    logger.exception("Commit failed during flow sync update")
+                    return Error(Conflict(message="Failed to persist user update"))
+
+                if self._publisher:
+                    await self._publisher.publish(entity_type="user", entity_id=existing_user.id, operation="update")
+
+                logger.info("Flow sync: updated existing user %s", existing_user.id)
+                return Ok({"user": existing_user.model_dump(), "created": False})
+
+            # Check for existing user by email (upsert)
+            existing_user = await self._user_repo.get_by_email(email)
+            created = False
+
+            if existing_user is None:
+                # Create new user
+                new_user = User(
+                    email=email,
+                    user_name=email,
+                    given_name=resolved_given,
+                    family_name=resolved_family,
+                    status=UserStatus.active,
+                )
+                try:
+                    new_user = await self._user_repo.create(new_user)
+                except RepositoryConflictError:
+                    return Error(Conflict(message=f"User with email '{email}' already exists"))
+                existing_user = new_user
+                created = True
+
+            # Create IdP link
+            link = IdPLink(
+                user_id=existing_user.id,
+                provider_id=provider.id,
+                external_sub=user_id,
+                external_email=email,
+            )
+            try:
+                await self._link_repo.create(link)
+            except RepositoryConflictError:
+                return Error(Conflict(message="IdP link already exists for provider/subject"))
+
+            try:
+                await self._user_repo.commit()
+            except Exception:
+                logger.exception("Commit failed during flow sync create/link")
+                return Error(Conflict(message="Failed to persist user and link"))
+
+            if self._publisher:
+                await self._publisher.publish(
+                    entity_type="user",
+                    entity_id=existing_user.id,
+                    operation="create" if created else "update",
+                )
+
+            action = "created" if created else "linked"
+            logger.info("Flow sync: %s user %s", action, existing_user.id)
+            return Ok({"user": existing_user.model_dump(), "created": created})
+
+    async def process_webhook_event(
+        self,
+        *,
+        event_type: str,
+        data: dict,
+    ) -> Result[dict, IdentityError]:
+        """Process a Descope audit webhook event.
+
+        AC-3.1.2: Routes event by type, idempotent processing.
+        Unknown event types → log warning, return success.
+        """
+        with tracer.start_as_current_span("InboundSyncService.process_webhook_event") as span:
+            span.set_attribute("webhook.event_type", event_type)
+
+            handler_map = {
+                "user.created": self._handle_user_created,
+                "user.updated": self._handle_user_updated,
+                "user.deleted": self._handle_user_deleted,
+            }
+
+            handler = handler_map.get(event_type)
+            if handler is None:
+                logger.warning("Unknown webhook event type: %s — ignoring", event_type)
+                return Ok({"status": "ignored", "event_type": event_type})
+
+            return await handler(data)
+
+    async def _handle_user_created(self, data: dict) -> Result[dict, IdentityError]:
+        """Handle user.created webhook — upsert user + create IdP link."""
+        email = data.get("email", "")
+        external_sub = data.get("user_id", "")
+
+        if not isinstance(email, str) or not isinstance(external_sub, str) or not email or not external_sub:
+            logger.warning("user.created webhook missing email or user_id, keys=%s", list(data.keys()))
+            return Ok({"status": "skipped", "reason": "missing required fields"})
+
+        name = data.get("name")
+        given_name = data.get("given_name")
+        family_name = data.get("family_name")
+
+        return await self.sync_user_from_flow(
+            user_id=external_sub,
+            email=email,
+            name=name if isinstance(name, str) else None,
+            given_name=given_name if isinstance(given_name, str) else None,
+            family_name=family_name if isinstance(family_name, str) else None,
+        )
+
+    async def _handle_user_updated(self, data: dict) -> Result[dict, IdentityError]:
+        """Handle user.updated webhook — update user fields if linked."""
+        external_sub = data.get("user_id", "")
+        if not isinstance(external_sub, str) or not external_sub:
+            logger.warning("user.updated webhook missing user_id, keys=%s", list(data.keys()))
+            return Ok({"status": "skipped", "reason": "missing user_id"})
+
+        provider = await self._provider_repo.get_by_type(ProviderType.descope)
+        if provider is None:
+            return Error(NotFound(message="Descope provider not configured"))
+
+        link = await self._link_repo.get_by_provider_and_sub(provider_id=provider.id, external_sub=external_sub)
+        if link is None:
+            logger.info("user.updated webhook for unknown user %s — ignoring", external_sub)
+            return Ok({"status": "ignored", "reason": "no linked user"})
+
+        user = await self._user_repo.get(link.user_id)
+        if user is None:
+            return Error(NotFound(message="Linked user not found"))
+
+        email = data.get("email")
+        if isinstance(email, str) and email:
+            user.email = email
+            link.external_email = email
+        name = data.get("name")
+        given_name = data.get("given_name")
+        family_name = data.get("family_name")
+        if isinstance(given_name, str) and given_name:
+            user.given_name = given_name
+        if isinstance(family_name, str) and family_name:
+            user.family_name = family_name
+        if not given_name and not family_name and isinstance(name, str) and name:
+            parts = name.split(" ", 1)
+            user.given_name = parts[0]
+            user.family_name = parts[1] if len(parts) > 1 else ""
+
+        try:
+            await self._user_repo.update(user)
+        except RepositoryConflictError:
+            return Error(Conflict(message="User update conflicts with existing data"))
+
+        try:
+            await self._user_repo.commit()
+        except Exception:
+            logger.exception("Commit failed during user.updated webhook")
+            return Error(Conflict(message="Failed to persist user update"))
+
+        if self._publisher:
+            await self._publisher.publish(entity_type="user", entity_id=user.id, operation="update")
+
+        logger.info("Webhook: updated user %s from user.updated event", user.id)
+        return Ok({"user": user.model_dump(), "created": False})
+
+    async def _handle_user_deleted(self, data: dict) -> Result[dict, IdentityError]:
+        """Handle user.deleted webhook — deactivate user if linked.
+
+        Deactivates rather than deletes to preserve audit trail.
+        FK cascade on idp_links will clean up links if the user is later hard-deleted.
+        """
+        external_sub = data.get("user_id", "")
+        if not isinstance(external_sub, str) or not external_sub:
+            logger.warning("user.deleted webhook missing user_id, keys=%s", list(data.keys()))
+            return Ok({"status": "skipped", "reason": "missing user_id"})
+
+        provider = await self._provider_repo.get_by_type(ProviderType.descope)
+        if provider is None:
+            return Error(NotFound(message="Descope provider not configured"))
+
+        link = await self._link_repo.get_by_provider_and_sub(provider_id=provider.id, external_sub=external_sub)
+        if link is None:
+            logger.info("user.deleted webhook for unknown user %s — ignoring", external_sub)
+            return Ok({"status": "ignored", "reason": "no linked user"})
+
+        user = await self._user_repo.get(link.user_id)
+        if user is None:
+            return Error(NotFound(message="Linked user not found"))
+
+        user.status = UserStatus.inactive
+        try:
+            await self._user_repo.update(user)
+        except RepositoryConflictError:
+            return Error(Conflict(message="User deactivation conflicts with existing data"))
+
+        try:
+            await self._user_repo.commit()
+        except Exception:
+            logger.exception("Commit failed during user.deleted webhook")
+            return Error(Conflict(message="Failed to persist user deactivation"))
+
+        if self._publisher:
+            await self._publisher.publish(entity_type="user", entity_id=user.id, operation="deactivate")
+
+        logger.info("Webhook: deactivated user %s from user.deleted event", user.id)
+        return Ok({"status": "deactivated", "user_id": str(user.id)})

--- a/backend/app/services/permission.py
+++ b/backend/app/services/permission.py
@@ -1,0 +1,198 @@
+"""PermissionService — domain orchestration for canonical Permission operations.
+
+Middle layer of onion architecture: orchestrates PermissionRepository (data access)
+and IdentityProviderAdapter (IdP sync). All methods return Result[T, IdentityError].
+OTel spans on every method. Sync failure -> log warning, still return Ok.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from expression import Error, Ok, Result
+from opentelemetry import trace
+
+from app.errors.identity import Conflict, IdentityError, NotFound
+from app.models.identity.role import Permission
+from app.repositories.permission import PermissionRepository
+from app.repositories.user import RepositoryConflictError
+from app.services.adapters.base import IdentityProviderAdapter, SyncError
+from app.services.cache_invalidation import CacheInvalidationPublisher
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+
+class PermissionService:
+    """Domain service for Permission operations.
+
+    Orchestrates PermissionRepository (inner) and IdentityProviderAdapter (outer).
+    Contains NO direct SQLAlchemy imports — uses repository methods only.
+    """
+
+    def __init__(
+        self,
+        *,
+        repository: PermissionRepository,
+        adapter: IdentityProviderAdapter,
+        publisher: CacheInvalidationPublisher | None = None,
+    ) -> None:
+        self._repository = repository
+        self._adapter = adapter
+        self._publisher = publisher
+
+    async def create_permission(
+        self,
+        *,
+        name: str,
+        description: str = "",
+    ) -> Result[dict, IdentityError]:
+        """Create a new permission: persist via repo, then sync to IdP.
+
+        AC-2.2.2: permission CRUD via PermissionRepository + adapter.sync_permission().
+        AC-2.2.5: duplicate name -> Conflict.
+        """
+        with tracer.start_as_current_span("PermissionService.create_permission") as span:
+            span.set_attribute("permission.name", name)
+
+            existing = await self._repository.get_by_name(name)
+            if existing is not None:
+                return Error(Conflict(message=f"Permission '{name}' already exists"))
+
+            permission = Permission(name=name, description=description)
+            try:
+                permission = await self._repository.create(permission)
+            except RepositoryConflictError:
+                await self._repository.rollback()
+                return Error(Conflict(message=f"Permission '{name}' already exists"))
+
+            result_dict = permission.model_dump()
+            permission_id = permission.id
+            await self._repository.commit()
+
+            if self._publisher:
+                await self._publisher.publish(entity_type="permission", entity_id=permission_id, operation="create")
+
+            self._log_sync_failure(
+                await self._adapter.sync_permission(
+                    permission_id=permission_id,
+                    data={"name": permission.name, "description": permission.description},
+                ),
+                permission_id,
+                "create_permission",
+            )
+
+            return Ok(result_dict)
+
+    async def get_permission(
+        self,
+        *,
+        permission_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Retrieve a permission by ID."""
+        with tracer.start_as_current_span("PermissionService.get_permission") as span:
+            span.set_attribute("permission.id", str(permission_id))
+
+            permission = await self._repository.get(permission_id)
+            if permission is None:
+                return Error(NotFound(message=f"Permission '{permission_id}' not found"))
+            return Ok(permission.model_dump())
+
+    async def list_permissions(self) -> Result[list[dict], IdentityError]:
+        """List all permissions."""
+        with tracer.start_as_current_span("PermissionService.list_permissions"):
+            permissions = await self._repository.list_all()
+            return Ok([p.model_dump() for p in permissions])
+
+    async def update_permission(
+        self,
+        *,
+        permission_id: uuid.UUID,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> Result[dict, IdentityError]:
+        """Update permission fields, then sync to IdP."""
+        with tracer.start_as_current_span("PermissionService.update_permission") as span:
+            span.set_attribute("permission.id", str(permission_id))
+
+            permission = await self._repository.get(permission_id)
+            if permission is None:
+                return Error(NotFound(message=f"Permission '{permission_id}' not found"))
+
+            if name is not None:
+                existing = await self._repository.get_by_name(name)
+                if existing is not None and existing.id != permission_id:
+                    return Error(Conflict(message=f"Permission '{name}' already exists"))
+                permission.name = name
+            if description is not None:
+                permission.description = description
+
+            try:
+                permission = await self._repository.update(permission)
+            except RepositoryConflictError:
+                await self._repository.rollback()
+                return Error(Conflict(message=f"Permission name '{name}' conflicts with existing permission"))
+
+            result_dict = permission.model_dump()
+            await self._repository.commit()
+
+            if self._publisher:
+                await self._publisher.publish(entity_type="permission", entity_id=permission.id, operation="update")
+
+            self._log_sync_failure(
+                await self._adapter.sync_permission(
+                    permission_id=permission.id,
+                    data={"name": permission.name, "description": permission.description},
+                ),
+                permission.id,
+                "update_permission",
+            )
+
+            return Ok(result_dict)
+
+    async def delete_permission(
+        self,
+        *,
+        permission_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Delete a permission from DB and sync deletion to IdP."""
+        with tracer.start_as_current_span("PermissionService.delete_permission") as span:
+            span.set_attribute("permission.id", str(permission_id))
+
+            permission = await self._repository.get(permission_id)
+            if permission is None:
+                return Error(NotFound(message=f"Permission '{permission_id}' not found"))
+
+            perm_name = permission.name
+            deleted = await self._repository.delete(permission_id)
+            if not deleted:
+                return Error(NotFound(message=f"Permission '{permission_id}' not found"))
+
+            await self._repository.commit()
+
+            if self._publisher:
+                await self._publisher.publish(entity_type="permission", entity_id=permission_id, operation="delete")
+
+            self._log_sync_failure(
+                await self._adapter.delete_permission(permission_id=permission_id),
+                permission_id,
+                "delete_permission",
+            )
+
+            return Ok({"status": "deleted", "name": perm_name})
+
+    @staticmethod
+    def _log_sync_failure(
+        result: Result[None, SyncError],
+        entity_id: uuid.UUID,
+        operation: str,
+    ) -> None:
+        """Log adapter sync failures as warnings without propagating."""
+        if result.is_error():
+            logger.warning(
+                "IdP sync failed for permission %s (%s): %s",
+                entity_id,
+                operation,
+                result.error.message,
+            )

--- a/backend/app/services/provider.py
+++ b/backend/app/services/provider.py
@@ -1,0 +1,147 @@
+"""ProviderService — domain orchestration for canonical Provider operations.
+
+Middle layer of onion architecture: orchestrates ProviderRepository (data access).
+All methods return Result[T, IdentityError]. OTel spans on every method.
+No credentials stored in Postgres — config_ref points to external secret manager.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from expression import Error, Ok, Result
+from opentelemetry import trace
+
+from app.errors.identity import Conflict, IdentityError, NotFound
+from app.models.identity.provider import Provider, ProviderType
+from app.repositories.provider import ProviderRepository
+from app.repositories.user import RepositoryConflictError
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+
+class ProviderService:
+    """Domain service for Provider operations.
+
+    Orchestrates ProviderRepository (inner).
+    Contains NO direct SQLAlchemy imports — uses repository methods only.
+    """
+
+    def __init__(
+        self,
+        *,
+        repository: ProviderRepository,
+    ) -> None:
+        self._repository = repository
+
+    async def register_provider(
+        self,
+        *,
+        name: str,
+        type: ProviderType,
+        issuer_url: str = "",
+        base_url: str = "",
+        capabilities: list[str] | None = None,
+        config_ref: str = "",
+    ) -> Result[dict, IdentityError]:
+        """Register a new identity provider.
+
+        AC-4.1.2: no credentials in Postgres, config_ref only.
+        """
+        with tracer.start_as_current_span("ProviderService.register_provider") as span:
+            span.set_attribute("provider.name", name)
+            span.set_attribute("provider.type", type.value)
+
+            existing = await self._repository.get_by_name(name)
+            if existing is not None:
+                return Error(Conflict(message=f"Provider '{name}' already exists"))
+
+            provider = Provider(
+                name=name,
+                type=type,
+                issuer_url=issuer_url,
+                base_url=base_url,
+                capabilities=capabilities or [],
+                config_ref=config_ref,
+            )
+            # TOCTOU guard: get_by_name pre-check above provides clean error
+            # messages, but a concurrent insert can race past it. The
+            # RepositoryConflictError fallback below catches the DB-level
+            # unique constraint violation. Both checks are required.
+            try:
+                provider = await self._repository.create(provider)
+            except RepositoryConflictError:
+                return Error(Conflict(message=f"Provider '{name}' already exists"))
+
+            result_dict = provider.model_dump()
+            result_dict.pop("config_ref", None)
+            await self._repository.commit()
+
+            return Ok(result_dict)
+
+    async def list_providers(self) -> Result[list[dict], IdentityError]:
+        """List all registered providers with config_ref stripped.
+
+        AC-4.2.2: config_ref MUST never be exposed in API responses.
+        """
+        with tracer.start_as_current_span("ProviderService.list_providers"):
+            providers = await self._repository.list_all()
+            result = []
+            for p in providers:
+                d = p.model_dump()
+                d.pop("config_ref", None)
+                result.append(d)
+            return Ok(result)
+
+    async def deactivate_provider(
+        self,
+        *,
+        provider_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Deactivate a provider. Idempotent — already-inactive returns Ok.
+
+        AC-4.1.2: sets active=False.
+        """
+        with tracer.start_as_current_span("ProviderService.deactivate_provider") as span:
+            span.set_attribute("provider.id", str(provider_id))
+
+            provider = await self._repository.get(provider_id)
+            if provider is None:
+                return Error(NotFound(message=f"Provider '{provider_id}' not found"))
+
+            if not provider.active:
+                d = provider.model_dump()
+                d.pop("config_ref", None)
+                return Ok(d)
+
+            provider.active = False
+            try:
+                provider = await self._repository.update(provider)
+            except RepositoryConflictError:
+                return Error(Conflict(message=f"Provider '{provider_id}' conflict during deactivation"))
+
+            result_dict = provider.model_dump()
+            result_dict.pop("config_ref", None)
+            await self._repository.commit()
+
+            return Ok(result_dict)
+
+    async def get_provider_capabilities(
+        self,
+        *,
+        provider_id: uuid.UUID,
+    ) -> Result[list[str], IdentityError]:
+        """Get the capabilities list for a provider.
+
+        AC-4.1.2: returns the capabilities JSON array.
+        """
+        with tracer.start_as_current_span("ProviderService.get_provider_capabilities") as span:
+            span.set_attribute("provider.id", str(provider_id))
+
+            provider = await self._repository.get(provider_id)
+            if provider is None:
+                return Error(NotFound(message=f"Provider '{provider_id}' not found"))
+
+            return Ok(provider.capabilities)

--- a/backend/app/services/reconciliation.py
+++ b/backend/app/services/reconciliation.py
@@ -1,0 +1,415 @@
+"""ReconciliationService — domain orchestration for drift detection/resolution.
+
+Detects and resolves drift between canonical Postgres state and Descope.
+Middle layer of onion architecture: orchestrates repositories and Descope client.
+All methods return Result[T, IdentityError]. OTel spans on every method.
+
+AC-3.2.1: Reconciliation logic (diff + upsert)
+AC-3.2.2: Advisory lock for concurrency safety
+AC-3.2.3: Descope outage handling (abort on failure)
+AC-3.2.4: Performance (batch fetches, OTel spans for visibility)
+AC-3.2.5: Failed sync retry (drift detection covers prior failures)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from expression import Error, Ok, Result
+from opentelemetry import trace
+
+from app.errors.identity import IdentityError, ProviderError
+from app.models.identity.provider import ProviderType
+from app.models.identity.role import Permission, Role
+from app.models.identity.tenant import Tenant, TenantStatus
+from app.models.identity.user import IdPLink, User, UserStatus
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.permission import PermissionRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.role import RoleRepository
+from app.repositories.tenant import TenantRepository
+from app.repositories.user import RepositoryConflictError, UserRepository
+from app.services.cache_invalidation import CacheInvalidationPublisher
+from app.services.descope import DescopeManagementClient
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+# Descope status → canonical UserStatus mapping
+_DESCOPE_STATUS_MAP: dict[str, UserStatus] = {
+    "enabled": UserStatus.active,
+    "disabled": UserStatus.inactive,
+    "invited": UserStatus.provisioned,
+}
+
+
+class ReconciliationService:
+    """Domain service for drift detection and resolution between Postgres and Descope.
+
+    Orchestrates repositories for canonical state and DescopeManagementClient for
+    Descope state. No direct SQLAlchemy imports — advisory lock injected via callable.
+    """
+
+    def __init__(
+        self,
+        *,
+        session: AsyncSession,
+        acquire_lock: Callable[[], Coroutine[Any, Any, None]],
+        descope_client: DescopeManagementClient,
+        user_repository: UserRepository,
+        role_repository: RoleRepository,
+        permission_repository: PermissionRepository,
+        tenant_repository: TenantRepository,
+        idp_link_repository: IdPLinkRepository,
+        provider_repository: ProviderRepository,
+        publisher: CacheInvalidationPublisher | None = None,
+    ) -> None:
+        self._session = session
+        self._acquire_lock = acquire_lock
+        self._descope = descope_client
+        self._user_repo = user_repository
+        self._role_repo = role_repository
+        self._permission_repo = permission_repository
+        self._tenant_repo = tenant_repository
+        self._link_repo = idp_link_repository
+        self._provider_repo = provider_repository
+        self._publisher = publisher
+
+    async def run(self) -> Result[dict, IdentityError]:
+        """Execute a full reconciliation pass.
+
+        AC-3.2.2: Acquires a Postgres advisory lock to prevent concurrent runs.
+        AC-3.2.3: Aborts without modifying canonical state on Descope fetch failure.
+        """
+        with tracer.start_as_current_span("ReconciliationService.run") as span:
+            # AC-3.2.2: Advisory lock — prevents concurrent reconciliation
+            try:
+                await self._acquire_lock()
+            except Exception as exc:
+                logger.error("Failed to acquire advisory lock: %s", exc)
+                return Error(ProviderError(message=f"Failed to acquire reconciliation lock: {exc}"))
+
+            span.set_attribute("reconciliation.started_at", datetime.now(timezone.utc).isoformat())
+
+            # AC-3.2.3: Fetch all Descope state — abort on any failure
+            try:
+                descope_users = await self._descope.search_all_users()
+                descope_roles = await self._descope.list_roles()
+                descope_permissions = await self._descope.list_permissions()
+                descope_tenants = await self._descope.list_tenants()
+            except Exception as exc:
+                logger.error("Descope fetch failed — aborting reconciliation: %s", exc)
+                span.set_attribute("reconciliation.status", "aborted")
+                span.set_attribute("reconciliation.error", str(exc))
+                return Error(ProviderError(message=f"Descope API unavailable: {exc}"))
+
+            span.set_attribute("descope.user_count", len(descope_users))
+            span.set_attribute("descope.role_count", len(descope_roles))
+            span.set_attribute("descope.permission_count", len(descope_permissions))
+            span.set_attribute("descope.tenant_count", len(descope_tenants))
+
+            stats: dict[str, int] = {
+                "tenants_created": 0,
+                "tenants_updated": 0,
+                "permissions_created": 0,
+                "permissions_updated": 0,
+                "roles_created": 0,
+                "roles_updated": 0,
+                "users_created": 0,
+                "users_updated": 0,
+                "links_created": 0,
+            }
+
+            # Reconcile in dependency order: tenants, permissions, roles, users
+            tenant_result = await self._reconcile_tenants(descope_tenants, stats)
+            if tenant_result.is_error():
+                return tenant_result
+
+            perm_result = await self._reconcile_permissions(descope_permissions, stats)
+            if perm_result.is_error():
+                return perm_result
+
+            role_result = await self._reconcile_roles(descope_roles, stats)
+            if role_result.is_error():
+                return role_result
+
+            user_result = await self._reconcile_users(descope_users, stats)
+            if user_result.is_error():
+                return user_result
+
+            # Commit all changes in a single transaction
+            try:
+                await self._session.commit()
+            except Exception as exc:
+                logger.error("Commit failed during reconciliation: %s", exc)
+                await self._session.rollback()
+                return Error(ProviderError(message=f"Failed to commit reconciliation: {exc}"))
+
+            total_changes = sum(stats.values())
+            span.set_attribute("reconciliation.status", "completed")
+            span.set_attribute("reconciliation.total_changes", total_changes)
+
+            if self._publisher and total_changes > 0:
+                await self._publisher.publish_batch(operation="reconcile", stats=stats)
+
+            logger.info("Reconciliation completed: %s", stats)
+            return Ok({"status": "completed", "stats": stats})
+
+    async def _reconcile_tenants(
+        self,
+        descope_tenants: list[dict],
+        stats: dict[str, int],
+    ) -> Result[None, IdentityError]:
+        """Diff Descope tenants against canonical and upsert."""
+        with tracer.start_as_current_span("ReconciliationService._reconcile_tenants"):
+            canonical_tenants = await self._tenant_repo.list_all()
+            canonical_by_name = {t.name: t for t in canonical_tenants}
+
+            for dt in descope_tenants:
+                name = dt.get("name", "")
+                if not name:
+                    continue
+
+                domains = dt.get("selfProvisioningDomains") or []
+                existing = canonical_by_name.get(name)
+
+                if existing is None:
+                    tenant = Tenant(name=name, domains=domains, status=TenantStatus.active)
+                    try:
+                        async with self._session.begin_nested():
+                            await self._tenant_repo.create(tenant)
+                    except RepositoryConflictError:
+                        logger.warning("Tenant '%s' conflict during reconciliation — skipping", name)
+                        continue
+                    stats["tenants_created"] += 1
+                    logger.info("Reconciliation: created tenant '%s'", name)
+                else:
+                    changed = False
+                    old_domains = list(existing.domains) if existing.domains else []
+                    if existing.domains != domains:
+                        existing.domains = domains
+                        changed = True
+                    if changed:
+                        try:
+                            async with self._session.begin_nested():
+                                await self._tenant_repo.update(existing)
+                        except RepositoryConflictError:
+                            logger.warning("Tenant '%s' update conflict — skipping", name)
+                            continue
+                        stats["tenants_updated"] += 1
+                        logger.info(
+                            "Reconciliation: updated tenant '%s' domains: %s → %s",
+                            name,
+                            old_domains,
+                            domains,
+                        )
+
+            return Ok(None)
+
+    async def _reconcile_permissions(
+        self,
+        descope_permissions: list[dict],
+        stats: dict[str, int],
+    ) -> Result[None, IdentityError]:
+        """Diff Descope permissions against canonical and upsert."""
+        with tracer.start_as_current_span("ReconciliationService._reconcile_permissions"):
+            canonical_perms = await self._permission_repo.list_all()
+            canonical_by_name = {p.name: p for p in canonical_perms}
+
+            for dp in descope_permissions:
+                name = dp.get("name", "")
+                if not name:
+                    continue
+
+                description = dp.get("description", "")
+                existing = canonical_by_name.get(name)
+
+                if existing is None:
+                    perm = Permission(name=name, description=description)
+                    try:
+                        async with self._session.begin_nested():
+                            await self._permission_repo.create(perm)
+                    except RepositoryConflictError:
+                        logger.warning("Permission '%s' conflict during reconciliation — skipping", name)
+                        continue
+                    stats["permissions_created"] += 1
+                    logger.info("Reconciliation: created permission '%s'", name)
+                else:
+                    changed = False
+                    old_description = existing.description
+                    if existing.description != description:
+                        existing.description = description
+                        changed = True
+                    if changed:
+                        try:
+                            async with self._session.begin_nested():
+                                await self._permission_repo.update(existing)
+                        except RepositoryConflictError:
+                            logger.warning("Permission '%s' update conflict — skipping", name)
+                            continue
+                        stats["permissions_updated"] += 1
+                        logger.info(
+                            "Reconciliation: updated permission '%s' description: '%s' → '%s'",
+                            name,
+                            old_description,
+                            description,
+                        )
+
+            return Ok(None)
+
+    async def _reconcile_roles(
+        self,
+        descope_roles: list[dict],
+        stats: dict[str, int],
+    ) -> Result[None, IdentityError]:
+        """Diff Descope roles against canonical and upsert (global roles only)."""
+        with tracer.start_as_current_span("ReconciliationService._reconcile_roles"):
+            # Descope roles are global (no tenant scoping)
+            canonical_roles = await self._role_repo.list_by_tenant(tenant_id=None)
+            canonical_by_name = {r.name: r for r in canonical_roles}
+
+            for dr in descope_roles:
+                name = dr.get("name", "")
+                if not name:
+                    continue
+
+                description = dr.get("description", "")
+                existing = canonical_by_name.get(name)
+
+                if existing is None:
+                    role = Role(name=name, description=description, tenant_id=None)
+                    try:
+                        async with self._session.begin_nested():
+                            await self._role_repo.create(role)
+                    except RepositoryConflictError:
+                        logger.warning("Role '%s' conflict during reconciliation — skipping", name)
+                        continue
+                    stats["roles_created"] += 1
+                    logger.info("Reconciliation: created role '%s'", name)
+                else:
+                    changed = False
+                    old_description = existing.description
+                    if existing.description != description:
+                        existing.description = description
+                        changed = True
+                    if changed:
+                        try:
+                            async with self._session.begin_nested():
+                                await self._role_repo.update(existing)
+                        except RepositoryConflictError:
+                            logger.warning("Role '%s' update conflict — skipping", name)
+                            continue
+                        stats["roles_updated"] += 1
+                        logger.info(
+                            "Reconciliation: updated role '%s' description: '%s' → '%s'",
+                            name,
+                            old_description,
+                            description,
+                        )
+
+            return Ok(None)
+
+    async def _reconcile_users(
+        self,
+        descope_users: list[dict],
+        stats: dict[str, int],
+    ) -> Result[None, IdentityError]:
+        """Diff Descope users against canonical and upsert with IdP links."""
+        with tracer.start_as_current_span("ReconciliationService._reconcile_users"):
+            provider = await self._provider_repo.get_by_type(ProviderType.descope)
+            if provider is None:
+                logger.warning("Descope provider not configured — skipping user reconciliation")
+                return Ok(None)
+
+            canonical_users = await self._user_repo.list_all()
+            # Use setdefault to keep first entry for each email (avoid silent overwrite)
+            canonical_by_email: dict[str, User] = {}
+            for u in canonical_users:
+                canonical_by_email.setdefault(u.email, u)
+
+            for du in descope_users:
+                email = du.get("email", "")
+                user_id = du.get("userId", "")
+                if not email or not user_id:
+                    continue
+
+                name = du.get("name", "")
+                given_name = du.get("givenName", "")
+                family_name = du.get("familyName", "")
+                if not given_name and not family_name and name:
+                    parts = name.split(" ", 1)
+                    given_name = parts[0]
+                    family_name = parts[1] if len(parts) > 1 else ""
+
+                # Map Descope status to canonical (invited → provisioned, not inactive)
+                descope_status = du.get("status", "enabled")
+                canonical_status = _DESCOPE_STATUS_MAP.get(descope_status, UserStatus.inactive)
+
+                existing = canonical_by_email.get(email)
+
+                if existing is None:
+                    user = User(
+                        email=email,
+                        user_name=email,
+                        given_name=given_name,
+                        family_name=family_name,
+                        status=canonical_status,
+                    )
+                    try:
+                        async with self._session.begin_nested():
+                            user = await self._user_repo.create(user)
+                    except RepositoryConflictError:
+                        logger.warning("User '%s' conflict during reconciliation — skipping", email)
+                        continue
+                    stats["users_created"] += 1
+                    logger.info("Reconciliation: created user '%s' (status=%s)", email, canonical_status.value)
+                    existing = user
+                else:
+                    changes: list[str] = []
+                    if given_name and existing.given_name != given_name:
+                        changes.append(f"given_name: '{existing.given_name}' → '{given_name}'")
+                        existing.given_name = given_name
+                    if family_name and existing.family_name != family_name:
+                        changes.append(f"family_name: '{existing.family_name}' → '{family_name}'")
+                        existing.family_name = family_name
+                    if existing.status != canonical_status:
+                        changes.append(f"status: '{existing.status.value}' → '{canonical_status.value}'")
+                        existing.status = canonical_status
+                    if changes:
+                        try:
+                            async with self._session.begin_nested():
+                                await self._user_repo.update(existing)
+                        except RepositoryConflictError:
+                            logger.warning("User '%s' update conflict — skipping", email)
+                            continue
+                        stats["users_updated"] += 1
+                        logger.info("Reconciliation: updated user '%s': %s", email, ", ".join(changes))
+
+                # Ensure IdP link exists
+                existing_link = await self._link_repo.get_by_provider_and_sub(
+                    provider_id=provider.id, external_sub=user_id
+                )
+                if existing_link is None:
+                    link = IdPLink(
+                        user_id=existing.id,
+                        provider_id=provider.id,
+                        external_sub=user_id,
+                        external_email=email,
+                    )
+                    try:
+                        async with self._session.begin_nested():
+                            await self._link_repo.create(link)
+                    except RepositoryConflictError:
+                        logger.warning("IdP link conflict for user '%s' — skipping", email)
+                        continue
+                    stats["links_created"] += 1
+                    logger.info("Reconciliation: created IdP link for user '%s'", email)
+
+            return Ok(None)

--- a/backend/app/services/role.py
+++ b/backend/app/services/role.py
@@ -1,0 +1,408 @@
+"""RoleService — domain orchestration for canonical Role operations.
+
+Middle layer of onion architecture: orchestrates RoleRepository, PermissionRepository,
+UserTenantRoleRepository (data access) and IdentityProviderAdapter (IdP sync).
+All methods return Result[T, IdentityError]. OTel spans on every method.
+Sync failure -> log warning, still return Ok.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from expression import Error, Ok, Result
+from opentelemetry import trace
+
+from app.errors.identity import Conflict, IdentityError, NotFound
+from app.models.identity.assignment import UserTenantRole
+from app.models.identity.role import Role
+from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.permission import PermissionRepository
+from app.repositories.role import RoleRepository
+from app.repositories.user import RepositoryConflictError
+from app.services.adapters.base import IdentityProviderAdapter, SyncError
+from app.services.cache_invalidation import CacheInvalidationPublisher
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+
+class RoleService:
+    """Domain service for Role operations.
+
+    Orchestrates RoleRepository, PermissionRepository, UserTenantRoleRepository (inner)
+    and IdentityProviderAdapter (outer).
+    Contains NO direct SQLAlchemy imports — uses repository methods only.
+    """
+
+    def __init__(
+        self,
+        *,
+        repository: RoleRepository,
+        permission_repository: PermissionRepository,
+        assignment_repository: UserTenantRoleRepository,
+        adapter: IdentityProviderAdapter,
+        publisher: CacheInvalidationPublisher | None = None,
+    ) -> None:
+        self._repository = repository
+        self._permission_repository = permission_repository
+        self._assignment_repository = assignment_repository
+        self._adapter = adapter
+        self._publisher = publisher
+
+    async def create_role(
+        self,
+        *,
+        name: str,
+        description: str = "",
+        tenant_id: uuid.UUID | None = None,
+        permission_names: list[str] | None = None,
+    ) -> Result[dict, IdentityError]:
+        """Create a new role: persist via repo, then sync to IdP.
+
+        AC-2.2.1: role CRUD via RoleRepository + adapter.sync_role().
+        AC-2.2.5: duplicate name within scope -> Conflict.
+        """
+        with tracer.start_as_current_span("RoleService.create_role") as span:
+            span.set_attribute("role.name", name)
+            if tenant_id is not None:
+                span.set_attribute("tenant.id", str(tenant_id))
+
+            existing = await self._repository.get_by_name(name, tenant_id)
+            if existing is not None:
+                return Error(Conflict(message=f"Role '{name}' already exists in this scope"))
+
+            role = Role(name=name, description=description, tenant_id=tenant_id)
+            try:
+                role = await self._repository.create(role)
+            except RepositoryConflictError:
+                await self._repository.rollback()
+                return Error(Conflict(message=f"Role '{name}' already exists in this scope"))
+
+            # Map permissions to role if specified
+            resolved_permission_names: list[str] = []
+            if permission_names:
+                for perm_name in permission_names:
+                    perm = await self._permission_repository.get_by_name(perm_name)
+                    if perm is None:
+                        await self._repository.rollback()
+                        return Error(NotFound(message=f"Permission '{perm_name}' not found"))
+                    try:
+                        await self._repository.add_permission(role.id, perm.id)
+                    except RepositoryConflictError:
+                        pass  # already mapped, skip
+                    resolved_permission_names.append(perm_name)
+
+            result_dict = role.model_dump()
+            role_id = role.id
+            await self._repository.commit()
+
+            if self._publisher:
+                await self._publisher.publish(
+                    entity_type="role", entity_id=role_id, operation="create", tenant_id=tenant_id
+                )
+
+            sync_data: dict = {"name": role.name, "description": role.description}
+            if resolved_permission_names:
+                sync_data["permission_names"] = resolved_permission_names
+            self._log_sync_failure(
+                await self._adapter.sync_role(role_id=role_id, data=sync_data),
+                role_id,
+                "create_role",
+            )
+
+            return Ok(result_dict)
+
+    async def get_role(
+        self,
+        *,
+        role_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Retrieve a role by ID."""
+        with tracer.start_as_current_span("RoleService.get_role") as span:
+            span.set_attribute("role.id", str(role_id))
+
+            role = await self._repository.get(role_id)
+            if role is None:
+                return Error(NotFound(message=f"Role '{role_id}' not found"))
+            return Ok(role.model_dump())
+
+    async def map_permission_to_role(
+        self,
+        *,
+        role_id: uuid.UUID,
+        permission_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Map a permission to a role, then sync to IdP.
+
+        AC-2.2.2: permission mapping via RoleRepository.add_permission().
+        """
+        with tracer.start_as_current_span("RoleService.map_permission_to_role") as span:
+            span.set_attribute("role.id", str(role_id))
+            span.set_attribute("permission.id", str(permission_id))
+
+            role = await self._repository.get(role_id)
+            if role is None:
+                return Error(NotFound(message=f"Role '{role_id}' not found"))
+
+            permission = await self._permission_repository.get(permission_id)
+            if permission is None:
+                return Error(NotFound(message=f"Permission '{permission_id}' not found"))
+
+            try:
+                mapping = await self._repository.add_permission(role_id, permission_id)
+            except RepositoryConflictError:
+                await self._repository.rollback()
+                return Error(Conflict(message=f"Permission '{permission_id}' is already mapped to role '{role_id}'"))
+
+            result_dict = {
+                "role_id": str(mapping.role_id),
+                "permission_id": str(mapping.permission_id),
+            }
+
+            permissions = await self._repository.get_permissions(role_id)
+            permission_names = [p.name for p in permissions]
+            await self._repository.commit()
+
+            if self._publisher:
+                await self._publisher.publish(
+                    entity_type="role", entity_id=role_id, operation="update", tenant_id=role.tenant_id
+                )
+
+            self._log_sync_failure(
+                await self._adapter.sync_role(
+                    role_id=role_id,
+                    data={
+                        "name": role.name,
+                        "description": role.description,
+                        "permission_names": permission_names,
+                    },
+                ),
+                role_id,
+                "map_permission_to_role",
+            )
+
+            return Ok(result_dict)
+
+    async def assign_role_to_user(
+        self,
+        *,
+        user_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        role_id: uuid.UUID,
+        assigned_by: uuid.UUID | None = None,
+    ) -> Result[dict, IdentityError]:
+        """Assign a role to a user within a tenant, then sync to IdP.
+
+        AC-2.2.4: role assignment via UserTenantRoleRepository + adapter.sync_role_assignment().
+        """
+        with tracer.start_as_current_span("RoleService.assign_role_to_user") as span:
+            span.set_attribute("user.id", str(user_id))
+            span.set_attribute("tenant.id", str(tenant_id))
+            span.set_attribute("role.id", str(role_id))
+
+            role = await self._repository.get(role_id)
+            if role is None:
+                return Error(NotFound(message=f"Role '{role_id}' not found"))
+
+            existing = await self._assignment_repository.get(user_id, tenant_id, role_id)
+            if existing is not None:
+                return Error(Conflict(message=f"User '{user_id}' already has role '{role_id}' in tenant '{tenant_id}'"))
+
+            assignment = UserTenantRole(
+                user_id=user_id,
+                tenant_id=tenant_id,
+                role_id=role_id,
+                assigned_by=assigned_by,
+            )
+            try:
+                assignment = await self._assignment_repository.create(assignment)
+            except RepositoryConflictError:
+                await self._assignment_repository.rollback()
+                return Error(Conflict(message=f"User '{user_id}' already has role '{role_id}' in tenant '{tenant_id}'"))
+
+            result_dict = {
+                "user_id": str(assignment.user_id),
+                "tenant_id": str(assignment.tenant_id),
+                "role_id": str(assignment.role_id),
+                "assigned_by": str(assignment.assigned_by) if assignment.assigned_by else None,
+                "assigned_at": assignment.assigned_at.isoformat() if assignment.assigned_at else None,
+            }
+            await self._assignment_repository.commit()
+
+            if self._publisher:
+                await self._publisher.publish(
+                    entity_type="role", entity_id=role_id, operation="assign", tenant_id=tenant_id
+                )
+
+            self._log_sync_failure(
+                await self._adapter.sync_role_assignment(
+                    user_id=user_id,
+                    tenant_id=tenant_id,
+                    role_id=role_id,
+                    data={"role_name": role.name},
+                ),
+                role_id,
+                "assign_role_to_user",
+            )
+
+            return Ok(result_dict)
+
+    async def list_roles(
+        self,
+        *,
+        tenant_id: uuid.UUID | None = None,
+    ) -> Result[list[dict], IdentityError]:
+        """List roles filtered by tenant scope."""
+        with tracer.start_as_current_span("RoleService.list_roles") as span:
+            if tenant_id is not None:
+                span.set_attribute("tenant.id", str(tenant_id))
+
+            roles = await self._repository.list_by_tenant(tenant_id)
+            return Ok([r.model_dump() for r in roles])
+
+    async def update_role(
+        self,
+        *,
+        role_id: uuid.UUID,
+        name: str | None = None,
+        description: str | None = None,
+        permission_names: list[str] | None = None,
+    ) -> Result[dict, IdentityError]:
+        """Update role fields, then sync to IdP."""
+        with tracer.start_as_current_span("RoleService.update_role") as span:
+            span.set_attribute("role.id", str(role_id))
+
+            role = await self._repository.get(role_id)
+            if role is None:
+                return Error(NotFound(message=f"Role '{role_id}' not found"))
+
+            if name is not None:
+                existing = await self._repository.get_by_name(name, role.tenant_id)
+                if existing is not None and existing.id != role_id:
+                    return Error(Conflict(message=f"Role '{name}' already exists in this scope"))
+                role.name = name
+            if description is not None:
+                role.description = description
+
+            try:
+                role = await self._repository.update(role)
+            except RepositoryConflictError:
+                await self._repository.rollback()
+                return Error(Conflict(message=f"Role name '{name}' conflicts with existing role"))
+
+            result_dict = role.model_dump()
+            sync_data: dict = {"name": role.name, "description": role.description}
+            if permission_names is not None:
+                sync_data["permission_names"] = permission_names
+            await self._repository.commit()
+
+            if self._publisher:
+                await self._publisher.publish(
+                    entity_type="role", entity_id=role.id, operation="update", tenant_id=role.tenant_id
+                )
+
+            self._log_sync_failure(
+                await self._adapter.sync_role(role_id=role.id, data=sync_data),
+                role.id,
+                "update_role",
+            )
+
+            return Ok(result_dict)
+
+    async def delete_role(
+        self,
+        *,
+        role_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Delete a role from DB and sync deletion to IdP."""
+        with tracer.start_as_current_span("RoleService.delete_role") as span:
+            span.set_attribute("role.id", str(role_id))
+
+            role = await self._repository.get(role_id)
+            if role is None:
+                return Error(NotFound(message=f"Role '{role_id}' not found"))
+
+            role_name = role.name
+            deleted = await self._repository.delete(role_id)
+            if not deleted:
+                return Error(NotFound(message=f"Role '{role_id}' not found"))
+
+            await self._repository.commit()
+
+            if self._publisher:
+                await self._publisher.publish(
+                    entity_type="role", entity_id=role_id, operation="delete", tenant_id=role.tenant_id
+                )
+
+            self._log_sync_failure(
+                await self._adapter.delete_role(role_id=role_id),
+                role_id,
+                "delete_role",
+            )
+
+            return Ok({"status": "deleted", "name": role_name})
+
+    async def unassign_role_from_user(
+        self,
+        *,
+        user_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        role_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Remove a role assignment from a user within a tenant, then sync to IdP."""
+        with tracer.start_as_current_span("RoleService.unassign_role_from_user") as span:
+            span.set_attribute("user.id", str(user_id))
+            span.set_attribute("tenant.id", str(tenant_id))
+            span.set_attribute("role.id", str(role_id))
+
+            role = await self._repository.get(role_id)
+            role_name = role.name if role else str(role_id)
+
+            deleted = await self._assignment_repository.delete(user_id, tenant_id, role_id)
+            if not deleted:
+                msg = f"Role assignment not found for user '{user_id}' in tenant '{tenant_id}'"
+                return Error(NotFound(message=msg))
+
+            await self._assignment_repository.commit()
+
+            if self._publisher:
+                await self._publisher.publish(
+                    entity_type="role", entity_id=role_id, operation="unassign", tenant_id=tenant_id
+                )
+
+            self._log_sync_failure(
+                await self._adapter.delete_role_assignment(
+                    user_id=user_id,
+                    tenant_id=tenant_id,
+                    role_id=role_id,
+                    data={"role_name": role_name},
+                ),
+                role_id,
+                "unassign_role_from_user",
+            )
+
+            return Ok(
+                {
+                    "status": "removed",
+                    "user_id": str(user_id),
+                    "tenant_id": str(tenant_id),
+                    "role_id": str(role_id),
+                }
+            )
+
+    @staticmethod
+    def _log_sync_failure(
+        result: Result[None, SyncError],
+        entity_id: uuid.UUID,
+        operation: str,
+    ) -> None:
+        """Log adapter sync failures as warnings without propagating."""
+        if result.is_error():
+            logger.warning(
+                "IdP sync failed for role %s (%s): %s",
+                entity_id,
+                operation,
+                result.error.message,
+            )

--- a/backend/app/services/tenant.py
+++ b/backend/app/services/tenant.py
@@ -1,0 +1,151 @@
+"""TenantService — domain orchestration for canonical Tenant operations.
+
+Middle layer of onion architecture: orchestrates TenantRepository (data access)
+and IdentityProviderAdapter (IdP sync). All methods return Result[T, IdentityError].
+OTel spans on every method. Sync failure -> log warning, still return Ok.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from expression import Error, Ok, Result
+from opentelemetry import trace
+
+from app.errors.identity import Conflict, IdentityError, NotFound
+from app.models.identity.tenant import Tenant
+from app.repositories.tenant import TenantRepository
+from app.repositories.user import RepositoryConflictError
+from app.services.adapters.base import IdentityProviderAdapter, SyncError
+from app.services.cache_invalidation import CacheInvalidationPublisher
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+
+class TenantService:
+    """Domain service for Tenant operations.
+
+    Orchestrates TenantRepository (inner) and IdentityProviderAdapter (outer).
+    Contains NO direct SQLAlchemy imports — uses repository methods only.
+    """
+
+    def __init__(
+        self,
+        *,
+        repository: TenantRepository,
+        adapter: IdentityProviderAdapter,
+        publisher: CacheInvalidationPublisher | None = None,
+    ) -> None:
+        self._repository = repository
+        self._adapter = adapter
+        self._publisher = publisher
+
+    async def create_tenant(
+        self,
+        *,
+        name: str,
+        domains: list[str] | None = None,
+    ) -> Result[dict, IdentityError]:
+        """Create a new tenant: persist via repo, then sync to IdP.
+
+        AC-2.2.3: tenant CRUD via TenantRepository + adapter.sync_tenant().
+        """
+        with tracer.start_as_current_span("TenantService.create_tenant") as span:
+            span.set_attribute("tenant.name", name)
+
+            existing = await self._repository.get_by_name(name)
+            if existing is not None:
+                return Error(Conflict(message=f"Tenant '{name}' already exists"))
+
+            tenant = Tenant(name=name, domains=domains or [])
+            try:
+                tenant = await self._repository.create(tenant)
+            except RepositoryConflictError:
+                await self._repository.rollback()
+                return Error(Conflict(message=f"Tenant '{name}' already exists"))
+
+            result_dict = tenant.model_dump()
+            tenant_id = tenant.id
+            await self._repository.commit()
+
+            if self._publisher:
+                await self._publisher.publish(entity_type="tenant", entity_id=tenant_id, operation="create")
+
+            self._log_sync_failure(
+                await self._adapter.sync_tenant(
+                    tenant_id=tenant_id,
+                    data={
+                        "name": tenant.name,
+                        "self_provisioning_domains": tenant.domains,
+                    },
+                ),
+                tenant_id,
+                "create_tenant",
+            )
+
+            return Ok(result_dict)
+
+    async def get_tenant(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Retrieve a tenant by ID."""
+        with tracer.start_as_current_span("TenantService.get_tenant") as span:
+            span.set_attribute("tenant.id", str(tenant_id))
+
+            tenant = await self._repository.get(tenant_id)
+            if tenant is None:
+                return Error(NotFound(message=f"Tenant '{tenant_id}' not found"))
+            return Ok(tenant.model_dump())
+
+    async def get_tenant_users_with_roles(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+    ) -> Result[list[dict], IdentityError]:
+        """Get all users and their roles for a tenant.
+
+        AC-2.2.3: 3-way JOIN users <-> user_tenant_roles <-> roles.
+        """
+        with tracer.start_as_current_span("TenantService.get_tenant_users_with_roles") as span:
+            span.set_attribute("tenant.id", str(tenant_id))
+
+            tenant = await self._repository.get(tenant_id)
+            if tenant is None:
+                return Error(NotFound(message=f"Tenant '{tenant_id}' not found"))
+
+            rows = await self._repository.get_users_with_roles(tenant_id)
+
+            users_map: dict[str, dict] = {}
+            for user, role in rows:
+                uid = str(user.id)
+                if uid not in users_map:
+                    users_map[uid] = {
+                        "user_id": uid,
+                        "email": user.email,
+                        "user_name": user.user_name,
+                        "given_name": user.given_name,
+                        "family_name": user.family_name,
+                        "roles": [],
+                    }
+                users_map[uid]["roles"].append({"role_id": str(role.id), "name": role.name})
+
+            return Ok(list(users_map.values()))
+
+    @staticmethod
+    def _log_sync_failure(
+        result: Result[None, SyncError],
+        entity_id: uuid.UUID,
+        operation: str,
+    ) -> None:
+        """Log adapter sync failures as warnings without propagating."""
+        if result.is_error():
+            logger.warning(
+                "IdP sync failed for tenant %s (%s): %s",
+                entity_id,
+                operation,
+                result.error.message,
+            )

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -13,10 +13,12 @@ import uuid
 from expression import Error, Ok, Result
 from opentelemetry import trace
 
-from app.errors.identity import Conflict, IdentityError, NotFound
+from app.errors.identity import Conflict, Forbidden, IdentityError, NotFound
 from app.models.identity.user import User, UserStatus
+from app.repositories.assignment import UserTenantRoleRepository
 from app.repositories.user import RepositoryConflictError, UserRepository
 from app.services.adapters.base import IdentityProviderAdapter, SyncError
+from app.services.cache_invalidation import CacheInvalidationPublisher
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -34,9 +36,13 @@ class UserService:
         *,
         repository: UserRepository,
         adapter: IdentityProviderAdapter,
+        assignment_repository: UserTenantRoleRepository | None = None,
+        publisher: CacheInvalidationPublisher | None = None,
     ) -> None:
         self._repository = repository
         self._adapter = adapter
+        self._assignment_repository = assignment_repository
+        self._publisher = publisher
 
     async def create_user(
         self,
@@ -50,10 +56,6 @@ class UserService:
         """Create a new user: persist via repo, then sync to IdP.
 
         AC-2.1.2: sync failure → log warning, still return Ok(user).
-
-        Note: tenant_id is recorded for tracing but does NOT create a
-        UserTenantRole association. Tenant membership is established
-        via role assignment (a separate operation).
         """
         with tracer.start_as_current_span("UserService.create_user") as span:
             span.set_attribute("tenant.id", str(tenant_id))
@@ -76,12 +78,16 @@ class UserService:
             result_dict = user.model_dump()
             sync_data = {"email": user.email, "status": user.status.value}
             user_id = user.id
-
             try:
                 await self._repository.commit()
             except Exception:
                 logger.exception("Commit failed for create_user %s", user_id)
                 return Error(Conflict(message="Failed to persist user"))
+
+            if self._publisher:
+                await self._publisher.publish(
+                    entity_type="user", entity_id=user_id, operation="create", tenant_id=tenant_id
+                )
 
             self._log_sync_failure(
                 await self._adapter.sync_user(user_id=user_id, data=sync_data),
@@ -102,9 +108,14 @@ class UserService:
             span.set_attribute("tenant.id", str(tenant_id))
             span.set_attribute("user.id", str(user_id))
 
-            user = await self._repository.get_for_tenant(user_id, tenant_id)
+            user = await self._repository.get(user_id)
             if user is None:
                 return Error(NotFound(message=f"User '{user_id}' not found"))
+
+            membership_err = await self._verify_tenant_membership(user_id, tenant_id)
+            if membership_err is not None:
+                return Error(membership_err)
+
             return Ok(user.model_dump())
 
     async def update_user(
@@ -122,9 +133,13 @@ class UserService:
             span.set_attribute("tenant.id", str(tenant_id))
             span.set_attribute("user.id", str(user_id))
 
-            user = await self._repository.get_for_tenant(user_id, tenant_id)
+            user = await self._repository.get(user_id)
             if user is None:
                 return Error(NotFound(message=f"User '{user_id}' not found"))
+
+            membership_err = await self._verify_tenant_membership(user_id, tenant_id)
+            if membership_err is not None:
+                return Error(membership_err)
 
             if email is not None:
                 existing = await self._repository.get_by_email(email)
@@ -145,12 +160,12 @@ class UserService:
 
             result_dict = user.model_dump()
             sync_data = {"email": user.email, "status": user.status.value}
+            await self._repository.commit()
 
-            try:
-                await self._repository.commit()
-            except Exception:
-                logger.exception("Commit failed for update_user %s", user_id)
-                return Error(Conflict(message="Failed to persist user update"))
+            if self._publisher:
+                await self._publisher.publish(
+                    entity_type="user", entity_id=user.id, operation="update", tenant_id=tenant_id
+                )
 
             self._log_sync_failure(
                 await self._adapter.sync_user(user_id=user.id, data=sync_data),
@@ -160,13 +175,19 @@ class UserService:
 
             return Ok(result_dict)
 
+    async def _verify_tenant_membership(self, user_id: uuid.UUID, tenant_id: uuid.UUID) -> IdentityError | None:
+        """Verify user has a role assignment in the given tenant. Returns error if not."""
+        if not await self._repository.exists_in_tenant(user_id, tenant_id):
+            return Forbidden(message="User does not belong to your tenant")
+        return None
+
     async def deactivate_user(
         self,
         *,
         tenant_id: uuid.UUID,
         user_id: uuid.UUID,
     ) -> Result[dict, IdentityError]:
-        """Set user status to inactive (tenant-scoped) and sync to IdP.
+        """Set user status to inactive and sync to IdP.
 
         AC-2.1.4: repo sets status=inactive, adapter sync attempted.
         """
@@ -174,24 +195,28 @@ class UserService:
             span.set_attribute("tenant.id", str(tenant_id))
             span.set_attribute("user.id", str(user_id))
 
-            user = await self._repository.get_for_tenant(user_id, tenant_id)
+            user = await self._repository.get(user_id)
             if user is None:
                 return Error(NotFound(message=f"User '{user_id}' not found"))
+
+            membership_err = await self._verify_tenant_membership(user_id, tenant_id)
+            if membership_err is not None:
+                return Error(membership_err)
 
             user.status = UserStatus.inactive
             try:
                 user = await self._repository.update(user)
             except RepositoryConflictError:
-                return Error(Conflict(message="Deactivation conflicts with existing data"))
+                return Error(Conflict(message="User deactivation conflicts with existing data"))
 
             result_dict = user.model_dump()
             sync_data = {"email": user.email, "status": user.status.value}
+            await self._repository.commit()
 
-            try:
-                await self._repository.commit()
-            except Exception:
-                logger.exception("Commit failed for deactivate_user %s", user_id)
-                return Error(Conflict(message="Failed to persist user deactivation"))
+            if self._publisher:
+                await self._publisher.publish(
+                    entity_type="user", entity_id=user.id, operation="deactivate", tenant_id=tenant_id
+                )
 
             self._log_sync_failure(
                 await self._adapter.sync_user(user_id=user.id, data=sync_data),
@@ -200,6 +225,97 @@ class UserService:
             )
 
             return Ok(result_dict)
+
+    async def activate_user(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Set user status to active and sync to IdP.
+
+        Mirrors deactivate_user for reactivation.
+        """
+        with tracer.start_as_current_span("UserService.activate_user") as span:
+            span.set_attribute("tenant.id", str(tenant_id))
+            span.set_attribute("user.id", str(user_id))
+
+            user = await self._repository.get(user_id)
+            if user is None:
+                return Error(NotFound(message=f"User '{user_id}' not found"))
+
+            membership_err = await self._verify_tenant_membership(user_id, tenant_id)
+            if membership_err is not None:
+                return Error(membership_err)
+
+            user.status = UserStatus.active
+            try:
+                user = await self._repository.update(user)
+            except RepositoryConflictError:
+                return Error(Conflict(message="User activation conflicts with existing data"))
+
+            result_dict = user.model_dump()
+            sync_data = {"email": user.email, "status": user.status.value}
+            await self._repository.commit()
+
+            if self._publisher:
+                await self._publisher.publish(
+                    entity_type="user", entity_id=user.id, operation="activate", tenant_id=tenant_id
+                )
+
+            self._log_sync_failure(
+                await self._adapter.sync_user(user_id=user.id, data=sync_data),
+                user.id,
+                "activate",
+            )
+
+            return Ok(result_dict)
+
+    async def remove_user_from_tenant(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Remove a user's membership from a tenant by deleting all role assignments."""
+        with tracer.start_as_current_span("UserService.remove_user_from_tenant") as span:
+            span.set_attribute("tenant.id", str(tenant_id))
+            span.set_attribute("user.id", str(user_id))
+
+            user = await self._repository.get(user_id)
+            if user is None:
+                return Error(NotFound(message=f"User '{user_id}' not found"))
+
+            membership_err = await self._verify_tenant_membership(user_id, tenant_id)
+            if membership_err is not None:
+                return Error(membership_err)
+
+            if self._assignment_repository is None:
+                return Error(NotFound(message="Assignment repository not configured"))
+
+            deleted_count = await self._assignment_repository.delete_by_user_tenant(user_id, tenant_id)
+            if deleted_count == 0:
+                msg = f"No role assignments found for user '{user_id}' in tenant '{tenant_id}'"
+                return Error(NotFound(message=msg))
+
+            await self._assignment_repository.commit()
+
+            if self._publisher:
+                await self._publisher.publish(
+                    entity_type="user", entity_id=user_id, operation="unassign", tenant_id=tenant_id
+                )
+
+            # Best-effort sync: notify IdP of membership removal
+            self._log_sync_failure(
+                await self._adapter.sync_user(
+                    user_id=user_id,
+                    data={"email": user.email, "status": user.status.value},
+                ),
+                user_id,
+                "remove_user_from_tenant",
+            )
+
+            return Ok({"status": "removed", "user_id": str(user_id)})
 
     async def search_users(
         self,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "opentelemetry-instrumentation-httpx>=0.41b0",
     "opentelemetry-instrumentation-sqlalchemy>=0.41b0",
     "opentelemetry-instrumentation-logging>=0.41b0",
+    "redis[hiredis]>=5.0,<6",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/e2e/test_api_endpoints.py
+++ b/backend/tests/e2e/test_api_endpoints.py
@@ -53,6 +53,7 @@ class TestUnauthenticatedEndpoints:
             ("GET", "/api/permissions"),
             ("GET", "/api/keys"),
             ("GET", "/api/members"),
+            ("GET", "/api/providers"),
         ],
     )
     def test_protected_endpoints_return_401(
@@ -60,6 +61,24 @@ class TestUnauthenticatedEndpoints:
     ):
         """All protected endpoints return 401 without an auth token."""
         resp = api_context.get(f"{backend_url}{path}")
+        assert resp.status == 401, f"{method} {path} returned {resp.status}, expected 401"
+
+    @pytest.mark.parametrize(
+        "method,path",
+        [
+            ("POST", "/api/providers"),
+            ("GET", "/api/users/00000000-0000-0000-0000-000000000000/idp-links"),
+            ("POST", "/api/users/00000000-0000-0000-0000-000000000000/idp-links"),
+        ],
+    )
+    def test_new_write_endpoints_return_401(
+        self, api_context: APIRequestContext, backend_url: str, method: str, path: str
+    ):
+        """New write endpoints also require auth."""
+        if method == "POST":
+            resp = api_context.post(f"{backend_url}{path}", data="{}")
+        else:
+            resp = api_context.get(f"{backend_url}{path}")
         assert resp.status == 401, f"{method} {path} returned {resp.status}, expected 401"
 
 
@@ -137,6 +156,17 @@ class TestAdminEndpoints:
     def test_keys_list_responds(self, admin_api_context: APIRequestContext, backend_url: str):
         resp = admin_api_context.get(f"{backend_url}/api/keys")
         assert resp.status in (200, 403, 502), f"/api/keys returned {resp.status}"
+
+    def test_providers_list_responds(self, admin_api_context: APIRequestContext, backend_url: str):
+        """Providers endpoint responds (200/403 depending on token scope)."""
+        resp = admin_api_context.get(f"{backend_url}/api/providers")
+        assert resp.status in (200, 403), f"/api/providers returned {resp.status}"
+
+    def test_idp_links_responds(self, admin_api_context: APIRequestContext, backend_url: str):
+        """IdP links endpoint responds (200/403/404 depending on user existence)."""
+        fake_user = "00000000-0000-0000-0000-000000000000"
+        resp = admin_api_context.get(f"{backend_url}/api/users/{fake_user}/idp-links")
+        assert resp.status in (200, 403), f"/api/users/{{id}}/idp-links returned {resp.status}"
 
     def test_admin_endpoints_reject_non_admin_token(self, auth_api_context: APIRequestContext, backend_url: str):
         """Admin endpoints return 403 with a valid but non-admin token."""

--- a/backend/tests/e2e/test_identity_crud_e2e.py
+++ b/backend/tests/e2e/test_identity_crud_e2e.py
@@ -1,0 +1,585 @@
+"""E2E tests for canonical identity CRUD: users, roles, permissions, tenants.
+
+Validates 3-tier auth enforcement and canonical response shapes (id, created_at,
+updated_at) for Postgres-backed identity resources introduced by the onion
+architecture refactor (stories 2.1-2.4).
+
+Auth tiers:
+  - Tier 1: Unauthenticated (api_context) → 401
+  - Tier 2: Authenticated non-admin (auth_api_context) → 403
+  - Tier 3: Admin (admin_api_context) → success (200/201)
+"""
+
+import contextlib
+import os
+import time
+import uuid
+
+import pytest
+from playwright.sync_api import APIRequestContext
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DESCOPE_MANAGEMENT_KEY"),
+    reason="DESCOPE_MANAGEMENT_KEY not set",
+)
+
+MAX_API_RESPONSE_MS = 2000
+
+
+def _unique_name(prefix: str) -> str:
+    """Generate a unique name for test resources to avoid collisions."""
+    return f"{prefix}-e2e-{uuid.uuid4().hex[:8]}"
+
+
+def _timed_request(context: APIRequestContext, method: str, url: str, **kwargs) -> tuple:
+    """Execute a request and return (response, elapsed_ms)."""
+    start = time.monotonic()
+    if method == "GET":
+        resp = context.get(url, **kwargs)
+    elif method == "POST":
+        resp = context.post(url, **kwargs)
+    elif method == "PUT":
+        resp = context.put(url, **kwargs)
+    elif method == "DELETE":
+        resp = context.delete(url, **kwargs)
+    else:
+        raise ValueError(f"Unsupported method: {method}")
+    elapsed_ms = (time.monotonic() - start) * 1000
+    if not (200 <= resp.status < 300):
+        print(f"[E2E] {method} {url} → {resp.status}")
+    return resp, elapsed_ms
+
+
+# =============================================================================
+# 3-Tier Auth Enforcement
+# =============================================================================
+
+
+class TestMemberAuthEnforcement:
+    """Tier 1 (401) and Tier 2 (403) auth tests for /api/members endpoints."""
+
+    DUMMY_UUID = "00000000-0000-0000-0000-000000000000"
+
+    def test_unauth_list_members(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.get(f"{backend_url}/api/members")
+        assert resp.status == 401
+
+    def test_unauth_invite_member(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.post(
+            f"{backend_url}/api/members/invite",
+            data={"email": "nobody@test.example.com"},
+        )
+        assert resp.status == 401
+
+    def test_unauth_deactivate_member(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.post(f"{backend_url}/api/members/{self.DUMMY_UUID}/deactivate")
+        assert resp.status == 401
+
+    def test_unauth_activate_member(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.post(f"{backend_url}/api/members/{self.DUMMY_UUID}/activate")
+        assert resp.status == 401
+
+    def test_unauth_remove_member(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.delete(f"{backend_url}/api/members/{self.DUMMY_UUID}")
+        assert resp.status == 401
+
+    def test_nonadmin_list_members(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.get(f"{backend_url}/api/members")
+        assert resp.status == 403
+
+    def test_nonadmin_invite_member(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.post(
+            f"{backend_url}/api/members/invite",
+            data={"email": "nobody@test.example.com"},
+        )
+        assert resp.status == 403
+
+    def test_nonadmin_deactivate_member(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.post(f"{backend_url}/api/members/{self.DUMMY_UUID}/deactivate")
+        assert resp.status == 403
+
+    def test_nonadmin_activate_member(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.post(f"{backend_url}/api/members/{self.DUMMY_UUID}/activate")
+        assert resp.status == 403
+
+    def test_nonadmin_remove_member(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.delete(f"{backend_url}/api/members/{self.DUMMY_UUID}")
+        assert resp.status == 403
+
+
+class TestRoleAuthEnforcement:
+    """Tier 1 (401) and Tier 2 (403) auth tests for /api/roles CRUD endpoints."""
+
+    def test_unauth_list_roles(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.get(f"{backend_url}/api/roles")
+        assert resp.status == 401
+
+    def test_unauth_create_role(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.post(
+            f"{backend_url}/api/roles",
+            data={"name": "test", "description": "test"},
+        )
+        assert resp.status == 401
+
+    def test_unauth_update_role(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.put(
+            f"{backend_url}/api/roles/nonexistent",
+            data={"new_name": "test"},
+        )
+        assert resp.status == 401
+
+    def test_unauth_delete_role(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.delete(f"{backend_url}/api/roles/nonexistent")
+        assert resp.status == 401
+
+    def test_nonadmin_list_roles(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.get(f"{backend_url}/api/roles")
+        assert resp.status == 403
+
+    def test_nonadmin_create_role(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.post(
+            f"{backend_url}/api/roles",
+            data={"name": "test", "description": "test"},
+        )
+        assert resp.status == 403
+
+    def test_nonadmin_update_role(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.put(
+            f"{backend_url}/api/roles/nonexistent",
+            data={"new_name": "test"},
+        )
+        assert resp.status == 403
+
+    def test_nonadmin_delete_role(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.delete(f"{backend_url}/api/roles/nonexistent")
+        assert resp.status == 403
+
+
+class TestPermissionAuthEnforcement:
+    """Tier 1 (401) and Tier 2 (403) auth tests for /api/permissions endpoints."""
+
+    def test_unauth_list_permissions(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.get(f"{backend_url}/api/permissions")
+        assert resp.status == 401
+
+    def test_unauth_create_permission(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.post(
+            f"{backend_url}/api/permissions",
+            data={"name": "test", "description": "test"},
+        )
+        assert resp.status == 401
+
+    def test_unauth_update_permission(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.put(
+            f"{backend_url}/api/permissions/nonexistent",
+            data={"new_name": "test"},
+        )
+        assert resp.status == 401
+
+    def test_unauth_delete_permission(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.delete(f"{backend_url}/api/permissions/nonexistent")
+        assert resp.status == 401
+
+    def test_nonadmin_list_permissions(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.get(f"{backend_url}/api/permissions")
+        assert resp.status == 403
+
+    def test_nonadmin_create_permission(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.post(
+            f"{backend_url}/api/permissions",
+            data={"name": "test", "description": "test"},
+        )
+        assert resp.status == 403
+
+    def test_nonadmin_update_permission(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.put(
+            f"{backend_url}/api/permissions/nonexistent",
+            data={"new_name": "test"},
+        )
+        assert resp.status == 403
+
+    def test_nonadmin_delete_permission(self, auth_api_context: APIRequestContext, backend_url: str):
+        resp = auth_api_context.delete(f"{backend_url}/api/permissions/nonexistent")
+        assert resp.status == 403
+
+
+class TestTenantAuthEnforcement:
+    """Tier 1 (401) and Tier 2 (403) auth tests for /api/tenants endpoints."""
+
+    def test_unauth_list_tenants(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.get(f"{backend_url}/api/tenants")
+        assert resp.status == 401
+
+    def test_unauth_get_current_tenant(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.get(f"{backend_url}/api/tenants/current")
+        assert resp.status == 401
+
+    def test_unauth_create_tenant(self, api_context: APIRequestContext, backend_url: str):
+        resp = api_context.post(
+            f"{backend_url}/api/tenants",
+            data={"name": "test-tenant"},
+        )
+        assert resp.status == 401
+
+    def test_nonadmin_create_tenant(self, auth_api_context: APIRequestContext, backend_url: str):
+        """POST /tenants requires project-level admin role."""
+        resp = auth_api_context.post(
+            f"{backend_url}/api/tenants",
+            data={"name": "test-tenant"},
+        )
+        assert resp.status == 403
+
+    def test_nonadmin_get_current_tenant(self, auth_api_context: APIRequestContext, backend_url: str):
+        """GET /tenants/current requires dct claim — OIDC tokens lack it."""
+        resp = auth_api_context.get(f"{backend_url}/api/tenants/current")
+        assert resp.status == 403
+
+
+# =============================================================================
+# Tier 3: Admin CRUD Operations with Canonical Response Shapes
+# =============================================================================
+
+
+class TestPermissionCrudCanonical:
+    """Admin permission CRUD verifying canonical fields (id, created_at, updated_at)."""
+
+    def test_permission_create_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
+        """POST /permissions returns response with id (UUID), created_at, updated_at."""
+        perm_name = _unique_name("canon-perm")
+        try:
+            resp, elapsed_ms = _timed_request(
+                admin_api_context,
+                "POST",
+                f"{backend_url}/api/permissions",
+                data={"name": perm_name, "description": "canonical field test"},
+            )
+            assert resp.status == 201, f"Create failed: {resp.status}"
+            assert elapsed_ms < MAX_API_RESPONSE_MS
+
+            body = resp.json()
+            # Verify canonical fields exist
+            assert "id" in body, f"Missing 'id' in response: {body}"
+            assert "name" in body, f"Missing 'name' in response: {body}"
+            assert "created_at" in body, f"Missing 'created_at' in response: {body}"
+            assert "updated_at" in body, f"Missing 'updated_at' in response: {body}"
+            # Verify id is a valid UUID
+            uuid.UUID(str(body["id"]))
+            assert body["name"] == perm_name
+        finally:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/permissions/{perm_name}")
+
+    def test_permission_list_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
+        """GET /permissions returns list with canonical fields per item."""
+        perm_name = _unique_name("list-perm")
+        try:
+            # Create a permission so the list is non-empty
+            resp, _ = _timed_request(
+                admin_api_context,
+                "POST",
+                f"{backend_url}/api/permissions",
+                data={"name": perm_name, "description": "list test"},
+            )
+            assert resp.status == 201
+
+            resp, elapsed_ms = _timed_request(
+                admin_api_context,
+                "GET",
+                f"{backend_url}/api/permissions",
+            )
+            assert resp.status == 200, f"List failed: {resp.status}"
+            assert elapsed_ms < MAX_API_RESPONSE_MS
+
+            body = resp.json()
+            assert "permissions" in body
+            permissions = body["permissions"]
+            assert len(permissions) > 0
+
+            # Find our created permission and verify canonical fields
+            match = next((p for p in permissions if p["name"] == perm_name), None)
+            assert match is not None, f"Created permission '{perm_name}' not in list"
+            assert "id" in match
+            assert "created_at" in match
+            assert "updated_at" in match
+            uuid.UUID(str(match["id"]))
+        finally:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/permissions/{perm_name}")
+
+    def test_permission_update_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
+        """PUT /permissions/{name} returns updated resource with canonical fields."""
+        perm_name = _unique_name("upd-perm")
+        new_name = perm_name + "-renamed"
+        cleanup_name = perm_name
+        try:
+            resp, _ = _timed_request(
+                admin_api_context,
+                "POST",
+                f"{backend_url}/api/permissions",
+                data={"name": perm_name, "description": "update test"},
+            )
+            assert resp.status == 201
+
+            resp, elapsed_ms = _timed_request(
+                admin_api_context,
+                "PUT",
+                f"{backend_url}/api/permissions/{perm_name}",
+                data={"new_name": new_name, "description": "updated"},
+            )
+            assert resp.status == 200, f"Update failed: {resp.status}"
+            cleanup_name = new_name  # update before further assertions — rename already happened
+            assert elapsed_ms < MAX_API_RESPONSE_MS
+
+            body = resp.json()
+            assert "id" in body
+            assert "updated_at" in body
+            assert body["name"] == new_name
+        finally:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/permissions/{cleanup_name}")
+
+
+class TestRoleCrudCanonical:
+    """Admin role CRUD verifying canonical fields (id, created_at, updated_at)."""
+
+    def test_role_create_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
+        """POST /roles returns response with id (UUID), created_at, updated_at."""
+        role_name = _unique_name("canon-role")
+        try:
+            resp, elapsed_ms = _timed_request(
+                admin_api_context,
+                "POST",
+                f"{backend_url}/api/roles",
+                data={"name": role_name, "description": "canonical field test"},
+            )
+            assert resp.status == 201, f"Create failed: {resp.status}"
+            assert elapsed_ms < MAX_API_RESPONSE_MS
+
+            body = resp.json()
+            assert "id" in body, f"Missing 'id' in response: {body}"
+            assert "name" in body, f"Missing 'name' in response: {body}"
+            assert "created_at" in body, f"Missing 'created_at' in response: {body}"
+            assert "updated_at" in body, f"Missing 'updated_at' in response: {body}"
+            uuid.UUID(str(body["id"]))
+            assert body["name"] == role_name
+        finally:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/roles/{role_name}")
+
+    def test_role_list_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
+        """GET /roles returns list with canonical fields per item."""
+        role_name = _unique_name("list-role")
+        try:
+            resp, _ = _timed_request(
+                admin_api_context,
+                "POST",
+                f"{backend_url}/api/roles",
+                data={"name": role_name, "description": "list test"},
+            )
+            assert resp.status == 201
+
+            resp, elapsed_ms = _timed_request(
+                admin_api_context,
+                "GET",
+                f"{backend_url}/api/roles",
+            )
+            assert resp.status == 200, f"List failed: {resp.status}"
+            assert elapsed_ms < MAX_API_RESPONSE_MS
+
+            body = resp.json()
+            assert "roles" in body
+            roles = body["roles"]
+            assert len(roles) > 0
+
+            match = next((r for r in roles if r["name"] == role_name), None)
+            assert match is not None, f"Created role '{role_name}' not in list"
+            assert "id" in match
+            assert "created_at" in match
+            assert "updated_at" in match
+            uuid.UUID(str(match["id"]))
+        finally:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/roles/{role_name}")
+
+    def test_role_update_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
+        """PUT /roles/{name} returns updated resource with canonical fields."""
+        role_name = _unique_name("upd-role")
+        new_name = role_name + "-renamed"
+        cleanup_name = role_name
+        try:
+            resp, _ = _timed_request(
+                admin_api_context,
+                "POST",
+                f"{backend_url}/api/roles",
+                data={"name": role_name, "description": "update test"},
+            )
+            assert resp.status == 201
+
+            resp, elapsed_ms = _timed_request(
+                admin_api_context,
+                "PUT",
+                f"{backend_url}/api/roles/{role_name}",
+                data={"new_name": new_name, "description": "updated"},
+            )
+            assert resp.status == 200, f"Update failed: {resp.status}"
+            cleanup_name = new_name  # update before further assertions — rename already happened
+            assert elapsed_ms < MAX_API_RESPONSE_MS
+
+            body = resp.json()
+            assert "id" in body
+            assert "updated_at" in body
+            assert body["name"] == new_name
+        finally:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/roles/{cleanup_name}")
+
+
+class TestMemberCrud:
+    """Admin member CRUD operations via /api/members endpoints."""
+
+    def test_list_members(self, admin_api_context: APIRequestContext, backend_url: str):
+        """GET /members returns list of tenant members."""
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "GET",
+            f"{backend_url}/api/members",
+        )
+        assert resp.status == 200, f"List members failed: {resp.status}"
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+
+        body = resp.json()
+        assert "members" in body
+        assert isinstance(body["members"], list)
+
+    def test_invite_member_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
+        """POST /members/invite creates user with canonical fields in response."""
+        test_email = f"e2e-invite-{uuid.uuid4().hex[:8]}@test.example.com"
+        created_user_id = None
+        try:
+            resp, elapsed_ms = _timed_request(
+                admin_api_context,
+                "POST",
+                f"{backend_url}/api/members/invite",
+                data={"email": test_email, "role_names": ["member"]},
+            )
+            # Router returns 200 (no status_code=201 on decorator) or 207 (sync failed)
+            assert resp.status in (200, 207), f"Invite failed: {resp.status}"
+            assert elapsed_ms < MAX_API_RESPONSE_MS
+
+            body = resp.json()
+            if resp.status == 207:
+                # 207 = Postgres OK, Descope sync failed → RFC 9457 Problem Detail
+                # Extract user_id from inner detail if available, otherwise skip
+                pytest.skip("Invite returned 207 (sync failed) — canonical fields not in Problem Detail body")
+            assert "user" in body, f"Missing 'user' key in invite response: {body.keys()}"
+            user = body["user"]
+            assert "id" in user, f"Missing 'id' in user response: {user}"
+            assert "created_at" in user, f"Missing 'created_at' in user response: {user}"
+            created_user_id = str(user["id"])
+        finally:
+            if created_user_id:
+                with contextlib.suppress(Exception):
+                    admin_api_context.delete(f"{backend_url}/api/members/{created_user_id}")
+
+    def test_member_deactivate_activate_lifecycle(self, admin_api_context: APIRequestContext, backend_url: str):
+        """Invite → deactivate → activate → remove lifecycle."""
+        test_email = f"e2e-lifecycle-{uuid.uuid4().hex[:8]}@test.example.com"
+        created_user_id = None
+        try:
+            # Invite
+            resp, _ = _timed_request(
+                admin_api_context,
+                "POST",
+                f"{backend_url}/api/members/invite",
+                data={"email": test_email, "role_names": ["member"]},
+            )
+            # Router returns 200 (no status_code=201 on decorator) or 207 (sync failed)
+            assert resp.status in (200, 207), f"Invite failed: {resp.status}"
+            body = resp.json()
+            if resp.status != 207 and "user" in body and "id" in body["user"]:
+                created_user_id = str(body["user"]["id"])
+
+            if not created_user_id:
+                pytest.skip("Could not extract user_id from invite response")
+
+            # Deactivate
+            resp, elapsed_ms = _timed_request(
+                admin_api_context,
+                "POST",
+                f"{backend_url}/api/members/{created_user_id}/deactivate",
+            )
+            assert resp.status == 200, f"Deactivate failed: {resp.status}"
+            assert elapsed_ms < MAX_API_RESPONSE_MS
+            body = resp.json()
+            assert body.get("status") == "deactivated"
+
+            # Activate
+            resp, elapsed_ms = _timed_request(
+                admin_api_context,
+                "POST",
+                f"{backend_url}/api/members/{created_user_id}/activate",
+            )
+            assert resp.status == 200, f"Activate failed: {resp.status}"
+            assert elapsed_ms < MAX_API_RESPONSE_MS
+            body = resp.json()
+            assert body.get("status") == "activated"
+
+            # Remove
+            resp, elapsed_ms = _timed_request(
+                admin_api_context,
+                "DELETE",
+                f"{backend_url}/api/members/{created_user_id}",
+            )
+            assert resp.status == 200, f"Remove failed: {resp.status}"
+            assert elapsed_ms < MAX_API_RESPONSE_MS
+            body = resp.json()
+            assert body.get("status") == "removed"
+            created_user_id = None  # cleaned up
+        finally:
+            if created_user_id:
+                with contextlib.suppress(Exception):
+                    admin_api_context.delete(f"{backend_url}/api/members/{created_user_id}")
+
+
+class TestTenantOperations:
+    """Admin tenant operations via /api/tenants endpoints."""
+
+    def test_list_tenants_returns_jwt_tenants(self, admin_api_context: APIRequestContext, backend_url: str):
+        """GET /tenants returns tenants from JWT claims."""
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "GET",
+            f"{backend_url}/api/tenants",
+        )
+        assert resp.status == 200, f"List tenants failed: {resp.status}"
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+
+        body = resp.json()
+        assert "tenants" in body
+        tenants = body["tenants"]
+        assert isinstance(tenants, list)
+        assert len(tenants) > 0, "Admin token should have at least one tenant"
+
+        # Each tenant should have id, roles, permissions
+        for tenant in tenants:
+            assert "id" in tenant
+            assert "roles" in tenant
+            assert "permissions" in tenant
+
+    def test_get_current_tenant(self, admin_api_context: APIRequestContext, backend_url: str):
+        """GET /tenants/current returns current tenant context from dct claim."""
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "GET",
+            f"{backend_url}/api/tenants/current",
+        )
+        assert resp.status == 200, f"Get current tenant failed: {resp.status}"
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+
+        body = resp.json()
+        assert "tenant_id" in body
+        assert "tenant" in body, f"Missing 'tenant' key in current tenant response: {body.keys()}"
+        tenant = body["tenant"]
+        assert "id" in tenant, f"Missing 'id' in tenant response: {tenant}"
+        assert "created_at" in tenant, f"Missing 'created_at' in tenant response: {tenant}"
+        assert "updated_at" in tenant, f"Missing 'updated_at' in tenant response: {tenant}"

--- a/backend/tests/e2e/test_internal_endpoints_e2e.py
+++ b/backend/tests/e2e/test_internal_endpoints_e2e.py
@@ -1,0 +1,307 @@
+"""E2E tests for internal endpoints: flow sync + webhook + reconciliation + identity resolution.
+
+Story 3.1 ACs:
+  AC-3.1.4: /api/internal/ prefix bypasses JWT auth.
+  AC-3.1.3: Webhook HMAC validation rejects unauthenticated requests.
+Story 3.4 ACs:
+  AC-3.4.4: E2E regression — authenticated sync endpoint tests.
+Story 4.3 ACs:
+  AC-4.3.1: GET /api/internal/identity — identity resolution endpoint.
+  AC-4.3.4: Identity endpoint bypasses JWT auth.
+
+Internal endpoints do not use the 3-tier JWT auth model. Instead:
+- Flow sync: shared secret (X-Flow-Secret header)
+- Webhook: HMAC-SHA256 signature validation
+- Reconciliation: shared secret (X-Flow-Secret header)
+- Identity resolution: shared secret (X-Identity-Key header)
+
+These tests validate behavior against a running backend without needing
+Descope credentials (internal endpoints bypass JWT).
+"""
+
+import hashlib
+import hmac as hmac_mod
+import json
+import os
+import uuid
+
+import pytest
+from playwright.sync_api import APIRequestContext
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DESCOPE_MANAGEMENT_KEY"),
+    reason="DESCOPE_MANAGEMENT_KEY not set",
+)
+
+
+class TestInternalEndpointAuthBypass:
+    """AC-3.1.4: Internal endpoints bypass JWT auth — accessible without Bearer token."""
+
+    def test_flow_sync_accessible_without_jwt(self, api_context: APIRequestContext, backend_url: str):
+        """POST /api/internal/users/sync does not require Authorization header.
+
+        Without X-Flow-Secret header, returns 422 (missing header) — NOT 401 from JWT.
+        This proves the internal prefix bypasses JWT auth.
+        """
+        resp = api_context.post(
+            f"{backend_url}/api/internal/users/sync",
+            data=json.dumps(
+                {
+                    "user_id": f"e2e-test-{uuid.uuid4().hex[:8]}",
+                    "email": f"e2e-{uuid.uuid4().hex[:8]}@test.example.com",
+                }
+            ),
+            headers={"Content-Type": "application/json"},
+        )
+        # 422 (missing X-Flow-Secret header) proves JWT was bypassed
+        assert resp.status == 422, f"Expected 422 (missing header), got {resp.status}"
+
+    def test_webhook_accessible_without_jwt(self, api_context: APIRequestContext, backend_url: str):
+        """POST /api/internal/webhooks/descope does not return JWT 401.
+
+        Without HMAC header, FastAPI returns 422 (missing header), not 401 from JWT.
+        """
+        resp = api_context.post(
+            f"{backend_url}/api/internal/webhooks/descope",
+            data=json.dumps({"event_type": "user.created", "data": {}}),
+            headers={"Content-Type": "application/json"},
+        )
+        # 422 (missing HMAC header) proves JWT was bypassed
+        assert resp.status == 422, f"Expected 422 (missing HMAC header), got {resp.status}"
+
+
+class TestWebhookHmacValidation:
+    """AC-3.1.3: Webhook HMAC-SHA256 validation."""
+
+    def test_webhook_rejects_invalid_hmac(self, api_context: APIRequestContext, backend_url: str):
+        """Invalid HMAC signature → 401 from HMAC validation, not JWT."""
+        resp = api_context.post(
+            f"{backend_url}/api/internal/webhooks/descope",
+            data=json.dumps({"event_type": "user.created", "data": {}}),
+            headers={
+                "Content-Type": "application/json",
+                "X-Descope-Webhook-S256": "invalid-signature-value",
+            },
+        )
+        assert resp.status == 401
+
+    def test_webhook_rejects_missing_hmac_header(self, api_context: APIRequestContext, backend_url: str):
+        """Missing X-Descope-Webhook-S256 header → 422 (FastAPI header validation)."""
+        resp = api_context.post(
+            f"{backend_url}/api/internal/webhooks/descope",
+            data=json.dumps({"event_type": "user.created", "data": {}}),
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status == 422
+
+
+class TestFlowSyncEndpoint:
+    """AC-3.1.1: Flow HTTP Connector sync endpoint behavior."""
+
+    def test_flow_sync_missing_email_returns_422(self, api_context: APIRequestContext, backend_url: str):
+        """Missing required field (email) → Pydantic 422."""
+        resp = api_context.post(
+            f"{backend_url}/api/internal/users/sync",
+            data=json.dumps({"user_id": "test-123"}),
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status == 422
+
+    def test_flow_sync_invalid_email_returns_422(self, api_context: APIRequestContext, backend_url: str):
+        """Invalid email format → Pydantic 422."""
+        resp = api_context.post(
+            f"{backend_url}/api/internal/users/sync",
+            data=json.dumps({"user_id": "test-123", "email": "not-an-email"}),
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status == 422
+
+
+# --- AC-3.4.4: E2E regression with valid credentials ---
+
+_has_flow_secret = bool(os.environ.get("DESCOPE_FLOW_SYNC_SECRET"))
+_has_webhook_secret = bool(os.environ.get("DESCOPE_WEBHOOK_SECRET"))
+
+
+@pytest.mark.skipif(not _has_flow_secret, reason="DESCOPE_FLOW_SYNC_SECRET not set")
+class TestFlowSyncWithSecret:
+    """AC-3.4.4: Flow sync endpoint with valid shared secret."""
+
+    def test_valid_secret_passes_auth_and_returns_json(self, api_context: APIRequestContext, backend_url: str):
+        """Flow sync with valid X-Flow-Secret passes auth, returns structured JSON.
+
+        Success → {"user": {...}, "created": true/false}
+        Service error → RFC 9457 problem detail with type/title/detail.
+        """
+        secret = os.environ["DESCOPE_FLOW_SYNC_SECRET"]
+        resp = api_context.post(
+            f"{backend_url}/api/internal/users/sync",
+            data=json.dumps(
+                {
+                    "user_id": f"e2e-sync-{uuid.uuid4().hex[:8]}",
+                    "email": f"e2e-sync-{uuid.uuid4().hex[:8]}@test.example.com",
+                    "name": "E2E Sync Test",
+                }
+            ),
+            headers={"Content-Type": "application/json", "X-Flow-Secret": secret},
+        )
+        assert resp.status != 401, "Valid secret should not be rejected"
+        body = resp.json()
+        assert isinstance(body, dict)
+        if resp.status in (200, 201):
+            assert "user" in body, "Success response must include 'user'"
+            assert "created" in body, "Success response must include 'created'"
+        else:
+            # RFC 9457 problem detail
+            assert "type" in body, "Error response must be RFC 9457 problem detail"
+            assert "title" in body
+            assert "detail" in body
+
+    def test_idempotent_replay_returns_consistent_shape(self, api_context: APIRequestContext, backend_url: str):
+        """Replaying the same flow sync request twice returns consistent response shape.
+
+        Both requests should either succeed (200/201) or fail identically.
+        No duplicate user creation or crashes on replay.
+        """
+        secret = os.environ["DESCOPE_FLOW_SYNC_SECRET"]
+        user_id = f"e2e-replay-{uuid.uuid4().hex[:8]}"
+        email = f"e2e-replay-{uuid.uuid4().hex[:8]}@test.example.com"
+        payload = json.dumps({"user_id": user_id, "email": email, "name": "Replay Test"})
+        headers = {"Content-Type": "application/json", "X-Flow-Secret": secret}
+
+        resp1 = api_context.post(f"{backend_url}/api/internal/users/sync", data=payload, headers=headers)
+        resp2 = api_context.post(f"{backend_url}/api/internal/users/sync", data=payload, headers=headers)
+
+        # Both pass auth
+        assert resp1.status != 401
+        assert resp2.status != 401
+
+        # Consistent response shape (same keys in both)
+        body1 = resp1.json()
+        body2 = resp2.json()
+        assert body1.keys() == body2.keys(), "Replay must return same response shape"
+
+        # If both succeed, verify baseline and idempotency
+        if resp1.status in (200, 201) and resp2.status in (200, 201):
+            assert body1["created"] is True, "First call should create user"
+            assert body2["created"] is False, "Replay should update, not create duplicate"
+
+
+@pytest.mark.skipif(not _has_webhook_secret, reason="DESCOPE_WEBHOOK_SECRET not set")
+class TestWebhookWithValidHmac:
+    """AC-3.4.4: Webhook endpoint with valid HMAC signature."""
+
+    def test_valid_hmac_passes_auth_and_returns_json(self, api_context: APIRequestContext, backend_url: str):
+        """Webhook with correctly computed HMAC-SHA256 passes auth."""
+        secret = os.environ["DESCOPE_WEBHOOK_SECRET"]
+        body_str = json.dumps({"event_type": "user.created", "data": {"user_id": "e2e-hmac-test"}})
+        signature = hmac_mod.new(secret.encode(), body_str.encode(), hashlib.sha256).hexdigest()
+
+        resp = api_context.post(
+            f"{backend_url}/api/internal/webhooks/descope",
+            data=body_str,
+            headers={
+                "Content-Type": "application/json",
+                "X-Descope-Webhook-S256": signature,
+            },
+        )
+        # 200 proves HMAC accepted and event processed (not just "not 401")
+        assert resp.status == 200, f"Valid HMAC should return 200, got {resp.status}"
+        body = resp.json()
+        assert isinstance(body, dict)
+
+
+@pytest.mark.skipif(not _has_flow_secret, reason="DESCOPE_FLOW_SYNC_SECRET not set")
+class TestReconciliationEndpointE2E:
+    """AC-3.4.4: Reconciliation trigger endpoint with valid secret."""
+
+    def test_reconciliation_trigger_returns_json(self, api_context: APIRequestContext, backend_url: str):
+        """Reconciliation trigger with valid X-Flow-Secret returns structured JSON.
+
+        Success → {"status": "completed", "stats": {...}}
+        Service error → RFC 9457 problem detail.
+        """
+        secret = os.environ["DESCOPE_FLOW_SYNC_SECRET"]
+        resp = api_context.post(
+            f"{backend_url}/api/internal/reconciliation/run",
+            headers={"Content-Type": "application/json", "X-Flow-Secret": secret},
+        )
+        assert resp.status != 401, "Valid secret should not be rejected"
+        body = resp.json()
+        assert isinstance(body, dict)
+        if resp.status == 200:
+            assert "status" in body, "Success response must include 'status'"
+            assert "stats" in body, "Success response must include 'stats'"
+        else:
+            # RFC 9457 problem detail
+            assert "type" in body, "Error response must be RFC 9457 problem detail"
+            assert "title" in body, "Error response must include 'title'"
+            assert "detail" in body, "Error response must include 'detail'"
+
+
+# --- AC-4.3.1 / AC-4.3.4: Identity resolution endpoint ---
+
+_IDENTITY_KEY = os.environ.get("INTERNAL_IDENTITY_KEY", "")
+
+
+@pytest.mark.skipif(not os.environ.get("INTERNAL_IDENTITY_KEY"), reason="INTERNAL_IDENTITY_KEY not set")
+class TestIdentityResolutionEndpoint:
+    """AC-4.3.1 + AC-4.3.4: Identity resolution requires shared-secret auth, bypasses JWT."""
+
+    def _identity_headers(self) -> dict[str, str]:
+        return {"X-Identity-Key": _IDENTITY_KEY} if _IDENTITY_KEY else {}
+
+    def test_identity_endpoint_bypasses_jwt(self, api_context: APIRequestContext, backend_url: str):
+        """GET /api/internal/identity does not require Authorization header.
+
+        Without X-Identity-Key, returns 422 (missing header) — NOT 401 from JWT.
+        This proves the internal prefix bypasses JWT auth (AC-4.3.4).
+        """
+        resp = api_context.get(f"{backend_url}/api/internal/identity")
+        # 422 (missing X-Identity-Key header) proves JWT was bypassed
+        assert resp.status == 422, f"Expected 422 (missing header), got {resp.status}"
+
+    def test_identity_missing_sub_param(self, api_context: APIRequestContext, backend_url: str):
+        """Missing 'sub' query parameter → 422."""
+        resp = api_context.get(
+            f"{backend_url}/api/internal/identity",
+            params={"provider": "descope"},
+            headers=self._identity_headers(),
+        )
+        assert resp.status == 422
+
+    def test_identity_missing_provider_param(self, api_context: APIRequestContext, backend_url: str):
+        """Missing 'provider' query parameter → 422."""
+        resp = api_context.get(
+            f"{backend_url}/api/internal/identity",
+            params={"sub": "ext-123"},
+            headers=self._identity_headers(),
+        )
+        assert resp.status == 422
+
+    def test_identity_unknown_provider_returns_404(self, api_context: APIRequestContext, backend_url: str):
+        """Unknown provider name returns 404 (not 401 or 500)."""
+        resp = api_context.get(
+            f"{backend_url}/api/internal/identity",
+            params={"sub": "ext-123", "provider": f"nonexistent-{uuid.uuid4().hex[:8]}"},
+            headers=self._identity_headers(),
+        )
+        assert resp.status == 404, f"Expected 404 for unknown provider, got {resp.status}"
+        body = resp.json()
+        # RFC 9457 problem detail
+        assert "type" in body
+        assert "title" in body
+        assert "detail" in body
+
+    def test_identity_unknown_sub_returns_404(self, api_context: APIRequestContext, backend_url: str):
+        """Unknown sub for existing provider returns 404.
+
+        Even if 'descope' provider exists, a non-existent sub should get 404.
+        If 'descope' provider doesn't exist either, also 404 — both are valid.
+        """
+        resp = api_context.get(
+            f"{backend_url}/api/internal/identity",
+            params={"sub": f"nonexistent-{uuid.uuid4().hex[:8]}", "provider": "descope"},
+            headers=self._identity_headers(),
+        )
+        assert resp.status == 404, f"Expected 404 for unknown sub, got {resp.status}"

--- a/backend/tests/e2e/test_multi_idp_e2e.py
+++ b/backend/tests/e2e/test_multi_idp_e2e.py
@@ -1,0 +1,202 @@
+"""E2E tests for multi-IdP features: provider + IdP link endpoints.
+
+AC-4.4.5: E2E regression — IdP link management + provider config endpoints.
+
+Auth tiers:
+  - Tier 1: Unauthenticated (api_context) → 401
+  - Tier 2: Authenticated non-admin (auth_api_context) → 403
+  - Tier 3: Admin (admin_api_context) → success for IdP links, 403 for providers (requires operator)
+
+Provider endpoints require the ``operator`` role, which is distinct from
+``owner``/``admin``. E2E tests validate auth enforcement; CRUD success
+for providers is covered by unit + integration tests.
+"""
+
+import os
+import uuid
+
+import pytest
+from playwright.sync_api import APIRequestContext
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DESCOPE_MANAGEMENT_KEY"),
+    reason="DESCOPE_MANAGEMENT_KEY not set",
+)
+
+DUMMY_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+# =============================================================================
+# Provider Auth Enforcement (requires "operator" role)
+# =============================================================================
+
+
+class TestProviderAuthEnforcement:
+    """Auth enforcement for /api/providers endpoints (operator role required)."""
+
+    def test_unauth_list_providers(self, api_context: APIRequestContext, backend_url: str):
+        """GET /providers without auth → 401."""
+        resp = api_context.get(f"{backend_url}/api/providers")
+        assert resp.status == 401
+
+    def test_unauth_register_provider(self, api_context: APIRequestContext, backend_url: str):
+        """POST /providers without auth → 401."""
+        resp = api_context.post(
+            f"{backend_url}/api/providers",
+            data={"name": "test", "type": "oidc"},
+        )
+        assert resp.status == 401
+
+    def test_unauth_deactivate_provider(self, api_context: APIRequestContext, backend_url: str):
+        """PATCH /providers/{id} without auth → 401."""
+        resp = api_context.patch(
+            f"{backend_url}/api/providers/{DUMMY_UUID}",
+            data={"active": False},
+        )
+        assert resp.status == 401
+
+    def test_unauth_get_capabilities(self, api_context: APIRequestContext, backend_url: str):
+        """GET /providers/{id}/capabilities without auth → 401."""
+        resp = api_context.get(f"{backend_url}/api/providers/{DUMMY_UUID}/capabilities")
+        assert resp.status == 401
+
+    def test_nonadmin_list_providers(self, auth_api_context: APIRequestContext, backend_url: str):
+        """GET /providers with non-operator auth → 403."""
+        resp = auth_api_context.get(f"{backend_url}/api/providers")
+        assert resp.status == 403
+
+    def test_nonadmin_register_provider(self, auth_api_context: APIRequestContext, backend_url: str):
+        """POST /providers with non-operator auth → 403."""
+        resp = auth_api_context.post(
+            f"{backend_url}/api/providers",
+            data={"name": "test", "type": "oidc"},
+        )
+        assert resp.status == 403
+
+    def test_admin_list_providers_requires_operator(self, admin_api_context: APIRequestContext, backend_url: str):
+        """GET /providers with admin role (not operator) → 403.
+
+        Proves that the operator role is enforced separately from owner/admin.
+        """
+        resp = admin_api_context.get(f"{backend_url}/api/providers")
+        assert resp.status == 403
+
+
+# =============================================================================
+# IdP Link Auth Enforcement (requires "owner" or "admin" role)
+# =============================================================================
+
+
+class TestIdPLinkAuthEnforcement:
+    """Auth enforcement for /api/users/{user_id}/idp-links endpoints."""
+
+    def test_unauth_list_idp_links(self, api_context: APIRequestContext, backend_url: str):
+        """GET /users/{id}/idp-links without auth → 401."""
+        resp = api_context.get(f"{backend_url}/api/users/{DUMMY_UUID}/idp-links")
+        assert resp.status == 401
+
+    def test_unauth_create_idp_link(self, api_context: APIRequestContext, backend_url: str):
+        """POST /users/{id}/idp-links without auth → 401."""
+        resp = api_context.post(
+            f"{backend_url}/api/users/{DUMMY_UUID}/idp-links",
+            data={"provider_id": DUMMY_UUID, "external_sub": "ext-123"},
+        )
+        assert resp.status == 401
+
+    def test_unauth_delete_idp_link(self, api_context: APIRequestContext, backend_url: str):
+        """DELETE /users/{id}/idp-links/{link_id} without auth → 401."""
+        resp = api_context.delete(f"{backend_url}/api/users/{DUMMY_UUID}/idp-links/{DUMMY_UUID}")
+        assert resp.status == 401
+
+    def test_nonadmin_list_idp_links(self, auth_api_context: APIRequestContext, backend_url: str):
+        """GET /users/{id}/idp-links with non-admin auth → 403."""
+        resp = auth_api_context.get(f"{backend_url}/api/users/{DUMMY_UUID}/idp-links")
+        assert resp.status == 403
+
+    def test_nonadmin_create_idp_link(self, auth_api_context: APIRequestContext, backend_url: str):
+        """POST /users/{id}/idp-links with non-admin auth → 403."""
+        resp = auth_api_context.post(
+            f"{backend_url}/api/users/{DUMMY_UUID}/idp-links",
+            data={"provider_id": DUMMY_UUID, "external_sub": "ext-123"},
+        )
+        assert resp.status == 403
+
+
+# =============================================================================
+# IdP Link CRUD with Admin Context
+# =============================================================================
+
+
+class TestIdPLinkCrudAdmin:
+    """Admin-level IdP link operations via /api/users/{user_id}/idp-links."""
+
+    def test_list_idp_links_for_user(self, admin_api_context: APIRequestContext, backend_url: str):
+        """GET /users/{id}/idp-links returns structured response.
+
+        Uses a dummy user_id — may return empty list or 404 depending on whether
+        the user exists. Either way it should NOT return 401/403 (auth passes).
+        """
+        resp = admin_api_context.get(f"{backend_url}/api/users/{DUMMY_UUID}/idp-links")
+        # Admin auth should pass — result depends on whether user exists
+        assert resp.status in (200, 404), f"Expected 200 or 404, got {resp.status}"
+        if resp.status == 200:
+            body = resp.json()
+            assert "idp_links" in body
+            assert isinstance(body["idp_links"], list)
+
+    def test_create_idp_link_nonexistent_user(self, admin_api_context: APIRequestContext, backend_url: str):
+        """POST /users/{id}/idp-links with nonexistent user → 404."""
+        fake_user_id = str(uuid.uuid4())
+        fake_provider_id = str(uuid.uuid4())
+        resp = admin_api_context.post(
+            f"{backend_url}/api/users/{fake_user_id}/idp-links",
+            data={
+                "provider_id": fake_provider_id,
+                "external_sub": f"ext-{uuid.uuid4().hex[:8]}",
+            },
+        )
+        # User doesn't exist → 404 from service
+        assert resp.status == 404, f"Expected 404 for nonexistent user, got {resp.status}"
+        body = resp.json()
+        assert "type" in body  # RFC 9457 problem detail
+        assert "detail" in body
+
+    def test_delete_idp_link_nonexistent(self, admin_api_context: APIRequestContext, backend_url: str):
+        """DELETE /users/{id}/idp-links/{link_id} with nonexistent IDs → 404."""
+        fake_user_id = str(uuid.uuid4())
+        fake_link_id = str(uuid.uuid4())
+        resp = admin_api_context.delete(
+            f"{backend_url}/api/users/{fake_user_id}/idp-links/{fake_link_id}",
+        )
+        assert resp.status == 404, f"Expected 404, got {resp.status}"
+
+
+# =============================================================================
+# Identity Resolution Endpoint (internal, no JWT)
+# =============================================================================
+
+
+class TestIdentityResolutionRegression:
+    """Regression: identity resolution endpoint continues to work after multi-IdP changes."""
+
+    def test_identity_endpoint_still_bypasses_jwt(self, api_context: APIRequestContext, backend_url: str):
+        """GET /api/internal/identity still bypasses JWT auth (AC-4.3.4 regression)."""
+        resp = api_context.get(f"{backend_url}/api/internal/identity")
+        # 422 (missing params/header) proves JWT was bypassed — not 401
+        assert resp.status == 422, f"Expected 422, got {resp.status}"
+
+    def test_identity_unknown_provider_still_returns_404(self, api_context: APIRequestContext, backend_url: str):
+        """GET /api/internal/identity with unknown provider still returns 404."""
+        identity_key = os.environ.get("INTERNAL_IDENTITY_KEY", "")
+        headers = {}
+        if identity_key:
+            headers["X-Identity-Key"] = identity_key
+        resp = api_context.get(
+            f"{backend_url}/api/internal/identity",
+            params={"sub": "ext-123", "provider": f"nonexistent-{uuid.uuid4().hex[:8]}"},
+            headers=headers,
+        )
+        # Without the key we may get 401/403; with it we get 404
+        assert resp.status in (401, 403, 404), f"Expected 401/403/404, got {resp.status}"
+        if not identity_key:
+            pytest.skip("INTERNAL_IDENTITY_KEY not set — cannot verify 404 for unknown provider")

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,8 +1,9 @@
 """Shared fixtures for integration tests.
 
-Two fixture groups:
+Three fixture groups:
 1. Descope fixtures — for live integration tests against a Descope instance
 2. Postgres fixtures — testcontainers-based real Postgres with Alembic migrations
+3. Redis fixtures — testcontainers-based real Redis for cache tests
 """
 
 import os
@@ -10,6 +11,7 @@ import os
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/testdb")
 
 import pytest
+import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from py_identity_model import (
     ClientCredentialsTokenRequest,
@@ -19,6 +21,7 @@ from py_identity_model import (
 )
 from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
 from testcontainers.postgres import PostgresContainer
 
 
@@ -122,49 +125,49 @@ def postgres_url(postgres_container):
 
 @pytest.fixture(scope="session")
 def _run_migrations(postgres_url):
-    """Run Alembic migrations against the test Postgres instance (once per session)."""
-    from alembic import command
-    from alembic.config import Config
+    """Run Alembic migrations against the test Postgres instance (once per session).
 
-    # Set DATABASE_URL so migrations/env.py picks it up; restore original after
-    original_url = os.environ.get("DATABASE_URL")
-    os.environ["DATABASE_URL"] = postgres_url
-    try:
-        project_root = os.path.join(os.path.dirname(__file__), "..", "..")
-        alembic_cfg = Config(os.path.join(project_root, "alembic.ini"))
-        alembic_cfg.set_main_option("script_location", os.path.join(project_root, "migrations"))
-        command.upgrade(alembic_cfg, "head")
-    finally:
-        if original_url is None:
-            os.environ.pop("DATABASE_URL", None)
-        else:
-            os.environ["DATABASE_URL"] = original_url
+    Uses subprocess to avoid asyncio.run() inside Alembic's env.py from
+    interfering with the pytest-asyncio session event loop.
+    """
+    import subprocess
+    import sys
+
+    project_root = os.path.join(os.path.dirname(__file__), "..", "..")
+    env = os.environ.copy()
+    env["DATABASE_URL"] = postgres_url
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=project_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Alembic migration failed:\nstdout={result.stdout}\nstderr={result.stderr}")
 
 
 @pytest.fixture(scope="session")
 def async_engine(postgres_url, _run_migrations):
     """Create an async engine pointing at the test Postgres instance."""
-    engine = create_async_engine(postgres_url, echo=False)
+    engine = create_async_engine(postgres_url, echo=False, poolclass=NullPool)
     return engine
 
 
-@pytest.fixture
+@pytest_asyncio.fixture(loop_scope="session")
 async def db_session(async_engine):
     """Per-test async session with transactional rollback for clean state.
 
-    Each test runs inside a transaction that is rolled back after the test,
-    ensuring complete isolation between tests. Uses SAVEPOINT (begin_nested)
-    so that session.commit() inside the test only commits the savepoint,
-    allowing the outer transaction to still roll back.
+    Uses loop_scope="session" to match the session-scoped event loop
+    configured via asyncio_default_test_loop_scope in pyproject.toml.
     """
     async with async_engine.connect() as conn:
         transaction = await conn.begin()
         await conn.begin_nested()
         session_factory = async_sessionmaker(bind=conn, class_=AsyncSession, expire_on_commit=False)
         async with session_factory() as session:
-            # Re-create SAVEPOINT after each commit so that multiple
-            # session.commit() calls in test code don't escape the
-            # outer transaction
+
             @event.listens_for(session.sync_session, "after_transaction_end")
             def _restart_savepoint(sync_session, trans):
                 if conn.closed or not conn.in_transaction():
@@ -173,6 +176,8 @@ async def db_session(async_engine):
                     conn.sync_connection.begin_nested()
 
             yield session
+
+            event.remove(session.sync_session, "after_transaction_end", _restart_savepoint)
         await transaction.rollback()
 
 
@@ -182,3 +187,29 @@ def noop_adapter():
     from app.services.adapters.noop import NoOpSyncAdapter
 
     return NoOpSyncAdapter()
+
+
+# ──────────────────────────────────────────────
+# Testcontainers Redis fixtures (AC-4.4.4)
+# ──────────────────────────────────────────────
+
+
+@pytest.fixture(scope="session")
+def redis_container():
+    """Start a real Redis container for the test session."""
+    from testcontainers.redis import RedisContainer
+
+    with RedisContainer("redis:7-alpine") as rc:
+        yield rc
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def redis_client(redis_container):
+    """Async Redis client connected to the testcontainers Redis instance."""
+    from redis.asyncio import Redis
+
+    host = redis_container.get_container_host_ip()
+    port = redis_container.get_exposed_port(6379)
+    client = Redis(host=host, port=int(port), decode_responses=True)
+    yield client
+    await client.aclose()

--- a/backend/tests/integration/test_multi_idp_lifecycle.py
+++ b/backend/tests/integration/test_multi_idp_lifecycle.py
@@ -1,0 +1,449 @@
+"""Integration lifecycle tests for multi-IdP features against real Postgres + Redis.
+
+AC-4.4.4: Full lifecycle — register provider → create user → create IdP link
+→ resolve identity → verify Redis cache → update user → verify cache invalidated.
+
+Uses real Postgres via testcontainers (Alembic migrations) and real Redis
+via testcontainers for cache verification.
+"""
+
+import json
+import uuid
+
+import pytest
+
+from app.models.identity.assignment import UserTenantRole
+from app.models.identity.provider import ProviderType
+from app.models.identity.role import Role
+from app.models.identity.tenant import Tenant
+from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.role import RoleRepository
+from app.repositories.tenant import TenantRepository
+from app.repositories.user import UserRepository
+from app.services.adapters.noop import NoOpSyncAdapter
+from app.services.identity_resolution import IdentityResolutionService
+from app.services.idp_link import IdPLinkService
+from app.services.provider import ProviderService
+from app.services.user import UserService
+
+# ──────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────
+
+
+async def _delete_cache_key(redis_client, cache_key: str) -> None:
+    """Delete a cache key using the provided Redis client."""
+    if redis_client is not None:
+        await redis_client.delete(cache_key)
+
+
+async def _create_seed_data(db_session) -> dict:
+    """Create a tenant and role for a single test. Called per-test to avoid scope issues."""
+    suffix = uuid.uuid4().hex[:8]
+
+    tenant = Tenant(name=f"multi-idp-tenant-{suffix}", domains=[f"{suffix}.test"])
+    db_session.add(tenant)
+    await db_session.flush()
+
+    role = Role(name=f"multi-idp-role-{suffix}", description="test role", tenant_id=tenant.id)
+    db_session.add(role)
+    await db_session.flush()
+
+    return {"tenant": tenant, "role": role}
+
+
+# ──────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def user_service(db_session):
+    repo = UserRepository(db_session)
+    assignment_repo = UserTenantRoleRepository(db_session)
+    adapter = NoOpSyncAdapter()
+    return UserService(repository=repo, adapter=adapter, assignment_repository=assignment_repo)
+
+
+@pytest.fixture
+def provider_service(db_session):
+    repo = ProviderRepository(db_session)
+    return ProviderService(repository=repo)
+
+
+@pytest.fixture
+def idp_link_service(db_session):
+    return IdPLinkService(
+        repository=IdPLinkRepository(db_session),
+        user_repository=UserRepository(db_session),
+        provider_repository=ProviderRepository(db_session),
+    )
+
+
+@pytest.fixture
+def identity_resolution_service(db_session, redis_client):
+    return IdentityResolutionService(
+        user_repository=UserRepository(db_session),
+        idp_link_repository=IdPLinkRepository(db_session),
+        provider_repository=ProviderRepository(db_session),
+        assignment_repository=UserTenantRoleRepository(db_session),
+        role_repository=RoleRepository(db_session),
+        tenant_repository=TenantRepository(db_session),
+        redis_client=redis_client,
+    )
+
+
+@pytest.fixture
+def identity_resolution_service_no_redis(db_session):
+    """Identity resolution service without Redis (graceful degradation)."""
+    return IdentityResolutionService(
+        user_repository=UserRepository(db_session),
+        idp_link_repository=IdPLinkRepository(db_session),
+        provider_repository=ProviderRepository(db_session),
+        assignment_repository=UserTenantRoleRepository(db_session),
+        role_repository=RoleRepository(db_session),
+        tenant_repository=TenantRepository(db_session),
+        redis_client=None,
+    )
+
+
+# ──────────────────────────────────────────────
+# AC-4.4.4: Full lifecycle integration test
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_full_multi_idp_lifecycle(
+    db_session,
+    user_service,
+    provider_service,
+    idp_link_service,
+    identity_resolution_service,
+    redis_client,
+):
+    """Full lifecycle: provider → user → IdP link → resolve → cache → invalidate."""
+    seed_data = await _create_seed_data(db_session)
+    tenant = seed_data["tenant"]
+    role = seed_data["role"]
+    suffix = uuid.uuid4().hex[:8]
+
+    # 1. Register a provider
+    result = await provider_service.register_provider(
+        name=f"oidc-test-{suffix}",
+        type=ProviderType.oidc,
+        issuer_url="https://idp.example.com",
+        capabilities=["sso", "mfa"],
+        config_ref="vault:secret/oidc-test",
+    )
+    assert result.is_ok(), f"Provider registration failed: {result.error}"
+    provider_data = result.ok
+    provider_id = uuid.UUID(str(provider_data["id"]))
+
+    # 2. Create a user
+    result = await user_service.create_user(
+        tenant_id=tenant.id,
+        email=f"lifecycle-{suffix}@test.com",
+        user_name=f"lifecycle-{suffix}",
+        given_name="Multi",
+        family_name="IdP",
+    )
+    assert result.is_ok(), f"User creation failed: {result.error}"
+    user_id = uuid.UUID(str(result.ok["id"]))
+
+    # 3. Assign role so user has tenant membership
+    assignment = UserTenantRole(user_id=user_id, tenant_id=tenant.id, role_id=role.id)
+    db_session.add(assignment)
+    await db_session.flush()
+
+    # 4. Create an IdP link
+    result = await idp_link_service.create_idp_link(
+        user_id=user_id,
+        provider_id=provider_id,
+        external_sub=f"ext-{suffix}",
+        external_email=f"ext-{suffix}@idp.example.com",
+    )
+    assert result.is_ok(), f"IdP link creation failed: {result.error}"
+
+    # 5. Resolve identity (should populate Redis cache)
+    result = await identity_resolution_service.resolve(
+        provider=f"oidc-test-{suffix}",
+        sub=f"ext-{suffix}",
+    )
+    assert result.is_ok(), f"Identity resolution failed: {result.error}"
+    payload = result.ok
+
+    # Verify identity payload structure
+    assert payload["user"]["email"] == f"lifecycle-{suffix}@test.com"
+    assert payload["user"]["given_name"] == "Multi"
+    assert payload["user"]["family_name"] == "IdP"
+    assert payload["user"]["status"] == "active"
+    assert len(payload["roles"]) == 1
+    assert payload["roles"][0]["role_name"] == role.name
+    assert payload["roles"][0]["tenant_id"] == str(tenant.id)
+    assert len(payload["tenant_memberships"]) == 1
+    assert payload["tenant_memberships"][0]["tenant_name"] == tenant.name
+    assert len(payload["linked_idps"]) == 1
+    assert payload["linked_idps"][0]["external_sub"] == f"ext-{suffix}"
+
+    # 6. Verify Redis cache was populated
+    from urllib.parse import quote
+
+    cache_key = f"identity:{quote(f'oidc-test-{suffix}', safe='')}:{quote(f'ext-{suffix}', safe='')}"
+    cached_raw = await redis_client.get(cache_key)
+    assert cached_raw is not None, "Cache should be populated after resolve"
+    cached_data = json.loads(cached_raw)
+    assert cached_data["user"]["email"] == f"lifecycle-{suffix}@test.com"
+
+    # 7. Verify reverse index exists
+    reverse_key = f"identity:user:{user_id}"
+    reverse_members = await redis_client.smembers(reverse_key)
+    assert cache_key in reverse_members
+
+    # 8. Second resolve should hit cache (verify same result)
+    result2 = await identity_resolution_service.resolve(
+        provider=f"oidc-test-{suffix}",
+        sub=f"ext-{suffix}",
+    )
+    assert result2.is_ok()
+    assert result2.ok == payload
+
+    # 9. Simulate cache invalidation for user entity
+    from app.services.identity_resolution import _handle_invalidation_event
+
+    await _handle_invalidation_event(
+        redis_client,
+        {"entity_type": "user", "entity_id": str(user_id), "operation": "update"},
+    )
+
+    # 10. Verify cache was invalidated
+    cached_after = await redis_client.get(cache_key)
+    assert cached_after is None, "Cache should be empty after invalidation"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_idp_link_returns_conflict(
+    db_session,
+    user_service,
+    provider_service,
+    idp_link_service,
+):
+    """Creating a duplicate IdP link (same user + provider) returns Conflict."""
+    seed_data = await _create_seed_data(db_session)
+    tenant = seed_data["tenant"]
+    suffix = uuid.uuid4().hex[:8]
+
+    # Register provider
+    result = await provider_service.register_provider(
+        name=f"dup-test-{suffix}",
+        type=ProviderType.oidc,
+    )
+    assert result.is_ok()
+    provider_id = uuid.UUID(str(result.ok["id"]))
+
+    # Create user
+    result = await user_service.create_user(
+        tenant_id=tenant.id,
+        email=f"dup-{suffix}@test.com",
+        user_name=f"dup-{suffix}",
+    )
+    assert result.is_ok()
+    user_id = uuid.UUID(str(result.ok["id"]))
+
+    # First link succeeds
+    result = await idp_link_service.create_idp_link(
+        user_id=user_id,
+        provider_id=provider_id,
+        external_sub=f"ext-dup-{suffix}",
+    )
+    assert result.is_ok()
+
+    # Duplicate link returns conflict
+    result = await idp_link_service.create_idp_link(
+        user_id=user_id,
+        provider_id=provider_id,
+        external_sub=f"ext-dup-other-{suffix}",
+    )
+    assert result.is_error()
+    assert "already" in result.error.message.lower() or "conflict" in result.error.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_idp_link_clears_resolution(
+    db_session,
+    user_service,
+    provider_service,
+    idp_link_service,
+    identity_resolution_service,
+    redis_client,
+):
+    """After deleting an IdP link, identity resolution returns NotFound."""
+    seed_data = await _create_seed_data(db_session)
+    tenant = seed_data["tenant"]
+    suffix = uuid.uuid4().hex[:8]
+
+    # Setup: provider + user + link
+    result = await provider_service.register_provider(name=f"del-test-{suffix}", type=ProviderType.oidc)
+    assert result.is_ok()
+    provider_id = uuid.UUID(str(result.ok["id"]))
+
+    result = await user_service.create_user(
+        tenant_id=tenant.id, email=f"del-{suffix}@test.com", user_name=f"del-{suffix}"
+    )
+    assert result.is_ok()
+    user_id = uuid.UUID(str(result.ok["id"]))
+
+    result = await idp_link_service.create_idp_link(
+        user_id=user_id, provider_id=provider_id, external_sub=f"ext-del-{suffix}"
+    )
+    assert result.is_ok()
+    link_id = uuid.UUID(str(result.ok["id"]))
+
+    # Resolve works
+    result = await identity_resolution_service.resolve(provider=f"del-test-{suffix}", sub=f"ext-del-{suffix}")
+    assert result.is_ok()
+
+    # Delete link
+    result = await idp_link_service.delete_idp_link(link_id=link_id, user_id=user_id)
+    assert result.is_ok()
+
+    # Resolution after delete returns NotFound (DB miss even if cached)
+    # Clear cache first to force DB path, then verify NotFound.
+    from urllib.parse import quote
+
+    cache_key = f"identity:{quote(f'del-test-{suffix}', safe='')}:{quote(f'ext-del-{suffix}', safe='')}"
+    await _delete_cache_key(redis_client, cache_key)
+
+    # Re-resolve — link no longer exists, should return NotFound
+    result = await identity_resolution_service.resolve(provider=f"del-test-{suffix}", sub=f"ext-del-{suffix}")
+    assert result.is_error()
+    assert "found" in result.error.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_resolve_without_redis_graceful_degradation(
+    db_session,
+    user_service,
+    provider_service,
+    idp_link_service,
+    identity_resolution_service_no_redis,
+):
+    """Identity resolution works without Redis (graceful degradation)."""
+    seed_data = await _create_seed_data(db_session)
+    tenant = seed_data["tenant"]
+    role = seed_data["role"]
+    suffix = uuid.uuid4().hex[:8]
+
+    # Setup: provider + user + role assignment + link
+    result = await provider_service.register_provider(name=f"no-redis-{suffix}", type=ProviderType.oidc)
+    assert result.is_ok()
+    provider_id = uuid.UUID(str(result.ok["id"]))
+
+    result = await user_service.create_user(
+        tenant_id=tenant.id, email=f"no-redis-{suffix}@test.com", user_name=f"no-redis-{suffix}"
+    )
+    assert result.is_ok()
+    user_id = uuid.UUID(str(result.ok["id"]))
+
+    assignment = UserTenantRole(user_id=user_id, tenant_id=tenant.id, role_id=role.id)
+    db_session.add(assignment)
+    await db_session.flush()
+
+    result = await idp_link_service.create_idp_link(
+        user_id=user_id, provider_id=provider_id, external_sub=f"ext-no-redis-{suffix}"
+    )
+    assert result.is_ok()
+
+    # Resolve succeeds without Redis
+    result = await identity_resolution_service_no_redis.resolve(
+        provider=f"no-redis-{suffix}", sub=f"ext-no-redis-{suffix}"
+    )
+    assert result.is_ok()
+    assert result.ok["user"]["email"] == f"no-redis-{suffix}@test.com"
+
+
+@pytest.mark.asyncio
+async def test_resolve_unknown_provider_returns_not_found(identity_resolution_service):
+    """Resolving with a non-existent provider returns NotFound."""
+    result = await identity_resolution_service.resolve(
+        provider=f"nonexistent-{uuid.uuid4().hex[:8]}",
+        sub="any-sub",
+    )
+    assert result.is_error()
+    assert "not found" in result.error.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_resolve_unknown_sub_returns_not_found(
+    db_session,
+    provider_service,
+    identity_resolution_service,
+):
+    """Resolving with a valid provider but unknown sub returns NotFound."""
+    suffix = uuid.uuid4().hex[:8]
+    result = await provider_service.register_provider(name=f"sub-miss-{suffix}", type=ProviderType.oidc)
+    assert result.is_ok()
+
+    result = await identity_resolution_service.resolve(
+        provider=f"sub-miss-{suffix}",
+        sub=f"nonexistent-{suffix}",
+    )
+    assert result.is_error()
+    assert "found" in result.error.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_broad_cache_invalidation_clears_all(
+    db_session,
+    user_service,
+    provider_service,
+    idp_link_service,
+    identity_resolution_service,
+    redis_client,
+):
+    """Broad invalidation (role change) clears all identity cache entries."""
+    seed_data = await _create_seed_data(db_session)
+    tenant = seed_data["tenant"]
+    role = seed_data["role"]
+    suffix = uuid.uuid4().hex[:8]
+
+    # Setup: provider + user + assignment + link + resolve (populate cache)
+    result = await provider_service.register_provider(name=f"broad-{suffix}", type=ProviderType.oidc)
+    assert result.is_ok()
+    provider_id = uuid.UUID(str(result.ok["id"]))
+
+    result = await user_service.create_user(
+        tenant_id=tenant.id, email=f"broad-{suffix}@test.com", user_name=f"broad-{suffix}"
+    )
+    assert result.is_ok()
+    user_id = uuid.UUID(str(result.ok["id"]))
+
+    assignment = UserTenantRole(user_id=user_id, tenant_id=tenant.id, role_id=role.id)
+    db_session.add(assignment)
+    await db_session.flush()
+
+    result = await idp_link_service.create_idp_link(
+        user_id=user_id, provider_id=provider_id, external_sub=f"ext-broad-{suffix}"
+    )
+    assert result.is_ok()
+
+    result = await identity_resolution_service.resolve(provider=f"broad-{suffix}", sub=f"ext-broad-{suffix}")
+    assert result.is_ok()
+
+    # Verify cache populated
+    from urllib.parse import quote
+
+    cache_key = f"identity:{quote(f'broad-{suffix}', safe='')}:{quote(f'ext-broad-{suffix}', safe='')}"
+    assert await redis_client.get(cache_key) is not None
+
+    # Broad invalidation (role change)
+    from app.services.identity_resolution import _handle_invalidation_event
+
+    await _handle_invalidation_event(
+        redis_client,
+        {"entity_type": "role", "entity_id": str(role.id), "operation": "update"},
+    )
+
+    # Cache should be cleared
+    assert await redis_client.get(cache_key) is None

--- a/backend/tests/integration/test_permission_lifecycle.py
+++ b/backend/tests/integration/test_permission_lifecycle.py
@@ -1,0 +1,105 @@
+"""Integration lifecycle tests for PermissionService against real Postgres.
+
+AC-2.4.5: Full CRUD lifecycle — create → get → update → get → delete → verify gone.
+Uses PermissionService + PermissionRepository + NoOpSyncAdapter + real Postgres.
+"""
+
+import uuid
+
+import pytest
+
+from app.repositories.permission import PermissionRepository
+from app.services.adapters.noop import NoOpSyncAdapter
+from app.services.permission import PermissionService
+
+
+@pytest.fixture
+def permission_service(db_session):
+    repo = PermissionRepository(db_session)
+    adapter = NoOpSyncAdapter()
+    return PermissionService(repository=repo, adapter=adapter)
+
+
+@pytest.mark.asyncio
+async def test_permission_create_get_update_delete(db_session, permission_service):
+    """Full permission lifecycle: create → get → update → get → delete → verify gone."""
+    suffix = uuid.uuid4().hex[:8]
+
+    # --- Create ---
+    result = await permission_service.create_permission(
+        name=f"perm.lifecycle.{suffix}",
+        description="initial description",
+    )
+    assert result.is_ok()
+    perm_data = result.ok
+    perm_id = perm_data["id"]
+    assert perm_data["name"] == f"perm.lifecycle.{suffix}"
+    assert perm_data["description"] == "initial description"
+
+    # --- Get ---
+    result = await permission_service.get_permission(permission_id=perm_id)
+    assert result.is_ok()
+    assert result.ok["name"] == f"perm.lifecycle.{suffix}"
+
+    # --- Update ---
+    update_suffix = uuid.uuid4().hex[:8]
+    result = await permission_service.update_permission(
+        permission_id=perm_id,
+        name=f"perm.lifecycle.{update_suffix}",
+        description="updated description",
+    )
+    assert result.is_ok()
+    assert result.ok["name"] == f"perm.lifecycle.{update_suffix}"
+    assert result.ok["description"] == "updated description"
+
+    # --- Get after update ---
+    result = await permission_service.get_permission(permission_id=perm_id)
+    assert result.is_ok()
+    assert result.ok["name"] == f"perm.lifecycle.{update_suffix}"
+    assert result.ok["description"] == "updated description"
+
+    # --- Delete ---
+    result = await permission_service.delete_permission(permission_id=perm_id)
+    assert result.is_ok()
+    assert result.ok["status"] == "deleted"
+
+    # --- Verify gone ---
+    result = await permission_service.get_permission(permission_id=perm_id)
+    assert result.is_error()
+    assert "not found" in result.error.message
+
+
+@pytest.mark.asyncio
+async def test_permission_duplicate_name(db_session, permission_service):
+    """Creating a permission with a duplicate name returns Conflict."""
+    suffix = uuid.uuid4().hex[:8]
+    result = await permission_service.create_permission(name=f"perm.dup.{suffix}")
+    assert result.is_ok()
+
+    result = await permission_service.create_permission(name=f"perm.dup.{suffix}")
+    assert result.is_error()
+    assert "already exists" in result.error.message
+
+
+@pytest.mark.asyncio
+async def test_permission_get_not_found(db_session, permission_service):
+    """Getting a nonexistent permission returns NotFound."""
+    result = await permission_service.get_permission(permission_id=uuid.uuid4())
+    assert result.is_error()
+    assert "not found" in result.error.message
+
+
+@pytest.mark.asyncio
+async def test_permission_list(db_session, permission_service):
+    """List permissions returns all created permissions."""
+    suffix = uuid.uuid4().hex[:8]
+    result_a = await permission_service.create_permission(name=f"perm.list.a.{suffix}")
+    assert result_a.is_ok()
+    result_b = await permission_service.create_permission(name=f"perm.list.b.{suffix}")
+    assert result_b.is_ok()
+
+    result = await permission_service.list_permissions()
+    assert result.is_ok()
+    names = [p["name"] for p in result.ok]
+    assert f"perm.list.a.{suffix}" in names
+    assert f"perm.list.b.{suffix}" in names

--- a/backend/tests/integration/test_reconciliation.py
+++ b/backend/tests/integration/test_reconciliation.py
@@ -1,0 +1,520 @@
+"""Integration tests for ReconciliationService against real Postgres.
+
+AC-3.4.3: Reconciliation integration tests with testcontainers Postgres + mocked Descope.
+Tests cover:
+- Drift detection: pre-populated canonical state vs different Descope state
+- Resolution actions: correct upserts for tenants, permissions, roles, users
+- Idempotency: second run produces zero changes
+- Advisory lock acquisition
+- Descope outage handling: abort without canonical modifications
+- Status mapping: enabled->active, disabled->inactive, invited->provisioned
+"""
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.dependencies.identity import _RECONCILIATION_LOCK_ID
+from app.models.identity.provider import Provider, ProviderType
+from app.models.identity.role import Permission, Role
+from app.models.identity.tenant import Tenant, TenantStatus
+from app.models.identity.user import User, UserStatus
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.permission import PermissionRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.role import RoleRepository
+from app.repositories.tenant import TenantRepository
+from app.repositories.user import UserRepository
+from app.services.reconciliation import ReconciliationService
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def descope_provider(db_session):
+    """Seed a Descope provider row (required for user reconciliation)."""
+    provider = Provider(
+        name=f"descope-test-{uuid.uuid4().hex[:8]}",
+        type=ProviderType.descope,
+        issuer_url="https://api.descope.com/test",
+        base_url="https://api.descope.com",
+    )
+    db_session.add(provider)
+    await db_session.flush()
+    return provider
+
+
+def _make_descope_client() -> AsyncMock:
+    """Create a mock DescopeManagementClient with default empty responses."""
+    client = AsyncMock()
+    client.search_all_users = AsyncMock(return_value=[])
+    client.list_roles = AsyncMock(return_value=[])
+    client.list_permissions = AsyncMock(return_value=[])
+    client.list_tenants = AsyncMock(return_value=[])
+    return client
+
+
+def _build_service(db_session, descope_client, publisher=None) -> ReconciliationService:
+    """Build ReconciliationService wired to real repos and a mock Descope client."""
+
+    async def acquire_lock():
+        await db_session.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_id)"),
+            {"lock_id": _RECONCILIATION_LOCK_ID},
+        )
+
+    return ReconciliationService(
+        session=db_session,
+        acquire_lock=acquire_lock,
+        descope_client=descope_client,
+        user_repository=UserRepository(db_session),
+        role_repository=RoleRepository(db_session),
+        permission_repository=PermissionRepository(db_session),
+        tenant_repository=TenantRepository(db_session),
+        idp_link_repository=IdPLinkRepository(db_session),
+        provider_repository=ProviderRepository(db_session),
+        publisher=publisher,
+    )
+
+
+# ── Tests ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drift_detection_creates_new_entities(db_session, descope_provider):
+    """Descope has entities that don't exist in canonical — reconciliation creates them."""
+    suffix = uuid.uuid4().hex[:8]
+
+    client = _make_descope_client()
+    client.list_tenants.return_value = [
+        {"name": f"tenant-{suffix}", "selfProvisioningDomains": ["example.com"]},
+    ]
+    client.list_permissions.return_value = [
+        {"name": f"docs.write-{suffix}", "description": "Write documents"},
+    ]
+    client.list_roles.return_value = [
+        {"name": f"editor-{suffix}", "description": "Can edit"},
+    ]
+    client.search_all_users.return_value = [
+        {
+            "userId": f"descope-{suffix}",
+            "email": f"alice-{suffix}@test.com",
+            "name": "Alice Wonderland",
+            "status": "enabled",
+        },
+    ]
+
+    svc = _build_service(db_session, client)
+    result = await svc.run()
+
+    assert result.is_ok()
+    stats = result.ok["stats"]
+    assert stats["tenants_created"] == 1
+    assert stats["permissions_created"] == 1
+    assert stats["roles_created"] == 1
+    assert stats["users_created"] == 1
+    assert stats["links_created"] == 1
+
+    # Verify entities persisted in Postgres
+    tenant_repo = TenantRepository(db_session)
+    tenants = await tenant_repo.list_all()
+    tenant_names = [t.name for t in tenants]
+    assert f"tenant-{suffix}" in tenant_names
+
+    perm_repo = PermissionRepository(db_session)
+    perm = await perm_repo.get_by_name(f"docs.write-{suffix}")
+    assert perm is not None
+    assert perm.description == "Write documents"
+
+    role_repo = RoleRepository(db_session)
+    role = await role_repo.get_by_name(f"editor-{suffix}")
+    assert role is not None
+    assert role.description == "Can edit"
+
+    user_repo = UserRepository(db_session)
+    user = await user_repo.get_by_email(f"alice-{suffix}@test.com")
+    assert user is not None
+    assert user.given_name == "Alice"
+    assert user.family_name == "Wonderland"
+    assert user.status == UserStatus.active
+
+    link_repo = IdPLinkRepository(db_session)
+    link = await link_repo.get_by_provider_and_sub(provider_id=descope_provider.id, external_sub=f"descope-{suffix}")
+    assert link is not None
+    assert link.user_id == user.id
+
+
+@pytest.mark.asyncio
+async def test_drift_detection_updates_existing_entities(db_session, descope_provider):
+    """Descope has different data for existing canonical entities — reconciliation updates."""
+    suffix = uuid.uuid4().hex[:8]
+
+    # Pre-populate canonical state
+    tenant = Tenant(name=f"existing-tenant-{suffix}", domains=["old.com"], status=TenantStatus.active)
+    db_session.add(tenant)
+    await db_session.flush()
+
+    perm = Permission(name=f"existing-perm-{suffix}", description="Old description")
+    db_session.add(perm)
+    await db_session.flush()
+
+    role = Role(name=f"existing-role-{suffix}", description="Old role desc", tenant_id=None)
+    db_session.add(role)
+    await db_session.flush()
+
+    user = User(
+        email=f"existing-{suffix}@test.com",
+        user_name=f"existing-{suffix}@test.com",
+        given_name="Old",
+        family_name="Name",
+        status=UserStatus.inactive,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    # Mock Descope returns updated data
+    client = _make_descope_client()
+    client.list_tenants.return_value = [
+        {"name": f"existing-tenant-{suffix}", "selfProvisioningDomains": ["new.com"]},
+    ]
+    client.list_permissions.return_value = [
+        {"name": f"existing-perm-{suffix}", "description": "New description"},
+    ]
+    client.list_roles.return_value = [
+        {"name": f"existing-role-{suffix}", "description": "New role desc"},
+    ]
+    client.search_all_users.return_value = [
+        {
+            "userId": f"descope-existing-{suffix}",
+            "email": f"existing-{suffix}@test.com",
+            "givenName": "New",
+            "familyName": "Person",
+            "status": "enabled",
+        },
+    ]
+
+    svc = _build_service(db_session, client)
+    result = await svc.run()
+
+    assert result.is_ok()
+    stats = result.ok["stats"]
+    assert stats["tenants_updated"] == 1
+    assert stats["permissions_updated"] == 1
+    assert stats["roles_updated"] == 1
+    assert stats["users_updated"] == 1
+    assert stats["links_created"] == 1
+
+    # Verify updates persisted
+    updated_tenant = await TenantRepository(db_session).get_by_name(f"existing-tenant-{suffix}")
+    assert updated_tenant.domains == ["new.com"]
+
+    updated_perm = await PermissionRepository(db_session).get_by_name(f"existing-perm-{suffix}")
+    assert updated_perm.description == "New description"
+
+    updated_role = await RoleRepository(db_session).get_by_name(f"existing-role-{suffix}")
+    assert updated_role.description == "New role desc"
+
+    updated_user = await UserRepository(db_session).get_by_email(f"existing-{suffix}@test.com")
+    assert updated_user.given_name == "New"
+    assert updated_user.family_name == "Person"
+    assert updated_user.status == UserStatus.active
+
+
+@pytest.mark.asyncio
+async def test_idempotent_reconciliation(db_session, descope_provider):
+    """Running reconciliation twice with same data produces zero changes on second run."""
+    suffix = uuid.uuid4().hex[:8]
+
+    descope_data = {
+        "tenants": [{"name": f"idem-tenant-{suffix}", "selfProvisioningDomains": []}],
+        "permissions": [{"name": f"idem-perm-{suffix}", "description": "test"}],
+        "roles": [{"name": f"idem-role-{suffix}", "description": "test"}],
+        "users": [
+            {
+                "userId": f"descope-idem-{suffix}",
+                "email": f"idem-{suffix}@test.com",
+                "givenName": "Idem",
+                "familyName": "Potent",
+                "status": "enabled",
+            },
+        ],
+    }
+
+    client = _make_descope_client()
+    client.list_tenants.return_value = descope_data["tenants"]
+    client.list_permissions.return_value = descope_data["permissions"]
+    client.list_roles.return_value = descope_data["roles"]
+    client.search_all_users.return_value = descope_data["users"]
+
+    # First run — creates entities
+    svc = _build_service(db_session, client)
+    result1 = await svc.run()
+    assert result1.is_ok()
+    stats1 = result1.ok["stats"]
+    assert stats1["tenants_created"] == 1
+    assert stats1["permissions_created"] == 1
+    assert stats1["roles_created"] == 1
+    assert stats1["users_created"] == 1
+    assert stats1["links_created"] == 1
+
+    # Second run with same data — zero changes
+    client2 = _make_descope_client()
+    client2.list_tenants.return_value = descope_data["tenants"]
+    client2.list_permissions.return_value = descope_data["permissions"]
+    client2.list_roles.return_value = descope_data["roles"]
+    client2.search_all_users.return_value = descope_data["users"]
+
+    svc2 = _build_service(db_session, client2)
+    result2 = await svc2.run()
+    assert result2.is_ok()
+    stats2 = result2.ok["stats"]
+    for key, val in stats2.items():
+        assert val == 0, f"Expected zero {key} on idempotent replay, got {val}"
+
+
+@pytest.mark.asyncio
+async def test_advisory_lock_acquisition(db_session, descope_provider):
+    """Advisory lock is acquired successfully during reconciliation."""
+    client = _make_descope_client()
+
+    lock_acquired = False
+
+    async def tracking_lock():
+        nonlocal lock_acquired
+        await db_session.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_id)"),
+            {"lock_id": _RECONCILIATION_LOCK_ID},
+        )
+        lock_acquired = True
+
+    svc = ReconciliationService(
+        session=db_session,
+        acquire_lock=tracking_lock,
+        descope_client=client,
+        user_repository=UserRepository(db_session),
+        role_repository=RoleRepository(db_session),
+        permission_repository=PermissionRepository(db_session),
+        tenant_repository=TenantRepository(db_session),
+        idp_link_repository=IdPLinkRepository(db_session),
+        provider_repository=ProviderRepository(db_session),
+    )
+
+    result = await svc.run()
+    assert result.is_ok()
+    assert lock_acquired, "Advisory lock should have been acquired"
+
+
+@pytest.mark.asyncio
+async def test_descope_outage_aborts_without_changes(db_session, descope_provider):
+    """When Descope API fails, reconciliation aborts without modifying canonical state."""
+    suffix = uuid.uuid4().hex[:8]
+
+    # Pre-populate a tenant so we can verify it's unchanged after abort
+    tenant = Tenant(name=f"pre-outage-{suffix}", domains=["keep.com"], status=TenantStatus.active)
+    db_session.add(tenant)
+    await db_session.flush()
+
+    client = _make_descope_client()
+    client.search_all_users.side_effect = Exception("Descope API timeout")
+
+    svc = _build_service(db_session, client)
+    result = await svc.run()
+
+    assert result.is_error()
+    assert "unavailable" in result.error.message.lower()
+
+    # Verify pre-existing data is untouched
+    existing = await TenantRepository(db_session).get_by_name(f"pre-outage-{suffix}")
+    assert existing is not None
+    assert existing.domains == ["keep.com"]
+
+
+@pytest.mark.asyncio
+async def test_descope_status_mapping(db_session, descope_provider):
+    """Descope status values map correctly: enabled->active, disabled->inactive, invited->provisioned."""
+    suffix = uuid.uuid4().hex[:8]
+
+    client = _make_descope_client()
+    client.search_all_users.return_value = [
+        {
+            "userId": f"enabled-{suffix}",
+            "email": f"enabled-{suffix}@test.com",
+            "givenName": "Enabled",
+            "familyName": "User",
+            "status": "enabled",
+        },
+        {
+            "userId": f"disabled-{suffix}",
+            "email": f"disabled-{suffix}@test.com",
+            "givenName": "Disabled",
+            "familyName": "User",
+            "status": "disabled",
+        },
+        {
+            "userId": f"invited-{suffix}",
+            "email": f"invited-{suffix}@test.com",
+            "givenName": "Invited",
+            "familyName": "User",
+            "status": "invited",
+        },
+        {
+            "userId": f"unknown-{suffix}",
+            "email": f"unknown-{suffix}@test.com",
+            "givenName": "Unknown",
+            "familyName": "User",
+            "status": "some_unknown_status",
+        },
+    ]
+
+    svc = _build_service(db_session, client)
+    result = await svc.run()
+    assert result.is_ok()
+
+    user_repo = UserRepository(db_session)
+
+    enabled = await user_repo.get_by_email(f"enabled-{suffix}@test.com")
+    assert enabled.status == UserStatus.active
+
+    disabled = await user_repo.get_by_email(f"disabled-{suffix}@test.com")
+    assert disabled.status == UserStatus.inactive
+
+    invited = await user_repo.get_by_email(f"invited-{suffix}@test.com")
+    assert invited.status == UserStatus.provisioned
+
+    unknown = await user_repo.get_by_email(f"unknown-{suffix}@test.com")
+    assert unknown.status == UserStatus.inactive  # Unknown defaults to inactive
+
+
+@pytest.mark.asyncio
+async def test_empty_descope_state(db_session, descope_provider):
+    """Reconciliation with no entities in Descope produces zero changes."""
+    client = _make_descope_client()
+
+    svc = _build_service(db_session, client)
+    result = await svc.run()
+
+    assert result.is_ok()
+    stats = result.ok["stats"]
+    assert sum(stats.values()) == 0
+
+
+@pytest.mark.asyncio
+async def test_user_name_splitting(db_session, descope_provider):
+    """User with only 'name' field gets it split into given_name/family_name."""
+    suffix = uuid.uuid4().hex[:8]
+
+    client = _make_descope_client()
+    client.search_all_users.return_value = [
+        {
+            "userId": f"split-{suffix}",
+            "email": f"split-{suffix}@test.com",
+            "name": "Jean-Pierre de la Fontaine",
+            "status": "enabled",
+        },
+    ]
+
+    svc = _build_service(db_session, client)
+    result = await svc.run()
+    assert result.is_ok()
+
+    user = await UserRepository(db_session).get_by_email(f"split-{suffix}@test.com")
+    assert user is not None
+    assert user.given_name == "Jean-Pierre"
+    assert user.family_name == "de la Fontaine"
+
+
+@pytest.mark.asyncio
+async def test_skips_users_without_email(db_session, descope_provider):
+    """Users missing email or userId are silently skipped."""
+    suffix = uuid.uuid4().hex[:8]
+
+    client = _make_descope_client()
+    client.search_all_users.return_value = [
+        {"userId": f"no-email-{suffix}", "status": "enabled"},
+        {"email": f"no-uid-{suffix}@test.com", "status": "enabled"},
+        {
+            "userId": f"valid-{suffix}",
+            "email": f"valid-{suffix}@test.com",
+            "givenName": "Valid",
+            "familyName": "User",
+            "status": "enabled",
+        },
+    ]
+
+    svc = _build_service(db_session, client)
+    result = await svc.run()
+    assert result.is_ok()
+    assert result.ok["stats"]["users_created"] == 1
+
+    user = await UserRepository(db_session).get_by_email(f"valid-{suffix}@test.com")
+    assert user is not None
+
+
+@pytest.mark.asyncio
+async def test_lock_failure_returns_error(db_session, descope_provider):
+    """When advisory lock acquisition fails, reconciliation returns error without changes."""
+    suffix = uuid.uuid4().hex[:8]
+    client = _make_descope_client()
+    client.list_tenants.return_value = [{"name": f"should-not-exist-{suffix}"}]
+
+    async def failing_lock():
+        raise RuntimeError("Lock contention")
+
+    svc = ReconciliationService(
+        session=db_session,
+        acquire_lock=failing_lock,
+        descope_client=client,
+        user_repository=UserRepository(db_session),
+        role_repository=RoleRepository(db_session),
+        permission_repository=PermissionRepository(db_session),
+        tenant_repository=TenantRepository(db_session),
+        idp_link_repository=IdPLinkRepository(db_session),
+        provider_repository=ProviderRepository(db_session),
+    )
+
+    result = await svc.run()
+    assert result.is_error()
+    assert "lock" in result.error.message.lower()
+
+    # Verify nothing was created
+    existing = await TenantRepository(db_session).get_by_name(f"should-not-exist-{suffix}")
+    assert existing is None
+
+
+@pytest.mark.asyncio
+async def test_publisher_called_on_changes(db_session, descope_provider):
+    """CacheInvalidationPublisher.publish_batch is called when reconciliation makes changes."""
+    suffix = uuid.uuid4().hex[:8]
+
+    publisher = AsyncMock()
+    publisher.publish_batch = AsyncMock()
+
+    client = _make_descope_client()
+    client.list_tenants.return_value = [
+        {"name": f"pub-tenant-{suffix}", "selfProvisioningDomains": []},
+    ]
+
+    svc = _build_service(db_session, client, publisher=publisher)
+    result = await svc.run()
+
+    assert result.is_ok()
+    publisher.publish_batch.assert_awaited_once()
+    call_kwargs = publisher.publish_batch.call_args
+    assert call_kwargs.kwargs["operation"] == "reconcile"
+
+
+@pytest.mark.asyncio
+async def test_publisher_not_called_when_no_changes(db_session, descope_provider):
+    """CacheInvalidationPublisher is NOT called when reconciliation makes zero changes."""
+    publisher = AsyncMock()
+    publisher.publish_batch = AsyncMock()
+
+    client = _make_descope_client()
+    svc = _build_service(db_session, client, publisher=publisher)
+    result = await svc.run()
+
+    assert result.is_ok()
+    publisher.publish_batch.assert_not_awaited()

--- a/backend/tests/integration/test_role_lifecycle.py
+++ b/backend/tests/integration/test_role_lifecycle.py
@@ -1,0 +1,154 @@
+"""Integration lifecycle tests for RoleService against real Postgres.
+
+AC-2.4.5: Full CRUD lifecycle — create → get → update → get → delete → verify gone.
+Uses RoleService + RoleRepository + NoOpSyncAdapter + real Postgres via testcontainers.
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from app.models.identity.tenant import Tenant
+from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.permission import PermissionRepository
+from app.repositories.role import RoleRepository
+from app.services.adapters.noop import NoOpSyncAdapter
+from app.services.permission import PermissionService
+from app.services.role import RoleService
+
+
+@pytest.fixture
+def role_service(db_session):
+    role_repo = RoleRepository(db_session)
+    perm_repo = PermissionRepository(db_session)
+    assignment_repo = UserTenantRoleRepository(db_session)
+    adapter = NoOpSyncAdapter()
+    return RoleService(
+        repository=role_repo,
+        permission_repository=perm_repo,
+        assignment_repository=assignment_repo,
+        adapter=adapter,
+    )
+
+
+@pytest.fixture
+def permission_service(db_session):
+    perm_repo = PermissionRepository(db_session)
+    adapter = NoOpSyncAdapter()
+    return PermissionService(repository=perm_repo, adapter=adapter)
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def seed_tenant(db_session):
+    """Create a tenant for role lifecycle tests."""
+    suffix = uuid.uuid4().hex[:8]
+    tenant = Tenant(name=f"role-lifecycle-tenant-{suffix}", domains=[])
+    db_session.add(tenant)
+    await db_session.flush()
+    return tenant
+
+
+@pytest.mark.asyncio
+async def test_role_create_get_update_delete(db_session, role_service, seed_tenant):
+    """Full role lifecycle: create → get → update → get → delete → verify gone."""
+    tenant_id = seed_tenant.id
+    suffix = uuid.uuid4().hex[:8]
+
+    # --- Create ---
+    result = await role_service.create_role(
+        name=f"lifecycle-role-{suffix}",
+        description="initial description",
+        tenant_id=tenant_id,
+    )
+    assert result.is_ok()
+    role_data = result.ok
+    role_id = role_data["id"]
+    assert role_data["name"] == f"lifecycle-role-{suffix}"
+    assert role_data["description"] == "initial description"
+    assert role_data["tenant_id"] == tenant_id
+
+    # --- Get ---
+    result = await role_service.get_role(role_id=role_id)
+    assert result.is_ok()
+    assert result.ok["name"] == f"lifecycle-role-{suffix}"
+
+    # --- Update ---
+    update_suffix = uuid.uuid4().hex[:8]
+    result = await role_service.update_role(
+        role_id=role_id,
+        name=f"updated-role-{update_suffix}",
+        description="updated description",
+    )
+    assert result.is_ok()
+    assert result.ok["name"] == f"updated-role-{update_suffix}"
+    assert result.ok["description"] == "updated description"
+
+    # --- Get after update ---
+    result = await role_service.get_role(role_id=role_id)
+    assert result.is_ok()
+    assert result.ok["name"] == f"updated-role-{update_suffix}"
+
+    # --- Delete ---
+    result = await role_service.delete_role(role_id=role_id)
+    assert result.is_ok()
+    assert result.ok["status"] == "deleted"
+
+    # --- Verify gone ---
+    result = await role_service.get_role(role_id=role_id)
+    assert result.is_error()
+    assert "not found" in result.error.message
+
+
+@pytest.mark.asyncio
+async def test_role_with_permission_mapping(db_session, role_service, permission_service, seed_tenant):
+    """Create a role with permissions, then verify mapping lifecycle."""
+    suffix = uuid.uuid4().hex[:8]
+
+    # Create permissions first
+    perm1_result = await permission_service.create_permission(name=f"role-test-{suffix}.read", description="read")
+    assert perm1_result.is_ok()
+
+    perm2_result = await permission_service.create_permission(name=f"role-test-{suffix}.write", description="write")
+    assert perm2_result.is_ok()
+
+    # Create role with permission_names
+    result = await role_service.create_role(
+        name=f"permissioned-role-{suffix}",
+        tenant_id=seed_tenant.id,
+        permission_names=[f"role-test-{suffix}.read", f"role-test-{suffix}.write"],
+    )
+    assert result.is_ok()
+    role_id = result.ok["id"]
+
+    # Map an additional permission via map_permission_to_role
+    perm3_result = await permission_service.create_permission(name=f"role-test-{suffix}.delete", description="delete")
+    assert perm3_result.is_ok()
+    perm3_id = perm3_result.ok["id"]
+
+    map_result = await role_service.map_permission_to_role(role_id=role_id, permission_id=perm3_id)
+    assert map_result.is_ok()
+    assert map_result.ok["role_id"] == str(role_id)
+    assert map_result.ok["permission_id"] == str(perm3_id)
+
+
+@pytest.mark.asyncio
+async def test_role_duplicate_name_in_scope(db_session, role_service, seed_tenant):
+    """Creating a role with a duplicate name in the same tenant scope returns Conflict."""
+    tenant_id = seed_tenant.id
+    suffix = uuid.uuid4().hex[:8]
+
+    result = await role_service.create_role(name=f"unique-role-{suffix}", tenant_id=tenant_id)
+    assert result.is_ok()
+
+    result = await role_service.create_role(name=f"unique-role-{suffix}", tenant_id=tenant_id)
+    assert result.is_error()
+    assert "already exists" in result.error.message
+
+
+@pytest.mark.asyncio
+async def test_role_get_not_found(db_session, role_service):
+    """Getting a nonexistent role returns NotFound."""
+    result = await role_service.get_role(role_id=uuid.uuid4())
+    assert result.is_error()
+    assert "not found" in result.error.message

--- a/backend/tests/integration/test_tenant_lifecycle.py
+++ b/backend/tests/integration/test_tenant_lifecycle.py
@@ -1,0 +1,145 @@
+"""Integration lifecycle tests for TenantService against real Postgres.
+
+AC-2.4.5: Full CRUD lifecycle — create → get, plus get_tenant_users_with_roles.
+Uses TenantService + TenantRepository + NoOpSyncAdapter + real Postgres.
+"""
+
+import uuid
+
+import pytest
+
+from app.models.identity.assignment import UserTenantRole
+from app.models.identity.role import Role
+from app.models.identity.user import User
+from app.repositories.tenant import TenantRepository
+from app.services.adapters.noop import NoOpSyncAdapter
+from app.services.tenant import TenantService
+
+
+@pytest.fixture
+def tenant_service(db_session):
+    repo = TenantRepository(db_session)
+    adapter = NoOpSyncAdapter()
+    return TenantService(repository=repo, adapter=adapter)
+
+
+@pytest.mark.asyncio
+async def test_tenant_create_and_get(db_session, tenant_service):
+    """Create a tenant and retrieve it by ID."""
+    suffix = uuid.uuid4().hex[:8]
+
+    # --- Create ---
+    result = await tenant_service.create_tenant(
+        name=f"lifecycle-tenant-{suffix}",
+        domains=[f"{suffix}.example.com"],
+    )
+    assert result.is_ok()
+    tenant_data = result.ok
+    tenant_id = tenant_data["id"]
+    assert tenant_data["name"] == f"lifecycle-tenant-{suffix}"
+    assert tenant_data["domains"] == [f"{suffix}.example.com"]
+    assert tenant_data["status"] == "active"
+
+    # --- Get ---
+    result = await tenant_service.get_tenant(tenant_id=tenant_id)
+    assert result.is_ok()
+    assert result.ok["name"] == f"lifecycle-tenant-{suffix}"
+    assert result.ok["domains"] == [f"{suffix}.example.com"]
+
+
+@pytest.mark.asyncio
+async def test_tenant_duplicate_name(db_session, tenant_service):
+    """Creating a tenant with a duplicate name returns Conflict."""
+    suffix = uuid.uuid4().hex[:8]
+    result = await tenant_service.create_tenant(name=f"dup-tenant-{suffix}")
+    assert result.is_ok()
+
+    result = await tenant_service.create_tenant(name=f"dup-tenant-{suffix}")
+    assert result.is_error()
+    assert "already exists" in result.error.message
+
+
+@pytest.mark.asyncio
+async def test_tenant_get_not_found(db_session, tenant_service):
+    """Getting a nonexistent tenant returns NotFound."""
+    result = await tenant_service.get_tenant(tenant_id=uuid.uuid4())
+    assert result.is_error()
+    assert "not found" in result.error.message
+
+
+@pytest.mark.asyncio
+async def test_tenant_users_with_roles_empty(db_session, tenant_service):
+    """get_tenant_users_with_roles returns empty list for tenant with no assignments."""
+    suffix = uuid.uuid4().hex[:8]
+    create_result = await tenant_service.create_tenant(name=f"empty-tenant-{suffix}")
+    assert create_result.is_ok()
+    tenant_id = create_result.ok["id"]
+
+    result = await tenant_service.get_tenant_users_with_roles(tenant_id=tenant_id)
+    assert result.is_ok()
+    assert result.ok == []
+
+
+@pytest.mark.asyncio
+async def test_tenant_users_with_roles_populated(db_session, tenant_service):
+    """get_tenant_users_with_roles returns users with their assigned roles."""
+    suffix = uuid.uuid4().hex[:8]
+
+    # Create tenant via service
+    create_result = await tenant_service.create_tenant(name=f"populated-tenant-{suffix}")
+    assert create_result.is_ok()
+    tenant_id = create_result.ok["id"]
+
+    # Seed user and role directly via ORM (they're prerequisites, not under test)
+    user = User(email=f"tenant-user-{suffix}@test.com", user_name=f"tenant-user-{suffix}")
+    db_session.add(user)
+    await db_session.flush()
+
+    role = Role(name=f"tenant-role-{suffix}", description="test", tenant_id=tenant_id)
+    db_session.add(role)
+    await db_session.flush()
+
+    assignment = UserTenantRole(user_id=user.id, tenant_id=tenant_id, role_id=role.id)
+    db_session.add(assignment)
+    await db_session.commit()
+
+    # Query via service
+    result = await tenant_service.get_tenant_users_with_roles(tenant_id=tenant_id)
+    assert result.is_ok()
+    users = result.ok
+    assert len(users) == 1
+    assert users[0]["email"] == f"tenant-user-{suffix}@test.com"
+    assert len(users[0]["roles"]) == 1
+    assert users[0]["roles"][0]["name"] == f"tenant-role-{suffix}"
+
+
+@pytest.mark.asyncio
+async def test_tenant_users_with_roles_multiple_roles(db_session, tenant_service):
+    """A user with multiple roles appears once with all roles listed."""
+    suffix = uuid.uuid4().hex[:8]
+
+    create_result = await tenant_service.create_tenant(name=f"multi-role-tenant-{suffix}")
+    assert create_result.is_ok()
+    tenant_id = create_result.ok["id"]
+
+    user = User(email=f"multi-role-{suffix}@test.com", user_name=f"multi-role-user-{suffix}")
+    db_session.add(user)
+    await db_session.flush()
+
+    role1 = Role(name=f"role-alpha-{suffix}", description="alpha", tenant_id=tenant_id)
+    role2 = Role(name=f"role-beta-{suffix}", description="beta", tenant_id=tenant_id)
+    db_session.add(role1)
+    db_session.add(role2)
+    await db_session.flush()
+
+    for role in [role1, role2]:
+        assignment = UserTenantRole(user_id=user.id, tenant_id=tenant_id, role_id=role.id)
+        db_session.add(assignment)
+    await db_session.commit()
+
+    result = await tenant_service.get_tenant_users_with_roles(tenant_id=tenant_id)
+    assert result.is_ok()
+    users = result.ok
+    assert len(users) == 1
+    role_names = {r["name"] for r in users[0]["roles"]}
+    assert role_names == {f"role-alpha-{suffix}", f"role-beta-{suffix}"}

--- a/backend/tests/integration/test_user_lifecycle.py
+++ b/backend/tests/integration/test_user_lifecycle.py
@@ -1,0 +1,174 @@
+"""Integration lifecycle tests for UserService against real Postgres.
+
+AC-2.4.5: Full CRUD lifecycle — create → get → update → get → deactivate → get.
+Uses UserService + UserRepository + NoOpSyncAdapter + real Postgres via testcontainers.
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from app.models.identity.assignment import UserTenantRole
+from app.models.identity.role import Role
+from app.models.identity.tenant import Tenant
+from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.user import UserRepository
+from app.services.adapters.noop import NoOpSyncAdapter
+from app.services.user import UserService
+
+
+@pytest.fixture
+def user_service(db_session):
+    repo = UserRepository(db_session)
+    assignment_repo = UserTenantRoleRepository(db_session)
+    adapter = NoOpSyncAdapter()
+    return UserService(repository=repo, adapter=adapter, assignment_repository=assignment_repo)
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def seed_tenant(db_session):
+    """Create a tenant for user lifecycle tests."""
+    suffix = uuid.uuid4().hex[:8]
+    tenant = Tenant(name=f"lifecycle-tenant-{suffix}", domains=[f"{suffix}.test"])
+    db_session.add(tenant)
+    await db_session.flush()
+    return tenant
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def seed_role(db_session, seed_tenant):
+    """Create a role scoped to the seed tenant."""
+    suffix = uuid.uuid4().hex[:8]
+    role = Role(name=f"lifecycle-role-{suffix}", description="test role", tenant_id=seed_tenant.id)
+    db_session.add(role)
+    await db_session.flush()
+    return role
+
+
+@pytest.mark.asyncio
+async def test_user_create_get_update_deactivate(db_session, user_service, seed_tenant, seed_role):
+    """Full user lifecycle: create → get → update → get → deactivate → get."""
+    tenant_id = seed_tenant.id
+    suffix = uuid.uuid4().hex[:8]
+
+    # --- Create ---
+    result = await user_service.create_user(
+        tenant_id=tenant_id,
+        email=f"lifecycle-{suffix}@test.com",
+        user_name=f"lifecycle-user-{suffix}",
+        given_name="Life",
+        family_name="Cycle",
+    )
+    assert result.is_ok()
+    user_data = result.ok
+    user_id = user_data["id"]
+    assert user_data["email"] == f"lifecycle-{suffix}@test.com"
+    assert user_data["user_name"] == f"lifecycle-user-{suffix}"
+    assert user_data["given_name"] == "Life"
+    assert user_data["family_name"] == "Cycle"
+    assert user_data["status"] == "active"
+
+    # --- Assign role (required for tenant-scoped get/update/deactivate) ---
+    assignment = UserTenantRole(user_id=user_id, tenant_id=tenant_id, role_id=seed_role.id)
+    db_session.add(assignment)
+    await db_session.commit()
+
+    # --- Get ---
+    result = await user_service.get_user(tenant_id=tenant_id, user_id=user_id)
+    assert result.is_ok()
+    assert result.ok["email"] == f"lifecycle-{suffix}@test.com"
+
+    # --- Update ---
+    update_suffix = uuid.uuid4().hex[:8]
+    result = await user_service.update_user(
+        tenant_id=tenant_id,
+        user_id=user_id,
+        email=f"updated-{update_suffix}@test.com",
+        given_name="Updated",
+    )
+    assert result.is_ok()
+    updated = result.ok
+    assert updated["email"] == f"updated-{update_suffix}@test.com"
+    assert updated["given_name"] == "Updated"
+    assert updated["family_name"] == "Cycle"
+
+    # --- Get after update ---
+    result = await user_service.get_user(tenant_id=tenant_id, user_id=user_id)
+    assert result.is_ok()
+    assert result.ok["email"] == f"updated-{update_suffix}@test.com"
+    assert result.ok["given_name"] == "Updated"
+
+    # --- Deactivate ---
+    result = await user_service.deactivate_user(tenant_id=tenant_id, user_id=user_id)
+    assert result.is_ok()
+    assert result.ok["status"] == "inactive"
+
+    # --- Get after deactivate ---
+    result = await user_service.get_user(tenant_id=tenant_id, user_id=user_id)
+    assert result.is_ok()
+    assert result.ok["status"] == "inactive"
+
+
+@pytest.mark.asyncio
+async def test_user_create_duplicate_email(db_session, user_service, seed_tenant):
+    """Creating a user with a duplicate email returns Conflict."""
+    tenant_id = seed_tenant.id
+    suffix = uuid.uuid4().hex[:8]
+
+    result = await user_service.create_user(
+        tenant_id=tenant_id,
+        email=f"duplicate-{suffix}@test.com",
+        user_name=f"first-user-{suffix}",
+    )
+    assert result.is_ok()
+
+    result = await user_service.create_user(
+        tenant_id=tenant_id,
+        email=f"duplicate-{suffix}@test.com",
+        user_name=f"second-user-{suffix}",
+    )
+    assert result.is_error()
+    assert "already exists" in result.error.message
+
+
+@pytest.mark.asyncio
+async def test_user_get_not_found(db_session, user_service, seed_tenant):
+    """Getting a nonexistent user returns NotFound."""
+    result = await user_service.get_user(tenant_id=seed_tenant.id, user_id=uuid.uuid4())
+    assert result.is_error()
+    assert "not found" in result.error.message
+
+
+@pytest.mark.asyncio
+async def test_user_search_tenant_scoped(db_session, user_service, seed_tenant, seed_role):
+    """Search returns only users with role assignments in the tenant."""
+    tenant_id = seed_tenant.id
+    suffix = uuid.uuid4().hex[:8]
+
+    # Create a user but don't assign a role — should not appear in search
+    result = await user_service.create_user(
+        tenant_id=tenant_id,
+        email=f"no-role-{suffix}@test.com",
+        user_name=f"no-role-user-{suffix}",
+    )
+    assert result.is_ok()
+
+    # Create another user and assign a role — should appear
+    result = await user_service.create_user(
+        tenant_id=tenant_id,
+        email=f"has-role-{suffix}@test.com",
+        user_name=f"has-role-user-{suffix}",
+    )
+    assert result.is_ok()
+    user_with_role_id = result.ok["id"]
+
+    assignment = UserTenantRole(user_id=user_with_role_id, tenant_id=tenant_id, role_id=seed_role.id)
+    db_session.add(assignment)
+    await db_session.commit()
+
+    search_result = await user_service.search_users(tenant_id=tenant_id)
+    assert search_result.is_ok()
+    emails = [u["email"] for u in search_result.ok]
+    assert f"has-role-{suffix}@test.com" in emails
+    assert f"no-role-{suffix}@test.com" not in emails

--- a/backend/tests/unit/repositories/conftest.py
+++ b/backend/tests/unit/repositories/conftest.py
@@ -1,0 +1,93 @@
+"""Shared fixtures for repository unit tests.
+
+Uses testcontainers Postgres with Alembic migrations and per-test
+transactional rollback. Postgres fixtures mirror integration/conftest.py —
+kept separate so unit and integration test sessions use independent containers.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/testdb")
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+from testcontainers.postgres import PostgresContainer
+
+
+@pytest.fixture(scope="session")
+def postgres_container():
+    """Start a real Postgres container for the test session."""
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg
+
+
+@pytest.fixture(scope="session")
+def postgres_url(postgres_container):
+    """Async-compatible connection URL for the testcontainers Postgres instance."""
+    from urllib.parse import urlparse, urlunparse
+
+    sync_url = postgres_container.get_connection_url()
+    parsed = urlparse(sync_url)
+    async_url = urlunparse(parsed._replace(scheme="postgresql+asyncpg"))
+    return async_url
+
+
+@pytest.fixture(scope="session")
+def _run_migrations(postgres_url):
+    """Run Alembic migrations against the test Postgres instance (once per session).
+
+    Uses subprocess to avoid asyncio.run() inside Alembic's env.py from
+    interfering with the pytest-asyncio session event loop.
+    """
+    import subprocess
+    import sys
+
+    project_root = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+    env = os.environ.copy()
+    env["DATABASE_URL"] = postgres_url
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=project_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Alembic migration failed:\nstdout={result.stdout}\nstderr={result.stderr}")
+
+
+@pytest.fixture(scope="session")
+def async_engine(postgres_url, _run_migrations):
+    """Create an async engine pointing at the test Postgres instance."""
+    engine = create_async_engine(postgres_url, echo=False, poolclass=NullPool)
+    return engine
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def db_session(async_engine):
+    """Per-test async session with transactional rollback for clean state.
+
+    Uses loop_scope="session" to match the session-scoped event loop
+    configured via asyncio_default_test_loop_scope in pyproject.toml.
+    """
+    async with async_engine.connect() as conn:
+        transaction = await conn.begin()
+        await conn.begin_nested()
+        session_factory = async_sessionmaker(bind=conn, class_=AsyncSession, expire_on_commit=False)
+        async with session_factory() as session:
+
+            @event.listens_for(session.sync_session, "after_transaction_end")
+            def _restart_savepoint(sync_session, trans):
+                if conn.closed or not conn.in_transaction():
+                    return
+                if not conn.in_nested_transaction():
+                    conn.sync_connection.begin_nested()
+
+            yield session
+
+            event.remove(session.sync_session, "after_transaction_end", _restart_savepoint)
+        await transaction.rollback()

--- a/backend/tests/unit/repositories/test_assignment_repository.py
+++ b/backend/tests/unit/repositories/test_assignment_repository.py
@@ -1,0 +1,193 @@
+"""Unit tests for UserTenantRoleRepository — data access layer tests against real Postgres.
+
+Tests cover:
+- create: happy path, duplicate assignment → RepositoryConflictError
+- get: composite PK lookup (user_id, tenant_id, role_id)
+- list_by_user_tenant: returns all role assignments for a user in a tenant
+- delete: specific assignment (composite PK)
+- delete_by_user_tenant: bulk delete all assignments for user in tenant
+- Tenant isolation: data for tenant A not visible from tenant B queries
+"""
+
+import uuid
+
+import pytest
+
+from app.models.identity.assignment import UserTenantRole
+from app.models.identity.role import Role
+from app.models.identity.tenant import Tenant
+from app.models.identity.user import User, UserStatus
+from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.user import RepositoryConflictError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_user(**overrides) -> User:
+    defaults = {
+        "id": uuid.uuid4(),
+        "email": f"user-{uuid.uuid4().hex[:8]}@test.com",
+        "user_name": "testuser",
+        "given_name": "Test",
+        "family_name": "User",
+        "status": UserStatus.active,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _make_tenant(**overrides) -> Tenant:
+    defaults = {"id": uuid.uuid4(), "name": f"tenant-{uuid.uuid4().hex[:8]}"}
+    defaults.update(overrides)
+    return Tenant(**defaults)
+
+
+def _make_role(tenant_id=None, **overrides) -> Role:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"role-{uuid.uuid4().hex[:8]}",
+        "tenant_id": tenant_id,
+    }
+    defaults.update(overrides)
+    return Role(**defaults)
+
+
+async def _setup_entities(db_session):
+    """Create prerequisite user, tenant, and role for assignment tests."""
+    user = _make_user()
+    tenant = _make_tenant()
+    db_session.add_all([user, tenant])
+    await db_session.flush()
+    role = _make_role(tenant_id=tenant.id)
+    db_session.add(role)
+    await db_session.flush()
+    return user, tenant, role
+
+
+async def test_create_assignment(db_session):
+    repo = UserTenantRoleRepository(db_session)
+    user, tenant, role = await _setup_entities(db_session)
+
+    assignment = UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
+    created = await repo.create(assignment)
+    assert created.user_id == user.id
+    assert created.tenant_id == tenant.id
+    assert created.role_id == role.id
+    assert created.assigned_at is not None
+
+
+async def test_create_assignment_duplicate(db_session):
+    repo = UserTenantRoleRepository(db_session)
+    user, tenant, role = await _setup_entities(db_session)
+
+    a1 = UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
+    await repo.create(a1)
+    a2 = UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
+    with pytest.raises(RepositoryConflictError):
+        await repo.create(a2)
+
+
+async def test_get_assignment(db_session):
+    repo = UserTenantRoleRepository(db_session)
+    user, tenant, role = await _setup_entities(db_session)
+
+    assignment = UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
+    await repo.create(assignment)
+
+    fetched = await repo.get(user.id, tenant.id, role.id)
+    assert fetched is not None
+    assert fetched.user_id == user.id
+    assert fetched.tenant_id == tenant.id
+    assert fetched.role_id == role.id
+
+
+async def test_get_assignment_not_found(db_session):
+    repo = UserTenantRoleRepository(db_session)
+    result = await repo.get(uuid.uuid4(), uuid.uuid4(), uuid.uuid4())
+    assert result is None
+
+
+async def test_list_by_user_tenant(db_session):
+    repo = UserTenantRoleRepository(db_session)
+    user = _make_user()
+    tenant = _make_tenant()
+    db_session.add_all([user, tenant])
+    await db_session.flush()
+    r1 = _make_role(tenant_id=tenant.id)
+    r2 = _make_role(tenant_id=tenant.id)
+    db_session.add_all([r1, r2])
+    await db_session.flush()
+
+    a1 = UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=r1.id)
+    a2 = UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=r2.id)
+    await repo.create(a1)
+    await repo.create(a2)
+
+    assignments = await repo.list_by_user_tenant(user.id, tenant.id)
+    assert len(assignments) == 2
+    role_ids = {a.role_id for a in assignments}
+    assert r1.id in role_ids
+    assert r2.id in role_ids
+
+
+async def test_delete_assignment(db_session):
+    repo = UserTenantRoleRepository(db_session)
+    user, tenant, role = await _setup_entities(db_session)
+
+    assignment = UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
+    await repo.create(assignment)
+
+    assert await repo.delete(user.id, tenant.id, role.id) is True
+    assert await repo.get(user.id, tenant.id, role.id) is None
+
+
+async def test_delete_assignment_not_found(db_session):
+    repo = UserTenantRoleRepository(db_session)
+    assert await repo.delete(uuid.uuid4(), uuid.uuid4(), uuid.uuid4()) is False
+
+
+async def test_delete_by_user_tenant(db_session):
+    repo = UserTenantRoleRepository(db_session)
+    user = _make_user()
+    tenant = _make_tenant()
+    db_session.add_all([user, tenant])
+    await db_session.flush()
+    r1 = _make_role(tenant_id=tenant.id)
+    r2 = _make_role(tenant_id=tenant.id)
+    db_session.add_all([r1, r2])
+    await db_session.flush()
+
+    a1 = UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=r1.id)
+    a2 = UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=r2.id)
+    await repo.create(a1)
+    await repo.create(a2)
+
+    count = await repo.delete_by_user_tenant(user.id, tenant.id)
+    assert count == 2
+    assert await repo.list_by_user_tenant(user.id, tenant.id) == []
+
+
+async def test_tenant_isolation(db_session):
+    """Assignments in tenant A must not be visible when querying tenant B."""
+    repo = UserTenantRoleRepository(db_session)
+    user = _make_user()
+    tenant_a = _make_tenant()
+    tenant_b = _make_tenant()
+    db_session.add_all([user, tenant_a, tenant_b])
+    await db_session.flush()
+    role_a = _make_role(tenant_id=tenant_a.id)
+    role_b = _make_role(tenant_id=tenant_b.id)
+    db_session.add_all([role_a, role_b])
+    await db_session.flush()
+
+    # Assign user in tenant A only
+    assignment = UserTenantRole(user_id=user.id, tenant_id=tenant_a.id, role_id=role_a.id)
+    await repo.create(assignment)
+
+    # Tenant A has the assignment
+    a_results = await repo.list_by_user_tenant(user.id, tenant_a.id)
+    assert len(a_results) == 1
+
+    # Tenant B has nothing
+    b_results = await repo.list_by_user_tenant(user.id, tenant_b.id)
+    assert len(b_results) == 0

--- a/backend/tests/unit/repositories/test_idp_link_repository.py
+++ b/backend/tests/unit/repositories/test_idp_link_repository.py
@@ -1,0 +1,179 @@
+"""Unit tests for IdPLinkRepository — data access layer tests against real Postgres.
+
+Tests cover:
+- create: happy path, duplicate user+provider → RepositoryConflictError,
+          duplicate provider+external_sub → RepositoryConflictError
+- get: found, not found
+- delete: found → True, not found → False
+- get_by_user: returns all links for user, empty when none
+- get_by_provider_and_sub: found, not found
+"""
+
+import uuid
+
+import pytest
+
+from app.models.identity.provider import Provider, ProviderType
+from app.models.identity.user import IdPLink, User, UserStatus
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.user import RepositoryConflictError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_user(**overrides) -> User:
+    defaults = {
+        "id": uuid.uuid4(),
+        "email": f"user-{uuid.uuid4().hex[:8]}@test.com",
+        "user_name": "testuser",
+        "given_name": "Test",
+        "family_name": "User",
+        "status": UserStatus.active,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _make_provider(**overrides) -> Provider:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"provider-{uuid.uuid4().hex[:8]}",
+        "type": ProviderType.descope,
+    }
+    defaults.update(overrides)
+    return Provider(**defaults)
+
+
+def _make_idp_link(user_id: uuid.UUID, provider_id: uuid.UUID, **overrides) -> IdPLink:
+    defaults = {
+        "user_id": user_id,
+        "provider_id": provider_id,
+        "external_sub": f"ext-{uuid.uuid4().hex[:8]}",
+        "external_email": "ext@example.com",
+    }
+    defaults.update(overrides)
+    return IdPLink(**defaults)
+
+
+async def _seed_user_and_provider(db_session) -> tuple[User, Provider]:
+    """Insert a user and provider to satisfy FK constraints."""
+    user = _make_user()
+    provider = _make_provider()
+    db_session.add(user)
+    db_session.add(provider)
+    await db_session.flush()
+    return user, provider
+
+
+async def test_create_idp_link(db_session):
+    user, provider = await _seed_user_and_provider(db_session)
+    repo = IdPLinkRepository(db_session)
+    link = _make_idp_link(user.id, provider.id)
+
+    created = await repo.create(link)
+
+    assert created.id == link.id
+    assert created.user_id == user.id
+    assert created.provider_id == provider.id
+
+
+async def test_create_duplicate_user_provider(db_session):
+    """Unique constraint: same user + same provider → RepositoryConflictError."""
+    user, provider = await _seed_user_and_provider(db_session)
+    repo = IdPLinkRepository(db_session)
+
+    await repo.create(_make_idp_link(user.id, provider.id, external_sub="sub-1"))
+    with pytest.raises(RepositoryConflictError):
+        await repo.create(_make_idp_link(user.id, provider.id, external_sub="sub-2"))
+
+
+async def test_create_duplicate_provider_external_sub(db_session):
+    """Unique constraint: same provider + same external_sub → RepositoryConflictError."""
+    user1 = _make_user()
+    user2 = _make_user()
+    provider = _make_provider()
+    db_session.add_all([user1, user2, provider])
+    await db_session.flush()
+    repo = IdPLinkRepository(db_session)
+    ext_sub = "shared-ext-sub"
+
+    await repo.create(_make_idp_link(user1.id, provider.id, external_sub=ext_sub))
+    with pytest.raises(RepositoryConflictError):
+        await repo.create(_make_idp_link(user2.id, provider.id, external_sub=ext_sub))
+
+
+async def test_get_found(db_session):
+    user, provider = await _seed_user_and_provider(db_session)
+    repo = IdPLinkRepository(db_session)
+    link = _make_idp_link(user.id, provider.id)
+    await repo.create(link)
+
+    fetched = await repo.get(link.id)
+
+    assert fetched is not None
+    assert fetched.id == link.id
+
+
+async def test_get_not_found(db_session):
+    repo = IdPLinkRepository(db_session)
+    result = await repo.get(uuid.uuid4())
+    assert result is None
+
+
+async def test_delete_found(db_session):
+    user, provider = await _seed_user_and_provider(db_session)
+    repo = IdPLinkRepository(db_session)
+    link = _make_idp_link(user.id, provider.id)
+    await repo.create(link)
+
+    deleted = await repo.delete(link.id)
+
+    assert deleted is True
+    assert await repo.get(link.id) is None
+
+
+async def test_delete_not_found(db_session):
+    repo = IdPLinkRepository(db_session)
+    deleted = await repo.delete(uuid.uuid4())
+    assert deleted is False
+
+
+async def test_get_by_user(db_session):
+    user = _make_user()
+    p1 = _make_provider()
+    p2 = _make_provider()
+    db_session.add_all([user, p1, p2])
+    await db_session.flush()
+    repo = IdPLinkRepository(db_session)
+
+    await repo.create(_make_idp_link(user.id, p1.id))
+    await repo.create(_make_idp_link(user.id, p2.id))
+
+    links = await repo.get_by_user(user.id)
+    assert len(links) == 2
+    assert all(link.user_id == user.id for link in links)
+
+
+async def test_get_by_user_empty(db_session):
+    repo = IdPLinkRepository(db_session)
+    links = await repo.get_by_user(uuid.uuid4())
+    assert links == []
+
+
+async def test_get_by_provider_and_sub(db_session):
+    user, provider = await _seed_user_and_provider(db_session)
+    repo = IdPLinkRepository(db_session)
+    ext_sub = "unique-ext-sub"
+    link = _make_idp_link(user.id, provider.id, external_sub=ext_sub)
+    await repo.create(link)
+
+    fetched = await repo.get_by_provider_and_sub(provider.id, ext_sub)
+
+    assert fetched is not None
+    assert fetched.external_sub == ext_sub
+
+
+async def test_get_by_provider_and_sub_not_found(db_session):
+    repo = IdPLinkRepository(db_session)
+    result = await repo.get_by_provider_and_sub(uuid.uuid4(), "no-such-sub")
+    assert result is None

--- a/backend/tests/unit/repositories/test_permission_repository.py
+++ b/backend/tests/unit/repositories/test_permission_repository.py
@@ -1,0 +1,111 @@
+"""Unit tests for PermissionRepository — data access layer tests against real Postgres.
+
+Tests cover:
+- create: happy path, duplicate name → RepositoryConflictError
+- get: found, not found
+- get_by_name: found, not found
+- list_all: returns all permissions
+- update: happy path
+- delete: existing, non-existent
+"""
+
+import uuid
+
+import pytest
+
+from app.models.identity.role import Permission
+from app.repositories.permission import PermissionRepository
+from app.repositories.user import RepositoryConflictError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_permission(**overrides) -> Permission:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"perm-{uuid.uuid4().hex[:8]}",
+        "description": "test permission",
+    }
+    defaults.update(overrides)
+    return Permission(**defaults)
+
+
+async def test_create_permission(db_session):
+    repo = PermissionRepository(db_session)
+    perm = _make_permission()
+    created = await repo.create(perm)
+    assert created.id == perm.id
+    assert created.name == perm.name
+    assert created.created_at is not None
+
+
+async def test_create_permission_duplicate_name(db_session):
+    repo = PermissionRepository(db_session)
+    name = f"dup-perm-{uuid.uuid4().hex[:8]}"
+    await repo.create(_make_permission(name=name))
+    with pytest.raises(RepositoryConflictError):
+        await repo.create(_make_permission(name=name))
+
+
+async def test_get_permission(db_session):
+    repo = PermissionRepository(db_session)
+    perm = _make_permission()
+    await repo.create(perm)
+    fetched = await repo.get(perm.id)
+    assert fetched is not None
+    assert fetched.id == perm.id
+    assert fetched.name == perm.name
+
+
+async def test_get_permission_not_found(db_session):
+    repo = PermissionRepository(db_session)
+    assert await repo.get(uuid.uuid4()) is None
+
+
+async def test_get_by_name(db_session):
+    repo = PermissionRepository(db_session)
+    perm = _make_permission()
+    await repo.create(perm)
+    fetched = await repo.get_by_name(perm.name)
+    assert fetched is not None
+    assert fetched.id == perm.id
+
+
+async def test_get_by_name_not_found(db_session):
+    repo = PermissionRepository(db_session)
+    assert await repo.get_by_name("nonexistent-perm") is None
+
+
+async def test_list_all(db_session):
+    repo = PermissionRepository(db_session)
+    p1 = _make_permission()
+    p2 = _make_permission()
+    await repo.create(p1)
+    await repo.create(p2)
+
+    all_perms = await repo.list_all()
+    perm_ids = [p.id for p in all_perms]
+    assert p1.id in perm_ids
+    assert p2.id in perm_ids
+
+
+async def test_update_permission(db_session):
+    repo = PermissionRepository(db_session)
+    perm = _make_permission()
+    await repo.create(perm)
+    perm.description = "updated description"
+    updated = await repo.update(perm)
+    assert updated.description == "updated description"
+
+
+async def test_delete_permission(db_session):
+    repo = PermissionRepository(db_session)
+    perm = _make_permission()
+    await repo.create(perm)
+    assert await repo.delete(perm.id) is True
+    assert await repo.get(perm.id) is None
+
+
+async def test_delete_permission_not_found(db_session):
+    repo = PermissionRepository(db_session)
+    assert await repo.delete(uuid.uuid4()) is False

--- a/backend/tests/unit/repositories/test_provider_repository.py
+++ b/backend/tests/unit/repositories/test_provider_repository.py
@@ -1,0 +1,153 @@
+"""Unit tests for ProviderRepository — data access layer tests against real Postgres.
+
+Tests cover:
+- create: happy path, duplicate name → RepositoryConflictError
+- update: flush mutations, integrity error → RepositoryConflictError
+- get: found, not found
+- get_by_name: found, not found
+- get_by_type: found, not found
+- list_all: returns all ordered by name, empty when none exist
+"""
+
+import uuid
+
+import pytest
+
+from app.models.identity.provider import Provider, ProviderType
+from app.repositories.provider import ProviderRepository
+from app.repositories.user import RepositoryConflictError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_provider(**overrides) -> Provider:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"provider-{uuid.uuid4().hex[:8]}",
+        "type": ProviderType.descope,
+        "issuer_url": "https://api.descope.com/P123",
+        "base_url": "https://api.descope.com",
+        "capabilities": ["sso", "mfa"],
+        "config_ref": "infisical://test",
+        "active": True,
+    }
+    defaults.update(overrides)
+    return Provider(**defaults)
+
+
+async def test_create_provider(db_session):
+    repo = ProviderRepository(db_session)
+    provider = _make_provider()
+
+    created = await repo.create(provider)
+
+    assert created.id == provider.id
+    assert created.name == provider.name
+    assert created.type == ProviderType.descope
+    assert created.created_at is not None
+
+
+async def test_create_duplicate_name(db_session):
+    repo = ProviderRepository(db_session)
+    name = f"dup-{uuid.uuid4().hex[:8]}"
+
+    await repo.create(_make_provider(name=name))
+    with pytest.raises(RepositoryConflictError):
+        await repo.create(_make_provider(name=name))
+
+
+async def test_get_found(db_session):
+    repo = ProviderRepository(db_session)
+    provider = _make_provider()
+    await repo.create(provider)
+
+    fetched = await repo.get(provider.id)
+
+    assert fetched is not None
+    assert fetched.id == provider.id
+    assert fetched.name == provider.name
+
+
+async def test_get_not_found(db_session):
+    repo = ProviderRepository(db_session)
+    result = await repo.get(uuid.uuid4())
+    assert result is None
+
+
+async def test_get_by_name_found(db_session):
+    repo = ProviderRepository(db_session)
+    provider = _make_provider()
+    await repo.create(provider)
+
+    fetched = await repo.get_by_name(provider.name)
+
+    assert fetched is not None
+    assert fetched.id == provider.id
+
+
+async def test_get_by_name_not_found(db_session):
+    repo = ProviderRepository(db_session)
+    result = await repo.get_by_name("nonexistent-provider")
+    assert result is None
+
+
+async def test_get_by_type_found(db_session):
+    repo = ProviderRepository(db_session)
+    provider = _make_provider(type=ProviderType.ory)
+    await repo.create(provider)
+
+    fetched = await repo.get_by_type(ProviderType.ory)
+
+    assert fetched is not None
+    assert fetched.type == ProviderType.ory
+
+
+async def test_get_by_type_not_found(db_session):
+    repo = ProviderRepository(db_session)
+    result = await repo.get_by_type(ProviderType.cognito)
+    assert result is None
+
+
+async def test_update_provider(db_session):
+    repo = ProviderRepository(db_session)
+    provider = _make_provider(active=True)
+    await repo.create(provider)
+
+    provider.active = False
+    updated = await repo.update(provider)
+
+    assert updated.active is False
+
+
+async def test_update_capabilities(db_session):
+    repo = ProviderRepository(db_session)
+    provider = _make_provider(capabilities=["sso"])
+    await repo.create(provider)
+
+    provider.capabilities = ["sso", "mfa", "rbac"]
+    updated = await repo.update(provider)
+
+    assert updated.capabilities == ["sso", "mfa", "rbac"]
+
+
+async def test_list_all_returns_ordered_by_name(db_session):
+    repo = ProviderRepository(db_session)
+    # Insert in reverse alphabetical order
+    await repo.create(_make_provider(name="zeta-provider"))
+    await repo.create(_make_provider(name="alpha-provider"))
+    await repo.create(_make_provider(name="middle-provider"))
+
+    results = await repo.list_all()
+
+    names = [p.name for p in results]
+    assert names == sorted(names)
+    assert len(results) >= 3
+
+
+async def test_list_all_empty(db_session):
+    """Fresh database with no providers returns empty list."""
+    repo = ProviderRepository(db_session)
+    results = await repo.list_all()
+    # May have providers from other tests in the same session,
+    # but the method should always return a list
+    assert isinstance(results, list)

--- a/backend/tests/unit/repositories/test_role_repository.py
+++ b/backend/tests/unit/repositories/test_role_repository.py
@@ -1,0 +1,240 @@
+"""Unit tests for RoleRepository — data access layer tests against real Postgres.
+
+Tests cover:
+- create: happy path, duplicate name+tenant → RepositoryConflictError
+- get: found, not found
+- get_by_name: global scope (tenant_id=None), tenant scope
+- list_by_tenant: global roles, tenant-scoped roles
+- update: happy path
+- delete: existing, non-existent
+- add_permission / remove_permission / get_permissions: permission mapping
+- Name uniqueness: per-tenant (same name, different tenants → OK)
+"""
+
+import uuid
+
+import pytest
+
+from app.models.identity.role import Permission, Role
+from app.models.identity.tenant import Tenant
+from app.repositories.role import RoleRepository
+from app.repositories.user import RepositoryConflictError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_tenant(**overrides) -> Tenant:
+    defaults = {"id": uuid.uuid4(), "name": f"tenant-{uuid.uuid4().hex[:8]}"}
+    defaults.update(overrides)
+    return Tenant(**defaults)
+
+
+def _make_role(tenant_id=None, **overrides) -> Role:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"role-{uuid.uuid4().hex[:8]}",
+        "tenant_id": tenant_id,
+    }
+    defaults.update(overrides)
+    return Role(**defaults)
+
+
+def _make_permission(**overrides) -> Permission:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"perm-{uuid.uuid4().hex[:8]}",
+        "description": "test permission",
+    }
+    defaults.update(overrides)
+    return Permission(**defaults)
+
+
+async def test_create_role(db_session):
+    repo = RoleRepository(db_session)
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+
+    role = _make_role(tenant_id=tenant.id)
+    created = await repo.create(role)
+    assert created.id == role.id
+    assert created.name == role.name
+
+
+async def test_create_role_duplicate_name_same_tenant(db_session):
+    repo = RoleRepository(db_session)
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+
+    name = f"dup-role-{uuid.uuid4().hex[:8]}"
+    await repo.create(_make_role(tenant_id=tenant.id, name=name))
+    with pytest.raises(RepositoryConflictError):
+        await repo.create(_make_role(tenant_id=tenant.id, name=name))
+
+
+async def test_create_role_same_name_different_tenants(db_session):
+    """Same role name in different tenants should succeed."""
+    repo = RoleRepository(db_session)
+    t1 = _make_tenant()
+    t2 = _make_tenant()
+    db_session.add_all([t1, t2])
+    await db_session.flush()
+
+    name = f"shared-role-{uuid.uuid4().hex[:8]}"
+    r1 = await repo.create(_make_role(tenant_id=t1.id, name=name))
+    r2 = await repo.create(_make_role(tenant_id=t2.id, name=name))
+    assert r1.id != r2.id
+
+
+async def test_get_role(db_session):
+    repo = RoleRepository(db_session)
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+
+    role = _make_role(tenant_id=tenant.id)
+    await repo.create(role)
+    fetched = await repo.get(role.id)
+    assert fetched is not None
+    assert fetched.name == role.name
+
+
+async def test_get_role_not_found(db_session):
+    repo = RoleRepository(db_session)
+    assert await repo.get(uuid.uuid4()) is None
+
+
+async def test_get_by_name_global(db_session):
+    repo = RoleRepository(db_session)
+    role = _make_role(tenant_id=None)
+    await repo.create(role)
+    fetched = await repo.get_by_name(role.name, tenant_id=None)
+    assert fetched is not None
+    assert fetched.id == role.id
+
+
+async def test_get_by_name_tenant_scoped(db_session):
+    repo = RoleRepository(db_session)
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+
+    role = _make_role(tenant_id=tenant.id)
+    await repo.create(role)
+    fetched = await repo.get_by_name(role.name, tenant_id=tenant.id)
+    assert fetched is not None
+    assert fetched.id == role.id
+
+    # Same name in global scope should not match
+    assert await repo.get_by_name(role.name, tenant_id=None) is None
+
+
+async def test_list_by_tenant(db_session):
+    repo = RoleRepository(db_session)
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+
+    r1 = _make_role(tenant_id=tenant.id)
+    r2 = _make_role(tenant_id=tenant.id)
+    await repo.create(r1)
+    await repo.create(r2)
+
+    roles = await repo.list_by_tenant(tenant.id)
+    role_ids = [r.id for r in roles]
+    assert r1.id in role_ids
+    assert r2.id in role_ids
+
+
+async def test_update_role(db_session):
+    repo = RoleRepository(db_session)
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+
+    role = _make_role(tenant_id=tenant.id)
+    await repo.create(role)
+    role.description = "updated description"
+    updated = await repo.update(role)
+    assert updated.description == "updated description"
+
+
+async def test_delete_role(db_session):
+    repo = RoleRepository(db_session)
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+
+    role = _make_role(tenant_id=tenant.id)
+    await repo.create(role)
+    assert await repo.delete(role.id) is True
+    assert await repo.get(role.id) is None
+
+
+async def test_delete_role_not_found(db_session):
+    repo = RoleRepository(db_session)
+    assert await repo.delete(uuid.uuid4()) is False
+
+
+async def test_add_and_get_permissions(db_session):
+    repo = RoleRepository(db_session)
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+
+    role = _make_role(tenant_id=tenant.id)
+    await repo.create(role)
+
+    perm = _make_permission()
+    db_session.add(perm)
+    await db_session.flush()
+
+    mapping = await repo.add_permission(role.id, perm.id)
+    assert mapping.role_id == role.id
+    assert mapping.permission_id == perm.id
+
+    perms = await repo.get_permissions(role.id)
+    assert len(perms) == 1
+    assert perms[0].id == perm.id
+
+
+async def test_add_permission_duplicate(db_session):
+    repo = RoleRepository(db_session)
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+
+    role = _make_role(tenant_id=tenant.id)
+    await repo.create(role)
+    perm = _make_permission()
+    db_session.add(perm)
+    await db_session.flush()
+
+    await repo.add_permission(role.id, perm.id)
+    with pytest.raises(RepositoryConflictError):
+        await repo.add_permission(role.id, perm.id)
+
+
+async def test_remove_permission(db_session):
+    repo = RoleRepository(db_session)
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+
+    role = _make_role(tenant_id=tenant.id)
+    await repo.create(role)
+    perm = _make_permission()
+    db_session.add(perm)
+    await db_session.flush()
+
+    await repo.add_permission(role.id, perm.id)
+    assert await repo.remove_permission(role.id, perm.id) is True
+
+    perms = await repo.get_permissions(role.id)
+    assert len(perms) == 0
+
+
+async def test_remove_permission_not_found(db_session):
+    repo = RoleRepository(db_session)
+    assert await repo.remove_permission(uuid.uuid4(), uuid.uuid4()) is False

--- a/backend/tests/unit/repositories/test_tenant_repository.py
+++ b/backend/tests/unit/repositories/test_tenant_repository.py
@@ -1,0 +1,152 @@
+"""Unit tests for TenantRepository — data access layer tests against real Postgres.
+
+Tests cover:
+- create: happy path, duplicate name → RepositoryConflictError
+- get: found, not found
+- get_by_name: found, not found
+- list_all: returns all tenants
+- update: happy path
+- get_users_with_roles: 3-way JOIN returning (User, Role) tuples
+"""
+
+import uuid
+
+import pytest
+
+from app.models.identity.assignment import UserTenantRole
+from app.models.identity.role import Role
+from app.models.identity.tenant import Tenant
+from app.models.identity.user import User, UserStatus
+from app.repositories.tenant import TenantRepository
+from app.repositories.user import RepositoryConflictError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_tenant(**overrides) -> Tenant:
+    defaults = {"id": uuid.uuid4(), "name": f"tenant-{uuid.uuid4().hex[:8]}"}
+    defaults.update(overrides)
+    return Tenant(**defaults)
+
+
+def _make_user(**overrides) -> User:
+    defaults = {
+        "id": uuid.uuid4(),
+        "email": f"user-{uuid.uuid4().hex[:8]}@test.com",
+        "user_name": "testuser",
+        "given_name": "Test",
+        "family_name": "User",
+        "status": UserStatus.active,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _make_role(tenant_id=None, **overrides) -> Role:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"role-{uuid.uuid4().hex[:8]}",
+        "tenant_id": tenant_id,
+    }
+    defaults.update(overrides)
+    return Role(**defaults)
+
+
+async def test_create_tenant(db_session):
+    repo = TenantRepository(db_session)
+    tenant = _make_tenant()
+    created = await repo.create(tenant)
+    assert created.id == tenant.id
+    assert created.name == tenant.name
+    assert created.created_at is not None
+
+
+async def test_create_tenant_duplicate_name(db_session):
+    repo = TenantRepository(db_session)
+    name = f"dup-tenant-{uuid.uuid4().hex[:8]}"
+    await repo.create(_make_tenant(name=name))
+    with pytest.raises(RepositoryConflictError):
+        await repo.create(_make_tenant(name=name))
+
+
+async def test_get_tenant(db_session):
+    repo = TenantRepository(db_session)
+    tenant = _make_tenant()
+    await repo.create(tenant)
+    fetched = await repo.get(tenant.id)
+    assert fetched is not None
+    assert fetched.id == tenant.id
+    assert fetched.name == tenant.name
+
+
+async def test_get_tenant_not_found(db_session):
+    repo = TenantRepository(db_session)
+    assert await repo.get(uuid.uuid4()) is None
+
+
+async def test_get_by_name(db_session):
+    repo = TenantRepository(db_session)
+    tenant = _make_tenant()
+    await repo.create(tenant)
+    fetched = await repo.get_by_name(tenant.name)
+    assert fetched is not None
+    assert fetched.id == tenant.id
+
+
+async def test_get_by_name_not_found(db_session):
+    repo = TenantRepository(db_session)
+    assert await repo.get_by_name("nonexistent-tenant") is None
+
+
+async def test_list_all(db_session):
+    repo = TenantRepository(db_session)
+    t1 = _make_tenant()
+    t2 = _make_tenant()
+    await repo.create(t1)
+    await repo.create(t2)
+
+    all_tenants = await repo.list_all()
+    tenant_ids = [t.id for t in all_tenants]
+    assert t1.id in tenant_ids
+    assert t2.id in tenant_ids
+
+
+async def test_update_tenant(db_session):
+    repo = TenantRepository(db_session)
+    tenant = _make_tenant()
+    await repo.create(tenant)
+    tenant.name = f"updated-{uuid.uuid4().hex[:8]}"
+    updated = await repo.update(tenant)
+    assert updated.name == tenant.name
+
+
+async def test_get_users_with_roles(db_session):
+    """Verify 3-way JOIN returns (User, Role) tuples for a tenant."""
+    repo = TenantRepository(db_session)
+
+    tenant = _make_tenant()
+    await repo.create(tenant)
+
+    user = _make_user()
+    db_session.add(user)
+    role = _make_role(tenant_id=tenant.id)
+    db_session.add(role)
+    await db_session.flush()
+
+    assignment = UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
+    db_session.add(assignment)
+    await db_session.flush()
+
+    results = await repo.get_users_with_roles(tenant.id)
+    assert len(results) == 1
+    result_user, result_role = results[0]
+    assert result_user.id == user.id
+    assert result_role.id == role.id
+
+
+async def test_get_users_with_roles_empty(db_session):
+    repo = TenantRepository(db_session)
+    tenant = _make_tenant()
+    await repo.create(tenant)
+    results = await repo.get_users_with_roles(tenant.id)
+    assert results == []

--- a/backend/tests/unit/repositories/test_user_repository.py
+++ b/backend/tests/unit/repositories/test_user_repository.py
@@ -1,0 +1,240 @@
+"""Unit tests for UserRepository — data access layer tests against real Postgres.
+
+Tests cover:
+- create: happy path, duplicate email → RepositoryConflictError
+- get: found, not found
+- get_by_email: found, not found
+- update: happy path
+- search: tenant-scoped via UserTenantRole JOIN, email/name/status filters
+- exists_in_tenant: true when assigned, false when not
+"""
+
+import uuid
+
+import pytest
+
+from app.models.identity.assignment import UserTenantRole
+from app.models.identity.role import Role
+from app.models.identity.tenant import Tenant
+from app.models.identity.user import User, UserStatus
+from app.repositories.user import RepositoryConflictError, UserRepository
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_user(**overrides) -> User:
+    defaults = {
+        "id": uuid.uuid4(),
+        "email": f"user-{uuid.uuid4().hex[:8]}@test.com",
+        "user_name": "testuser",
+        "given_name": "Test",
+        "family_name": "User",
+        "status": UserStatus.active,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _make_tenant(**overrides) -> Tenant:
+    defaults = {"id": uuid.uuid4(), "name": f"tenant-{uuid.uuid4().hex[:8]}"}
+    defaults.update(overrides)
+    return Tenant(**defaults)
+
+
+def _make_role(tenant_id=None, **overrides) -> Role:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"role-{uuid.uuid4().hex[:8]}",
+        "tenant_id": tenant_id,
+    }
+    defaults.update(overrides)
+    return Role(**defaults)
+
+
+async def test_create_user(db_session):
+    repo = UserRepository(db_session)
+    user = _make_user()
+    created = await repo.create(user)
+    assert created.id == user.id
+    assert created.email == user.email
+    assert created.created_at is not None
+
+
+async def test_create_user_duplicate_email(db_session):
+    repo = UserRepository(db_session)
+    email = f"dup-{uuid.uuid4().hex[:8]}@test.com"
+    await repo.create(_make_user(email=email))
+    with pytest.raises(RepositoryConflictError):
+        await repo.create(_make_user(email=email))
+
+
+async def test_get_user(db_session):
+    repo = UserRepository(db_session)
+    user = _make_user()
+    await repo.create(user)
+    fetched = await repo.get(user.id)
+    assert fetched is not None
+    assert fetched.id == user.id
+    assert fetched.email == user.email
+
+
+async def test_get_user_not_found(db_session):
+    repo = UserRepository(db_session)
+    result = await repo.get(uuid.uuid4())
+    assert result is None
+
+
+async def test_get_by_email(db_session):
+    repo = UserRepository(db_session)
+    user = _make_user()
+    await repo.create(user)
+    fetched = await repo.get_by_email(user.email)
+    assert fetched is not None
+    assert fetched.id == user.id
+
+
+async def test_get_by_email_not_found(db_session):
+    repo = UserRepository(db_session)
+    result = await repo.get_by_email("nonexistent@test.com")
+    assert result is None
+
+
+async def test_update_user(db_session):
+    repo = UserRepository(db_session)
+    user = _make_user()
+    await repo.create(user)
+    user.given_name = "Updated"
+    updated = await repo.update(user)
+    assert updated.given_name == "Updated"
+
+
+async def test_search_tenant_scoped(db_session):
+    """Users are only returned when they have a role assignment in the tenant."""
+    repo = UserRepository(db_session)
+
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+    role = _make_role(tenant_id=tenant.id)
+    db_session.add(role)
+    await db_session.flush()
+
+    user_in = _make_user()
+    user_out = _make_user()
+    await repo.create(user_in)
+    await repo.create(user_out)
+
+    # Assign user_in to tenant
+    assignment = UserTenantRole(user_id=user_in.id, tenant_id=tenant.id, role_id=role.id)
+    db_session.add(assignment)
+    await db_session.flush()
+
+    results = await repo.search(tenant_id=tenant.id)
+    result_ids = [u.id for u in results]
+    assert user_in.id in result_ids
+    assert user_out.id not in result_ids
+
+
+async def test_search_email_filter(db_session):
+    repo = UserRepository(db_session)
+
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+    role = _make_role(tenant_id=tenant.id)
+    db_session.add(role)
+    await db_session.flush()
+
+    unique = uuid.uuid4().hex[:8]
+    user = _make_user(email=f"findme-{unique}@test.com")
+    await repo.create(user)
+    db_session.add(UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=role.id))
+    await db_session.flush()
+
+    results = await repo.search(tenant_id=tenant.id, email=f"findme-{unique}")
+    assert len(results) == 1
+    assert results[0].id == user.id
+
+
+async def test_search_name_filter(db_session):
+    repo = UserRepository(db_session)
+
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+    role = _make_role(tenant_id=tenant.id)
+    db_session.add(role)
+    await db_session.flush()
+
+    unique = uuid.uuid4().hex[:8]
+    user = _make_user(given_name=f"Unique{unique}")
+    await repo.create(user)
+    db_session.add(UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=role.id))
+    await db_session.flush()
+
+    results = await repo.search(tenant_id=tenant.id, name=f"Unique{unique}")
+    assert len(results) == 1
+    assert results[0].id == user.id
+
+
+async def test_search_status_filter(db_session):
+    repo = UserRepository(db_session)
+
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+    role = _make_role(tenant_id=tenant.id)
+    db_session.add(role)
+    await db_session.flush()
+
+    active_user = _make_user(status=UserStatus.active)
+    inactive_user = _make_user(status=UserStatus.inactive)
+    await repo.create(active_user)
+    await repo.create(inactive_user)
+    db_session.add(UserTenantRole(user_id=active_user.id, tenant_id=tenant.id, role_id=role.id))
+    db_session.add(UserTenantRole(user_id=inactive_user.id, tenant_id=tenant.id, role_id=role.id))
+    await db_session.flush()
+
+    results = await repo.search(tenant_id=tenant.id, status=UserStatus.inactive)
+    result_ids = [u.id for u in results]
+    assert inactive_user.id in result_ids
+    assert active_user.id not in result_ids
+
+
+async def test_exists_in_tenant_true(db_session):
+    repo = UserRepository(db_session)
+
+    tenant = _make_tenant()
+    db_session.add(tenant)
+    await db_session.flush()
+    role = _make_role(tenant_id=tenant.id)
+    db_session.add(role)
+    await db_session.flush()
+
+    user = _make_user()
+    await repo.create(user)
+    db_session.add(UserTenantRole(user_id=user.id, tenant_id=tenant.id, role_id=role.id))
+    await db_session.flush()
+
+    assert await repo.exists_in_tenant(user.id, tenant.id) is True
+
+
+async def test_exists_in_tenant_false(db_session):
+    repo = UserRepository(db_session)
+    user = _make_user()
+    await repo.create(user)
+    assert await repo.exists_in_tenant(user.id, uuid.uuid4()) is False
+
+
+async def test_deactivate_flow(db_session):
+    """Simulate deactivation: create user, update status to inactive, verify."""
+    repo = UserRepository(db_session)
+    user = _make_user(status=UserStatus.active)
+    await repo.create(user)
+
+    user.status = UserStatus.inactive
+    await repo.update(user)
+
+    fetched = await repo.get(user.id)
+    assert fetched is not None
+    assert fetched.status == UserStatus.inactive

--- a/backend/tests/unit/test_cache_invalidation.py
+++ b/backend/tests/unit/test_cache_invalidation.py
@@ -1,0 +1,145 @@
+"""Unit tests for CacheInvalidationPublisher (Story 3.3).
+
+Tests cover:
+- publish: publishes JSON event to identity:changes channel (AC-3.3.1)
+- publish: no-op when redis client is None
+- publish: swallows Redis exceptions, logs error (AC-3.3.2)
+- publish_batch: publishes batch event with stats
+- publish_batch: swallows exceptions like publish
+- Singleton lifecycle: init, get, shutdown
+- Event schema correctness (AC-3.3.3)
+"""
+
+import json
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.cache_invalidation import (
+    CHANNEL,
+    CacheInvalidationPublisher,
+    get_cache_publisher,
+    init_cache_publisher,
+    shutdown_cache_publisher,
+)
+
+
+@pytest.mark.anyio
+class TestPublish:
+    """AC-3.3.1: publish sends correct event to identity:changes channel."""
+
+    async def test_publish_sends_event_to_channel(self):
+        redis = AsyncMock()
+        redis.publish.return_value = 1
+        pub = CacheInvalidationPublisher(redis_client=redis)
+        entity_id = uuid.uuid4()
+        tenant_id = uuid.uuid4()
+
+        await pub.publish(
+            entity_type="user",
+            entity_id=entity_id,
+            operation="create",
+            tenant_id=tenant_id,
+        )
+
+        redis.publish.assert_awaited_once()
+        call_args = redis.publish.call_args
+        assert call_args[0][0] == CHANNEL
+        event = json.loads(call_args[0][1])
+        assert event["entity_type"] == "user"
+        assert event["entity_id"] == str(entity_id)
+        assert event["operation"] == "create"
+        assert event["tenant_id"] == str(tenant_id)
+        assert "timestamp" in event
+
+    async def test_publish_noop_when_no_redis_client(self):
+        """No-op publisher does not raise or attempt to publish."""
+        pub = CacheInvalidationPublisher(redis_client=None)
+        # Should complete silently — no exception
+        await pub.publish(entity_type="user", entity_id=uuid.uuid4(), operation="create")
+
+    async def test_publish_swallows_redis_exception(self):
+        """AC-3.3.2: Redis failure logged as error, never raised."""
+        redis = AsyncMock()
+        redis.publish.side_effect = ConnectionError("Redis gone")
+        pub = CacheInvalidationPublisher(redis_client=redis)
+
+        with patch("app.services.cache_invalidation.logger") as mock_logger:
+            await pub.publish(entity_type="user", entity_id=uuid.uuid4(), operation="update")
+
+        mock_logger.error.assert_called_once()
+        assert "Redis publish failed" in mock_logger.error.call_args[0][0]
+
+    async def test_publish_null_tenant_id(self):
+        """Global entities (roles, permissions) have tenant_id=null."""
+        redis = AsyncMock()
+        redis.publish.return_value = 1
+        pub = CacheInvalidationPublisher(redis_client=redis)
+
+        await pub.publish(entity_type="permission", entity_id=uuid.uuid4(), operation="create")
+
+        event = json.loads(redis.publish.call_args[0][1])
+        assert event["tenant_id"] is None
+
+
+@pytest.mark.anyio
+class TestPublishBatch:
+    """publish_batch sends a single batch event for reconciliation."""
+
+    async def test_publish_batch_sends_event(self):
+        redis = AsyncMock()
+        redis.publish.return_value = 1
+        pub = CacheInvalidationPublisher(redis_client=redis)
+        stats = {"users_created": 3, "roles_updated": 1}
+
+        await pub.publish_batch(operation="reconcile", stats=stats)
+
+        redis.publish.assert_awaited_once()
+        event = json.loads(redis.publish.call_args[0][1])
+        assert event["entity_type"] == "batch"
+        assert event["entity_id"] == "reconciliation"
+        assert event["operation"] == "reconcile"
+        assert event["stats"] == stats
+        assert event["tenant_id"] is None
+
+    async def test_publish_batch_noop_when_no_redis(self):
+        pub = CacheInvalidationPublisher(redis_client=None)
+        await pub.publish_batch(operation="reconcile", stats={"users_created": 1})
+
+    async def test_publish_batch_swallows_exception(self):
+        redis = AsyncMock()
+        redis.publish.side_effect = ConnectionError("Redis gone")
+        pub = CacheInvalidationPublisher(redis_client=redis)
+
+        with patch("app.services.cache_invalidation.logger") as mock_logger:
+            await pub.publish_batch(operation="reconcile", stats={})
+
+        mock_logger.error.assert_called_once()
+
+
+class TestSingletonLifecycle:
+    """Module-level singleton functions: init, get, shutdown."""
+
+    def setup_method(self):
+        shutdown_cache_publisher()
+
+    def teardown_method(self):
+        shutdown_cache_publisher()
+
+    def test_get_returns_noop_before_init(self):
+        pub = get_cache_publisher()
+        assert pub._redis is None
+
+    def test_init_and_get_returns_same_instance(self):
+        redis = AsyncMock()
+        created = init_cache_publisher(redis_client=redis)
+        retrieved = get_cache_publisher()
+        assert retrieved is created
+        assert retrieved._redis is redis
+
+    def test_shutdown_clears_singleton(self):
+        init_cache_publisher(redis_client=AsyncMock())
+        shutdown_cache_publisher()
+        pub = get_cache_publisher()
+        assert pub._redis is None

--- a/backend/tests/unit/test_descope_adapter.py
+++ b/backend/tests/unit/test_descope_adapter.py
@@ -196,10 +196,45 @@ class TestDeleteOperations:
         result = await adapter.delete_tenant(tenant_id=uuid.uuid4())
         assert result == Ok(None)
 
-    async def test_sync_role_assignment(self, adapter):
+    async def test_sync_role_assignment(self, adapter, mock_client):
+        user_id = uuid.uuid4()
+        tenant_id = uuid.uuid4()
+        role_id = uuid.uuid4()
+
+        result = await adapter.sync_role_assignment(
+            user_id=user_id,
+            tenant_id=tenant_id,
+            role_id=role_id,
+            data={"role_name": "admin", "login_id": "user@example.com"},
+        )
+
+        assert result == Ok(None)
+        mock_client.assign_roles.assert_awaited_once_with("user@example.com", str(tenant_id), ["admin"])
+
+    async def test_sync_role_assignment_fallback_without_data(self, adapter, mock_client):
+        """Without data, falls back to str(role_id) and str(user_id)."""
+        user_id = uuid.uuid4()
+        tenant_id = uuid.uuid4()
+        role_id = uuid.uuid4()
+
+        result = await adapter.sync_role_assignment(
+            user_id=user_id,
+            tenant_id=tenant_id,
+            role_id=role_id,
+        )
+
+        assert result == Ok(None)
+        mock_client.assign_roles.assert_awaited_once_with(str(user_id), str(tenant_id), [str(role_id)])
+
+    async def test_sync_role_assignment_failure(self, adapter, mock_client):
+        mock_client.assign_roles.side_effect = RuntimeError("API error")
+
         result = await adapter.sync_role_assignment(
             user_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             role_id=uuid.uuid4(),
         )
-        assert result == Ok(None)
+
+        assert result.is_error()
+        assert result.error.operation == "sync_role_assignment"
+        assert "API error" in result.error.message

--- a/backend/tests/unit/test_identity_adapter.py
+++ b/backend/tests/unit/test_identity_adapter.py
@@ -41,6 +41,15 @@ class TestNoOpSyncAdapterMethods:
         )
         assert result == Ok(None)
 
+    async def test_delete_role_assignment(self):
+        adapter = NoOpSyncAdapter()
+        result = await adapter.delete_role_assignment(
+            user_id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            role_id=uuid.uuid4(),
+        )
+        assert result == Ok(None)
+
     async def test_delete_user(self):
         adapter = NoOpSyncAdapter()
         result = await adapter.delete_user(user_id=uuid.uuid4())
@@ -73,6 +82,7 @@ class TestNoOpSyncAdapterMethods:
             await adapter.sync_permission(permission_id=uid, data=data),
             await adapter.sync_tenant(tenant_id=uid, data=data),
             await adapter.sync_role_assignment(user_id=uid, tenant_id=uid, role_id=uid),
+            await adapter.delete_role_assignment(user_id=uid, tenant_id=uid, role_id=uid),
             await adapter.delete_user(user_id=uid),
             await adapter.delete_role(role_id=uid),
             await adapter.delete_permission(permission_id=uid),

--- a/backend/tests/unit/test_identity_dependency.py
+++ b/backend/tests/unit/test_identity_dependency.py
@@ -1,16 +1,37 @@
-"""Unit tests for identity dependency factory (AC-2.1.7).
+"""Unit tests for identity dependency factories (AC-2.1.7, AC-2.2.6).
 
 Verifies:
 - get_user_service() returns a UserService with correctly wired repository and adapter.
+- get_role_service() returns a RoleService with 3 repositories and adapter.
+- get_permission_service() returns a PermissionService with repository and adapter.
+- get_tenant_service() returns a TenantService with repository and adapter.
 """
 
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.dependencies.identity import get_user_service
+from app.dependencies.identity import (
+    get_idp_link_service,
+    get_permission_service,
+    get_provider_service,
+    get_role_service,
+    get_tenant_service,
+    get_user_service,
+)
+from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.permission import PermissionRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.role import RoleRepository
+from app.repositories.tenant import TenantRepository
 from app.repositories.user import UserRepository
 from app.services.adapters.descope import DescopeSyncAdapter
+from app.services.idp_link import IdPLinkService
+from app.services.permission import PermissionService
+from app.services.provider import ProviderService
+from app.services.role import RoleService
+from app.services.tenant import TenantService
 from app.services.user import UserService
 
 
@@ -50,3 +71,128 @@ class TestGetUserService:
         service = await get_user_service(session=mock_session)
 
         assert service._adapter._client is mock_client
+
+
+@pytest.mark.anyio
+class TestGetRoleService:
+    """AC-2.2.6: get_role_service() wires 3 repositories + adapter → RoleService."""
+
+    @patch("app.dependencies.identity.get_descope_client")
+    async def test_returns_role_service(self, mock_get_client):
+        mock_session = AsyncMock()
+        mock_get_client.return_value = AsyncMock()
+
+        service = await get_role_service(session=mock_session)
+
+        assert isinstance(service, RoleService)
+        assert isinstance(service._repository, RoleRepository)
+        assert isinstance(service._permission_repository, PermissionRepository)
+        assert isinstance(service._assignment_repository, UserTenantRoleRepository)
+        assert isinstance(service._adapter, DescopeSyncAdapter)
+
+    @patch("app.dependencies.identity.get_descope_client")
+    async def test_all_repositories_share_session(self, mock_get_client):
+        """All repositories must receive the same session for transactional consistency."""
+        mock_session = AsyncMock()
+        mock_get_client.return_value = AsyncMock()
+
+        service = await get_role_service(session=mock_session)
+
+        assert service._repository._session is mock_session
+        assert service._permission_repository._session is mock_session
+        assert service._assignment_repository._session is mock_session
+
+
+@pytest.mark.anyio
+class TestGetPermissionService:
+    """AC-2.2.6: get_permission_service() wires PermissionRepository + adapter."""
+
+    @patch("app.dependencies.identity.get_descope_client")
+    async def test_returns_permission_service(self, mock_get_client):
+        mock_session = AsyncMock()
+        mock_get_client.return_value = AsyncMock()
+
+        service = await get_permission_service(session=mock_session)
+
+        assert isinstance(service, PermissionService)
+        assert isinstance(service._repository, PermissionRepository)
+        assert isinstance(service._adapter, DescopeSyncAdapter)
+
+    @patch("app.dependencies.identity.get_descope_client")
+    async def test_repository_receives_session(self, mock_get_client):
+        mock_session = AsyncMock()
+        mock_get_client.return_value = AsyncMock()
+
+        service = await get_permission_service(session=mock_session)
+
+        assert service._repository._session is mock_session
+
+
+@pytest.mark.anyio
+class TestGetTenantService:
+    """AC-2.2.6: get_tenant_service() wires TenantRepository + adapter."""
+
+    @patch("app.dependencies.identity.get_descope_client")
+    async def test_returns_tenant_service(self, mock_get_client):
+        mock_session = AsyncMock()
+        mock_get_client.return_value = AsyncMock()
+
+        service = await get_tenant_service(session=mock_session)
+
+        assert isinstance(service, TenantService)
+        assert isinstance(service._repository, TenantRepository)
+        assert isinstance(service._adapter, DescopeSyncAdapter)
+
+    @patch("app.dependencies.identity.get_descope_client")
+    async def test_repository_receives_session(self, mock_get_client):
+        mock_session = AsyncMock()
+        mock_get_client.return_value = AsyncMock()
+
+        service = await get_tenant_service(session=mock_session)
+
+        assert service._repository._session is mock_session
+
+
+@pytest.mark.anyio
+class TestGetIdPLinkService:
+    """AC-4.1.3: get_idp_link_service() wires 3 repositories → IdPLinkService."""
+
+    async def test_returns_idp_link_service(self):
+        mock_session = AsyncMock()
+
+        service = await get_idp_link_service(session=mock_session)
+
+        assert isinstance(service, IdPLinkService)
+        assert isinstance(service._repository, IdPLinkRepository)
+        assert isinstance(service._user_repository, UserRepository)
+        assert isinstance(service._provider_repository, ProviderRepository)
+
+    async def test_all_repositories_share_session(self):
+        """All repositories must receive the same session for transactional consistency."""
+        mock_session = AsyncMock()
+
+        service = await get_idp_link_service(session=mock_session)
+
+        assert service._repository._session is mock_session
+        assert service._user_repository._session is mock_session
+        assert service._provider_repository._session is mock_session
+
+
+@pytest.mark.anyio
+class TestGetProviderService:
+    """AC-4.1.3: get_provider_service() wires ProviderRepository → ProviderService."""
+
+    async def test_returns_provider_service(self):
+        mock_session = AsyncMock()
+
+        service = await get_provider_service(session=mock_session)
+
+        assert isinstance(service, ProviderService)
+        assert isinstance(service._repository, ProviderRepository)
+
+    async def test_repository_receives_session(self):
+        mock_session = AsyncMock()
+
+        service = await get_provider_service(session=mock_session)
+
+        assert service._repository._session is mock_session

--- a/backend/tests/unit/test_identity_resolution_service.py
+++ b/backend/tests/unit/test_identity_resolution_service.py
@@ -1,0 +1,588 @@
+"""Unit tests for IdentityResolutionService (Story 4.3).
+
+Tests cover:
+- AC-4.3.1: resolve() happy path — provider lookup, IdP link, user, build payload
+- AC-4.3.2: Redis cache hit returns cached data; cache miss writes back
+- AC-4.3.2: Redis unavailable → graceful degradation (skip cache, query Postgres)
+- AC-4.3.3: Cache invalidation subscriber — user-scoped + broad invalidation
+- Edge cases: provider not found, link not found, user not found
+"""
+
+import asyncio
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.errors.identity import NotFound
+from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.role import RoleRepository
+from app.repositories.tenant import TenantRepository
+from app.repositories.user import UserRepository
+from app.services.identity_resolution import (
+    IDENTITY_CACHE_TTL,
+    IdentityResolutionService,
+    _handle_invalidation_event,
+    run_cache_invalidation_subscriber,
+)
+
+
+def _make_redis_mock():
+    """Create a properly structured Redis mock.
+
+    redis.asyncio.Redis.pipeline() and .pubsub() are synchronous methods
+    that return pipeline/pubsub objects. pipeline methods (setex, sadd, etc.)
+    are synchronous queue-adds; only execute() is async.
+    """
+    redis = AsyncMock()
+
+    # pipeline() is sync, returns a MagicMock with sync queue methods + async execute
+    pipe = MagicMock()
+    pipe.execute = AsyncMock()
+    redis.pipeline = MagicMock(return_value=pipe)
+
+    return redis, pipe
+
+
+def _make_pubsub_mock():
+    """Create a properly structured pubsub mock.
+
+    redis.pubsub() is synchronous. Subscribe/unsubscribe/listen/aclose are async.
+    """
+    pubsub = MagicMock()
+    pubsub.subscribe = AsyncMock()
+    pubsub.unsubscribe = AsyncMock()
+    pubsub.aclose = AsyncMock()
+    return pubsub
+
+
+# --- Helpers ---
+
+
+def _make_user(**overrides):
+    """Create a mock user entity."""
+    user = MagicMock()
+    user.id = overrides.get("id", uuid.uuid4())
+    user.email = overrides.get("email", "alice@example.com")
+    user.user_name = overrides.get("user_name", "alice")
+    user.given_name = overrides.get("given_name", "Alice")
+    user.family_name = overrides.get("family_name", "Smith")
+    user.status = MagicMock()
+    user.status.value = overrides.get("status", "active")
+    return user
+
+
+def _make_provider(**overrides):
+    provider = MagicMock()
+    provider.id = overrides.get("id", uuid.uuid4())
+    provider.name = overrides.get("name", "descope")
+    return provider
+
+
+def _make_link(**overrides):
+    link = MagicMock()
+    link.id = overrides.get("id", uuid.uuid4())
+    link.user_id = overrides.get("user_id", uuid.uuid4())
+    link.provider_id = overrides.get("provider_id", uuid.uuid4())
+    link.external_sub = overrides.get("external_sub", "ext-sub-123")
+    return link
+
+
+def _make_assignment(**overrides):
+    assignment = MagicMock()
+    assignment.tenant_id = overrides.get("tenant_id", uuid.uuid4())
+    assignment.role_id = overrides.get("role_id", uuid.uuid4())
+    return assignment
+
+
+def _make_role(**overrides):
+    role = MagicMock()
+    role.id = overrides.get("id", uuid.uuid4())
+    role.name = overrides.get("name", "admin")
+    return role
+
+
+def _make_permission(**overrides):
+    perm = MagicMock()
+    perm.name = overrides.get("name", "read:users")
+    return perm
+
+
+def _make_tenant(**overrides):
+    tenant = MagicMock()
+    tenant.id = overrides.get("id", uuid.uuid4())
+    tenant.name = overrides.get("name", "Acme Corp")
+    return tenant
+
+
+def _build_service(*, redis_client=None):
+    """Build an IdentityResolutionService with all mocked repositories."""
+    user_repo = AsyncMock(spec=UserRepository)
+    idp_link_repo = AsyncMock(spec=IdPLinkRepository)
+    provider_repo = AsyncMock(spec=ProviderRepository)
+    assignment_repo = AsyncMock(spec=UserTenantRoleRepository)
+    role_repo = AsyncMock(spec=RoleRepository)
+    tenant_repo = AsyncMock(spec=TenantRepository)
+
+    service = IdentityResolutionService(
+        user_repository=user_repo,
+        idp_link_repository=idp_link_repo,
+        provider_repository=provider_repo,
+        assignment_repository=assignment_repo,
+        role_repository=role_repo,
+        tenant_repository=tenant_repo,
+        redis_client=redis_client,
+    )
+    return service, user_repo, idp_link_repo, provider_repo, assignment_repo, role_repo, tenant_repo
+
+
+# --- AC-4.3.1: resolve() ---
+
+
+@pytest.mark.anyio
+class TestResolveHappyPath:
+    """AC-4.3.1: resolve() builds canonical identity payload."""
+
+    async def test_resolve_returns_full_payload(self):
+        """Resolve builds user + roles + tenant memberships + linked IdPs."""
+        service, user_repo, idp_link_repo, provider_repo, assignment_repo, role_repo, tenant_repo = _build_service()
+
+        user_id = uuid.uuid4()
+        provider_id = uuid.uuid4()
+        tenant_id = uuid.uuid4()
+        role_id = uuid.uuid4()
+        user = _make_user(id=user_id)
+        provider = _make_provider(id=provider_id, name="descope")
+        link = _make_link(user_id=user_id, provider_id=provider_id, external_sub="ext-123")
+        assignment = _make_assignment(tenant_id=tenant_id, role_id=role_id)
+        role = _make_role(id=role_id, name="admin")
+        perm = _make_permission(name="read:users")
+        tenant = _make_tenant(id=tenant_id, name="Acme")
+
+        provider_repo.get_by_name.return_value = provider
+        idp_link_repo.get_by_provider_name_and_sub.return_value = link
+        user_repo.get.return_value = user
+        assignment_repo.list_by_user.return_value = [assignment]
+        role_repo.get.return_value = role
+        role_repo.get_permissions.return_value = [perm]
+        tenant_repo.get.return_value = tenant
+        idp_link_repo.get_by_user.return_value = [link]
+        provider_repo.get.return_value = provider
+
+        result = await service.resolve(provider="descope", sub="ext-123")
+
+        assert result.is_ok()
+        payload = result.ok
+        assert payload["user"]["id"] == str(user_id)
+        assert payload["user"]["email"] == "alice@example.com"
+        assert len(payload["roles"]) == 1
+        assert payload["roles"][0]["role_name"] == "admin"
+        assert payload["roles"][0]["permissions"] == ["read:users"]
+        assert payload["roles"][0]["tenant_id"] == str(tenant_id)
+        assert len(payload["tenant_memberships"]) == 1
+        assert payload["tenant_memberships"][0]["tenant_name"] == "Acme"
+        assert len(payload["linked_idps"]) == 1
+        assert payload["linked_idps"][0]["provider_name"] == "descope"
+
+    async def test_resolve_user_with_no_roles(self):
+        """User with no role assignments returns empty roles and memberships."""
+        service, user_repo, idp_link_repo, provider_repo, assignment_repo, role_repo, tenant_repo = _build_service()
+
+        user_id = uuid.uuid4()
+        user = _make_user(id=user_id)
+        provider = _make_provider()
+        link = _make_link(user_id=user_id)
+
+        provider_repo.get_by_name.return_value = provider
+        idp_link_repo.get_by_provider_name_and_sub.return_value = link
+        user_repo.get.return_value = user
+        assignment_repo.list_by_user.return_value = []
+        idp_link_repo.get_by_user.return_value = [link]
+        provider_repo.get.return_value = provider
+
+        result = await service.resolve(provider="descope", sub="ext-sub-123")
+
+        assert result.is_ok()
+        assert result.ok["roles"] == []
+        assert result.ok["tenant_memberships"] == []
+
+    async def test_resolve_user_with_multiple_tenants(self):
+        """User assigned to multiple tenants returns all memberships."""
+        service, user_repo, idp_link_repo, provider_repo, assignment_repo, role_repo, tenant_repo = _build_service()
+
+        user_id = uuid.uuid4()
+        tenant_a = uuid.uuid4()
+        tenant_b = uuid.uuid4()
+        role_a = uuid.uuid4()
+        role_b = uuid.uuid4()
+
+        provider_repo.get_by_name.return_value = _make_provider()
+        idp_link_repo.get_by_provider_name_and_sub.return_value = _make_link(user_id=user_id)
+        user_repo.get.return_value = _make_user(id=user_id)
+        assignment_repo.list_by_user.return_value = [
+            _make_assignment(tenant_id=tenant_a, role_id=role_a),
+            _make_assignment(tenant_id=tenant_b, role_id=role_b),
+        ]
+        role_repo.get.side_effect = [
+            _make_role(id=role_a, name="viewer"),
+            _make_role(id=role_b, name="editor"),
+        ]
+        role_repo.get_permissions.side_effect = [[], [_make_permission(name="write:docs")]]
+        tenant_repo.get.side_effect = [
+            _make_tenant(id=tenant_a, name="Acme"),
+            _make_tenant(id=tenant_b, name="Beta"),
+        ]
+        idp_link_repo.get_by_user.return_value = []
+
+        result = await service.resolve(provider="descope", sub="ext-123")
+
+        assert result.is_ok()
+        assert len(result.ok["roles"]) == 2
+        assert len(result.ok["tenant_memberships"]) == 2
+        names = {m["tenant_name"] for m in result.ok["tenant_memberships"]}
+        assert names == {"Acme", "Beta"}
+
+
+@pytest.mark.anyio
+class TestResolveErrors:
+    """AC-4.3.1: resolve() returns NotFound for missing entities."""
+
+    async def test_provider_not_found(self):
+        service, *_ = _build_service()
+        service._provider_repository.get_by_name.return_value = None
+
+        result = await service.resolve(provider="unknown", sub="ext-123")
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        assert "Provider" in result.error.message
+
+    async def test_idp_link_not_found(self):
+        service, *_ = _build_service()
+        service._provider_repository.get_by_name.return_value = _make_provider()
+        service._idp_link_repository.get_by_provider_name_and_sub.return_value = None
+
+        result = await service.resolve(provider="descope", sub="unknown-sub")
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        assert "No identity found" in result.error.message
+
+    async def test_linked_user_not_found(self):
+        """FK integrity violation — user deleted but link remains."""
+        service, *_ = _build_service()
+        service._provider_repository.get_by_name.return_value = _make_provider()
+        service._idp_link_repository.get_by_provider_name_and_sub.return_value = _make_link()
+        service._user_repository.get.return_value = None
+
+        result = await service.resolve(provider="descope", sub="ext-123")
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        assert "Linked user" in result.error.message
+
+
+# --- AC-4.3.2: Redis cache ---
+
+
+@pytest.mark.anyio
+class TestRedisCache:
+    """AC-4.3.2: Redis cache read/write with configurable TTL."""
+
+    async def test_cache_hit_returns_cached_data(self):
+        """Cache hit returns deserialized JSON without querying Postgres."""
+        redis = AsyncMock()
+        cached_payload = {"user": {"id": "123"}, "roles": [], "tenant_memberships": [], "linked_idps": []}
+        redis.get.return_value = json.dumps(cached_payload)
+
+        service, user_repo, idp_link_repo, *_ = _build_service(redis_client=redis)
+
+        result = await service.resolve(provider="descope", sub="ext-123")
+
+        assert result.is_ok()
+        assert result.ok == cached_payload
+        # Cache key uses URL-encoding for dynamic parts
+        expected_key = IdentityResolutionService._cache_key("descope", "ext-123")
+        redis.get.assert_awaited_once_with(expected_key)
+        # Should NOT have queried Postgres
+        idp_link_repo.get_by_provider_name_and_sub.assert_not_awaited()
+
+    async def test_cache_miss_writes_result_to_redis(self):
+        """Cache miss queries Postgres and writes result to Redis."""
+        redis, pipe = _make_redis_mock()
+        redis.get.return_value = None
+
+        service, user_repo, idp_link_repo, provider_repo, assignment_repo, role_repo, tenant_repo = _build_service(
+            redis_client=redis
+        )
+
+        user_id = uuid.uuid4()
+        user = _make_user(id=user_id)
+        provider_repo.get_by_name.return_value = _make_provider()
+        idp_link_repo.get_by_provider_name_and_sub.return_value = _make_link(user_id=user_id)
+        user_repo.get.return_value = user
+        assignment_repo.list_by_user.return_value = []
+        idp_link_repo.get_by_user.return_value = []
+
+        result = await service.resolve(provider="descope", sub="ext-123")
+
+        assert result.is_ok()
+        # Should have created an atomic pipeline
+        redis.pipeline.assert_called_once_with(transaction=True)
+        # Should have written to Redis pipeline with correct TTL
+        expected_key = IdentityResolutionService._cache_key("descope", "ext-123")
+        pipe.setex.assert_called_once_with(expected_key, IDENTITY_CACHE_TTL, pipe.setex.call_args[0][2])
+        pipe.sadd.assert_called()
+        pipe.execute.assert_awaited_once()
+
+    async def test_cache_read_failure_degrades_gracefully(self):
+        """Redis read failure → skip cache, query Postgres directly."""
+        redis, pipe = _make_redis_mock()
+        redis.get.side_effect = ConnectionError("Redis gone")
+
+        service, user_repo, idp_link_repo, provider_repo, assignment_repo, *_ = _build_service(redis_client=redis)
+
+        user_id = uuid.uuid4()
+        provider_repo.get_by_name.return_value = _make_provider()
+        idp_link_repo.get_by_provider_name_and_sub.return_value = _make_link(user_id=user_id)
+        user_repo.get.return_value = _make_user(id=user_id)
+        assignment_repo.list_by_user.return_value = []
+        idp_link_repo.get_by_user.return_value = []
+
+        result = await service.resolve(provider="descope", sub="ext-123")
+
+        assert result.is_ok()
+        # Still queried Postgres after cache failure
+        idp_link_repo.get_by_provider_name_and_sub.assert_awaited_once()
+
+    async def test_cache_write_failure_still_returns_ok(self):
+        """Redis write failure doesn't affect the response."""
+        redis, pipe = _make_redis_mock()
+        redis.get.return_value = None
+        pipe.execute.side_effect = ConnectionError("Redis gone")
+
+        service, user_repo, idp_link_repo, provider_repo, assignment_repo, *_ = _build_service(redis_client=redis)
+
+        user_id = uuid.uuid4()
+        provider_repo.get_by_name.return_value = _make_provider()
+        idp_link_repo.get_by_provider_name_and_sub.return_value = _make_link(user_id=user_id)
+        user_repo.get.return_value = _make_user(id=user_id)
+        assignment_repo.list_by_user.return_value = []
+        idp_link_repo.get_by_user.return_value = []
+
+        result = await service.resolve(provider="descope", sub="ext-123")
+
+        assert result.is_ok()
+
+    async def test_no_redis_client_skips_cache(self):
+        """Service without Redis client goes directly to Postgres."""
+        service, user_repo, idp_link_repo, provider_repo, assignment_repo, *_ = _build_service(redis_client=None)
+
+        user_id = uuid.uuid4()
+        provider_repo.get_by_name.return_value = _make_provider()
+        idp_link_repo.get_by_provider_name_and_sub.return_value = _make_link(user_id=user_id)
+        user_repo.get.return_value = _make_user(id=user_id)
+        assignment_repo.list_by_user.return_value = []
+        idp_link_repo.get_by_user.return_value = []
+
+        result = await service.resolve(provider="descope", sub="ext-123")
+
+        assert result.is_ok()
+        idp_link_repo.get_by_provider_name_and_sub.assert_awaited_once()
+
+    async def test_cache_key_escapes_colons(self):
+        """Cache key URL-encodes dynamic parts to prevent key collision."""
+        # Two different (provider, sub) pairs that would collide without encoding
+        key1 = IdentityResolutionService._cache_key("a:b", "c")
+        key2 = IdentityResolutionService._cache_key("a", "b:c")
+        assert key1 != key2
+        # Colons in dynamic parts are encoded
+        assert "%3A" in key1
+        assert "%3A" in key2
+
+
+# --- AC-4.3.3: Cache invalidation subscriber ---
+
+
+@pytest.mark.anyio
+class TestHandleInvalidationEvent:
+    """AC-4.3.3: _handle_invalidation_event invalidates cache entries."""
+
+    async def test_user_event_deletes_user_cache_keys(self):
+        """User change event deletes all cache entries for that user via reverse index."""
+        redis, pipe = _make_redis_mock()
+        user_id = str(uuid.uuid4())
+        cache_keys = {b"identity:descope:ext-123", b"identity:google:goog-456"}
+        redis.smembers.return_value = cache_keys
+
+        await _handle_invalidation_event(redis, {"entity_type": "user", "entity_id": user_id})
+
+        redis.smembers.assert_awaited_once_with(f"identity:user:{user_id}")
+        # Should use atomic pipeline
+        redis.pipeline.assert_called_once_with(transaction=True)
+        # Should delete each cache key + remove from master set + delete reverse key
+        assert pipe.delete.call_count >= 3  # 2 cache keys + 1 reverse key
+        pipe.execute.assert_awaited_once()
+
+    async def test_user_event_rejects_invalid_entity_id(self):
+        """User event with non-UUID entity_id is rejected."""
+        redis, pipe = _make_redis_mock()
+
+        await _handle_invalidation_event(redis, {"entity_type": "user", "entity_id": "not-a-uuid"})
+
+        redis.smembers.assert_not_awaited()
+        redis.pipeline.assert_not_called()
+
+    async def test_user_event_no_cache_keys_is_noop(self):
+        """User change event with no cached entries does nothing."""
+        redis, pipe = _make_redis_mock()
+        redis.smembers.return_value = set()
+
+        await _handle_invalidation_event(redis, {"entity_type": "user", "entity_id": str(uuid.uuid4())})
+
+        redis.pipeline.assert_not_called()
+
+    async def test_role_event_triggers_broad_invalidation(self):
+        """Role change event deletes all identity cache keys + reverse indexes."""
+        redis, pipe = _make_redis_mock()
+        all_keys = {b"identity:descope:ext-1", b"identity:google:goog-2"}
+        redis.smembers.return_value = all_keys
+        # Mock scan to return reverse-index keys
+        redis.scan.return_value = (0, [b"identity:user:abc-123"])
+
+        await _handle_invalidation_event(redis, {"entity_type": "role", "entity_id": str(uuid.uuid4())})
+
+        redis.smembers.assert_awaited_once_with("identity:all-keys")
+        redis.pipeline.assert_called_once_with(transaction=True)
+        # Should delete cache keys + reverse-index keys + master set
+        # 2 cache keys + 1 reverse key + 1 master set = 4 deletes
+        assert pipe.delete.call_count >= 4
+        pipe.execute.assert_awaited_once()
+
+    async def test_permission_event_triggers_broad_invalidation(self):
+        redis, pipe = _make_redis_mock()
+        redis.smembers.return_value = {b"identity:descope:ext-1"}
+        redis.scan.return_value = (0, [])
+
+        await _handle_invalidation_event(redis, {"entity_type": "permission", "entity_id": str(uuid.uuid4())})
+
+        redis.smembers.assert_awaited_once_with("identity:all-keys")
+
+    async def test_tenant_event_triggers_broad_invalidation(self):
+        redis, pipe = _make_redis_mock()
+        redis.smembers.return_value = {b"identity:descope:ext-1"}
+        redis.scan.return_value = (0, [])
+
+        await _handle_invalidation_event(redis, {"entity_type": "tenant", "entity_id": str(uuid.uuid4())})
+
+        redis.smembers.assert_awaited_once_with("identity:all-keys")
+
+    async def test_batch_event_triggers_broad_invalidation(self):
+        redis, pipe = _make_redis_mock()
+        redis.smembers.return_value = {b"identity:descope:ext-1"}
+        redis.scan.return_value = (0, [])
+
+        await _handle_invalidation_event(redis, {"entity_type": "batch", "entity_id": "reconciliation"})
+
+        redis.smembers.assert_awaited_once_with("identity:all-keys")
+
+    async def test_broad_invalidation_no_keys_is_noop(self):
+        """Broad invalidation with empty master set does nothing."""
+        redis, pipe = _make_redis_mock()
+        redis.smembers.return_value = set()
+
+        await _handle_invalidation_event(redis, {"entity_type": "role", "entity_id": str(uuid.uuid4())})
+
+        redis.pipeline.assert_not_called()
+
+    async def test_unknown_entity_type_is_noop(self):
+        """Unknown entity_type is silently ignored."""
+        redis, pipe = _make_redis_mock()
+
+        await _handle_invalidation_event(redis, {"entity_type": "unknown", "entity_id": "x"})
+
+        redis.smembers.assert_not_awaited()
+        redis.pipeline.assert_not_called()
+
+
+@pytest.mark.anyio
+class TestRunCacheInvalidationSubscriber:
+    """AC-4.3.3: Background subscriber lifecycle."""
+
+    async def test_subscriber_handles_cancellation_gracefully(self):
+        """Subscriber shuts down cleanly on task cancellation (no exception propagated)."""
+        redis, _ = _make_redis_mock()
+        pubsub = _make_pubsub_mock()
+        redis.pubsub = MagicMock(return_value=pubsub)
+
+        # Simulate listen() that blocks then gets cancelled
+        async def blocking_listen():
+            await asyncio.sleep(100)
+            yield  # pragma: no cover
+
+        pubsub.listen = MagicMock(return_value=blocking_listen())
+
+        task = asyncio.create_task(run_cache_invalidation_subscriber(redis))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        # Function catches CancelledError gracefully — should complete without error
+        await task
+
+        pubsub.subscribe.assert_awaited_once_with("identity:changes")
+        pubsub.unsubscribe.assert_awaited_with("identity:changes")
+
+    async def test_subscriber_processes_valid_message(self):
+        """Subscriber processes a valid identity:changes message."""
+        redis, _ = _make_redis_mock()
+        pubsub = _make_pubsub_mock()
+        redis.pubsub = MagicMock(return_value=pubsub)
+        # Return empty set for smembers (no cache keys to invalidate)
+        redis.smembers.return_value = set()
+
+        messages = [
+            {"type": "subscribe", "data": None},  # subscription confirmation
+            {"type": "message", "data": json.dumps({"entity_type": "user", "entity_id": str(uuid.uuid4())})},
+        ]
+
+        async def listen_messages():
+            for msg in messages:
+                yield msg
+            # Simulate end of stream via cancellation (caught gracefully by subscriber)
+            raise asyncio.CancelledError
+
+        pubsub.listen = MagicMock(return_value=listen_messages())
+
+        # Function catches CancelledError — completes normally
+        await run_cache_invalidation_subscriber(redis)
+
+        # Should have processed the user event (skip subscribe confirmation)
+        redis.smembers.assert_awaited_once()
+
+    async def test_subscriber_swallows_handler_exception(self):
+        """Bad message data doesn't crash the subscriber loop."""
+        redis, _ = _make_redis_mock()
+        pubsub = _make_pubsub_mock()
+        redis.pubsub = MagicMock(return_value=pubsub)
+
+        messages = [
+            {"type": "message", "data": "not-valid-json"},
+            {"type": "message", "data": json.dumps({"entity_type": "user", "entity_id": str(uuid.uuid4())})},
+        ]
+
+        async def listen_messages():
+            for msg in messages:
+                yield msg
+            raise asyncio.CancelledError
+
+        pubsub.listen = MagicMock(return_value=listen_messages())
+        redis.smembers.return_value = set()
+
+        # Function catches CancelledError — completes normally
+        await run_cache_invalidation_subscriber(redis)
+
+        # Should still have attempted to process the second message
+        # (smembers called for the valid user event)
+        redis.smembers.assert_awaited_once()

--- a/backend/tests/unit/test_idp_link_service.py
+++ b/backend/tests/unit/test_idp_link_service.py
@@ -1,0 +1,228 @@
+"""Unit tests for IdPLinkService domain orchestration (Story 4.1).
+
+Tests cover:
+- create_idp_link: validates user+provider exist, unique constraint → Conflict
+- get_user_idp_links: delegates to repository
+- delete_idp_link: found → deleted; not found → NotFound
+"""
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.errors.identity import Conflict, NotFound
+from app.models.identity.user import IdPLink
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.user import RepositoryConflictError, UserRepository
+from app.services.idp_link import IdPLinkService
+
+
+def _make_idp_link(**overrides) -> IdPLink:
+    """Create an IdPLink with sensible defaults."""
+    defaults = {
+        "id": uuid.uuid4(),
+        "user_id": uuid.uuid4(),
+        "provider_id": uuid.uuid4(),
+        "external_sub": "ext-sub-123",
+        "external_email": "ext@example.com",
+        "metadata_": None,
+    }
+    defaults.update(overrides)
+    return IdPLink(**defaults)
+
+
+def _build_service(
+    repo: AsyncMock | None = None,
+    user_repo: AsyncMock | None = None,
+    provider_repo: AsyncMock | None = None,
+) -> tuple[IdPLinkService, AsyncMock, AsyncMock, AsyncMock]:
+    """Build an IdPLinkService with mocked repositories."""
+    if repo is None:
+        repo = AsyncMock(spec=IdPLinkRepository)
+    if user_repo is None:
+        user_repo = AsyncMock(spec=UserRepository)
+    if provider_repo is None:
+        provider_repo = AsyncMock(spec=ProviderRepository)
+    service = IdPLinkService(
+        repository=repo,
+        user_repository=user_repo,
+        provider_repository=provider_repo,
+    )
+    return service, repo, user_repo, provider_repo
+
+
+@pytest.mark.anyio
+class TestCreateIdPLink:
+    """AC-4.1.1: create_idp_link validates user+provider, enforces unique constraints."""
+
+    async def test_create_success(self):
+        service, repo, user_repo, provider_repo = _build_service()
+        user_id = uuid.uuid4()
+        provider_id = uuid.uuid4()
+        link = _make_idp_link(user_id=user_id, provider_id=provider_id)
+
+        user_repo.get.return_value = AsyncMock()  # user exists
+        provider_repo.get.return_value = AsyncMock()  # provider exists
+        repo.create.return_value = link
+
+        result = await service.create_idp_link(
+            user_id=user_id,
+            provider_id=provider_id,
+            external_sub="ext-sub-123",
+            external_email="ext@example.com",
+        )
+
+        assert result.is_ok()
+        user_repo.get.assert_awaited_once_with(user_id)
+        provider_repo.get.assert_awaited_once_with(provider_id)
+        repo.create.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+
+    async def test_create_user_not_found(self):
+        service, repo, user_repo, provider_repo = _build_service()
+        user_repo.get.return_value = None
+
+        result = await service.create_idp_link(
+            user_id=uuid.uuid4(),
+            provider_id=uuid.uuid4(),
+            external_sub="ext-sub",
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        assert "User" in result.error.message
+        repo.create.assert_not_awaited()
+
+    async def test_create_provider_not_found(self):
+        service, repo, user_repo, provider_repo = _build_service()
+        user_repo.get.return_value = AsyncMock()
+        provider_repo.get.return_value = None
+
+        result = await service.create_idp_link(
+            user_id=uuid.uuid4(),
+            provider_id=uuid.uuid4(),
+            external_sub="ext-sub",
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        assert "Provider" in result.error.message
+        repo.create.assert_not_awaited()
+
+    async def test_create_duplicate_returns_conflict(self):
+        """Unique constraint violation (user+provider or provider+sub) → Conflict."""
+        service, repo, user_repo, provider_repo = _build_service()
+        user_repo.get.return_value = AsyncMock()
+        provider_repo.get.return_value = AsyncMock()
+        repo.create.side_effect = RepositoryConflictError("duplicate key")
+
+        result = await service.create_idp_link(
+            user_id=uuid.uuid4(),
+            provider_id=uuid.uuid4(),
+            external_sub="ext-sub",
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        repo.commit.assert_not_awaited()
+
+    async def test_create_with_metadata(self):
+        service, repo, user_repo, provider_repo = _build_service()
+        user_id = uuid.uuid4()
+        provider_id = uuid.uuid4()
+        metadata = {"source": "migration", "version": 2}
+        link = _make_idp_link(user_id=user_id, provider_id=provider_id, metadata_=metadata)
+
+        user_repo.get.return_value = AsyncMock()
+        provider_repo.get.return_value = AsyncMock()
+        repo.create.return_value = link
+
+        result = await service.create_idp_link(
+            user_id=user_id,
+            provider_id=provider_id,
+            external_sub="ext-sub",
+            metadata=metadata,
+        )
+
+        assert result.is_ok()
+        assert result.ok["metadata_"] == metadata
+
+
+@pytest.mark.anyio
+class TestGetUserIdPLinks:
+    """AC-4.1.1: get_user_idp_links delegates to repository."""
+
+    async def test_get_returns_list(self):
+        service, repo, _user_repo, _provider_repo = _build_service()
+        user_id = uuid.uuid4()
+        links = [
+            _make_idp_link(user_id=user_id),
+            _make_idp_link(user_id=user_id),
+        ]
+        repo.get_by_user.return_value = links
+
+        result = await service.get_user_idp_links(user_id=user_id)
+
+        assert result.is_ok()
+        assert len(result.ok) == 2
+        repo.get_by_user.assert_awaited_once_with(user_id)
+
+    async def test_get_empty_list(self):
+        service, repo, _user_repo, _provider_repo = _build_service()
+        repo.get_by_user.return_value = []
+
+        result = await service.get_user_idp_links(user_id=uuid.uuid4())
+
+        assert result.is_ok()
+        assert result.ok == []
+
+
+@pytest.mark.anyio
+class TestDeleteIdPLink:
+    """AC-4.1.1: delete_idp_link removes link; not found → NotFound."""
+
+    async def test_delete_success(self):
+        service, repo, _user_repo, _provider_repo = _build_service()
+        user_id = uuid.uuid4()
+        link_id = uuid.uuid4()
+        link = _make_idp_link(id=link_id, user_id=user_id)
+        repo.get.return_value = link
+        repo.delete.return_value = True
+
+        result = await service.delete_idp_link(link_id=link_id, user_id=user_id)
+
+        assert result.is_ok()
+        assert result.ok["status"] == "deleted"
+        assert result.ok["link_id"] == str(link_id)
+        repo.get.assert_awaited_once_with(link_id)
+        repo.delete.assert_awaited_once_with(link_id)
+        repo.commit.assert_awaited_once()
+
+    async def test_delete_not_found(self):
+        service, repo, _user_repo, _provider_repo = _build_service()
+        repo.get.return_value = None
+
+        result = await service.delete_idp_link(link_id=uuid.uuid4(), user_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        repo.delete.assert_not_awaited()
+        repo.commit.assert_not_awaited()
+
+    async def test_delete_wrong_user(self):
+        """IDOR guard: delete scoped to owning user."""
+        service, repo, _user_repo, _provider_repo = _build_service()
+        owner_id = uuid.uuid4()
+        other_user_id = uuid.uuid4()
+        link_id = uuid.uuid4()
+        link = _make_idp_link(id=link_id, user_id=owner_id)
+        repo.get.return_value = link
+
+        result = await service.delete_idp_link(link_id=link_id, user_id=other_user_id)
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        repo.delete.assert_not_awaited()
+        repo.commit.assert_not_awaited()

--- a/backend/tests/unit/test_idp_links_router.py
+++ b/backend/tests/unit/test_idp_links_router.py
@@ -1,0 +1,436 @@
+"""Unit tests for the IdP links router (Story 4.2).
+
+Tests cover:
+- Auth enforcement: unauthenticated → 401, wrong role → 403
+- Tenant scoping: user not in caller's tenant → 404
+- Happy paths: list links, create link (201), delete link (204)
+- Error handling: NotFound → 404, Conflict → 409
+- Input validation: invalid UUID → 422, empty external_sub rejected, metadata limits
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from expression import Error, Ok
+from httpx import ASGITransport, AsyncClient
+
+from app.dependencies.identity import get_idp_link_service
+from app.errors.identity import Conflict, NotFound
+from app.main import app
+from app.models.database import get_async_session
+from app.services.idp_link import IdPLinkService
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _set_env(monkeypatch):
+    monkeypatch.setenv("DESCOPE_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("DESCOPE_MANAGEMENT_KEY", "test-management-key")
+
+
+@pytest.fixture
+def mock_idp_link_service():
+    return AsyncMock(spec=IdPLinkService)
+
+
+@pytest.fixture
+def mock_session():
+    return AsyncMock()
+
+
+@pytest.fixture(autouse=True)
+def _override_services(mock_idp_link_service, mock_session):
+    app.dependency_overrides[get_idp_link_service] = lambda: mock_idp_link_service
+    app.dependency_overrides[get_async_session] = lambda: mock_session
+    yield
+    app.dependency_overrides.pop(get_idp_link_service, None)
+    app.dependency_overrides.pop(get_async_session, None)
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+TENANT_ID = "51c5957b-684a-453f-8ab1-8f239999c4d8"
+
+ADMIN_CLAIMS = {
+    "sub": "admin1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["admin"], "permissions": []},
+    },
+}
+
+OWNER_CLAIMS = {
+    "sub": "owner1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["owner"], "permissions": []},
+    },
+}
+
+VIEWER_CLAIMS = {
+    "sub": "viewer1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["viewer"], "permissions": []},
+    },
+}
+
+OPERATOR_CLAIMS = {
+    "sub": "operator1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["operator"], "permissions": []},
+    },
+}
+
+AUTH_HEADER = {"Authorization": "Bearer valid.token"}
+
+USER_ID = str(uuid.uuid4())
+PROVIDER_ID = str(uuid.uuid4())
+LINK_ID = str(uuid.uuid4())
+
+SAMPLE_LINK = {
+    "id": LINK_ID,
+    "user_id": USER_ID,
+    "provider_id": PROVIDER_ID,
+    "external_sub": "ext-sub-123",
+    "external_email": "ext@example.com",
+    "metadata_": None,
+}
+
+
+def _mock_tenant_check_pass():
+    """Patch UserTenantRoleRepository so _verify_user_in_tenant passes."""
+    mock_repo_instance = AsyncMock()
+    mock_repo_instance.list_by_user_tenant.return_value = [MagicMock()]  # non-empty → passes
+    return patch("app.routers.idp_links.UserTenantRoleRepository", return_value=mock_repo_instance)
+
+
+def _mock_tenant_check_fail():
+    """Patch UserTenantRoleRepository so _verify_user_in_tenant fails (user not in tenant)."""
+    mock_repo_instance = AsyncMock()
+    mock_repo_instance.list_by_user_tenant.return_value = []  # empty → 404
+    return patch("app.routers.idp_links.UserTenantRoleRepository", return_value=mock_repo_instance)
+
+
+# --- Auth enforcement ---
+
+
+@pytest.mark.anyio
+async def test_list_links_rejects_unauthenticated(client):
+    response = await client.get(f"/api/users/{USER_ID}/idp-links")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_create_link_rejects_unauthenticated(client):
+    response = await client.post(
+        f"/api/users/{USER_ID}/idp-links",
+        json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_delete_link_rejects_unauthenticated(client):
+    response = await client.delete(f"/api/users/{USER_ID}/idp-links/{LINK_ID}")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_links_rejected_for_viewer(mock_validate, client):
+    mock_validate.return_value = VIEWER_CLAIMS
+    response = await client.get(f"/api/users/{USER_ID}/idp-links", headers=AUTH_HEADER)
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_link_rejected_for_operator(mock_validate, client):
+    """Admin/owner-only endpoints reject operator role."""
+    mock_validate.return_value = OPERATOR_CLAIMS
+    response = await client.post(
+        f"/api/users/{USER_ID}/idp-links",
+        headers=AUTH_HEADER,
+        json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_delete_link_rejected_without_tenant(mock_validate, client):
+    mock_validate.return_value = {"sub": "user1", "tenants": {}}
+    response = await client.delete(
+        f"/api/users/{USER_ID}/idp-links/{LINK_ID}",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 403
+
+
+# --- Tenant scoping ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_links_user_not_in_tenant_returns_404(mock_validate, client):
+    """User not in caller's tenant → 404 (does not leak user existence)."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    with _mock_tenant_check_fail():
+        response = await client.get(f"/api/users/{USER_ID}/idp-links", headers=AUTH_HEADER)
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_link_user_not_in_tenant_returns_404(mock_validate, client):
+    """User not in caller's tenant → 404 on create."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    with _mock_tenant_check_fail():
+        response = await client.post(
+            f"/api/users/{USER_ID}/idp-links",
+            headers=AUTH_HEADER,
+            json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub"},
+        )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_delete_link_user_not_in_tenant_returns_404(mock_validate, client):
+    """User not in caller's tenant → 404 on delete."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    with _mock_tenant_check_fail():
+        response = await client.delete(
+            f"/api/users/{USER_ID}/idp-links/{LINK_ID}",
+            headers=AUTH_HEADER,
+        )
+    assert response.status_code == 404
+
+
+# --- Happy paths ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_user_idp_links(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    links = [SAMPLE_LINK, {**SAMPLE_LINK, "external_sub": "ext-sub-456"}]
+    mock_idp_link_service.get_user_idp_links.return_value = Ok(links)
+
+    with _mock_tenant_check_pass():
+        response = await client.get(f"/api/users/{USER_ID}/idp-links", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    data = response.json()
+    assert "idp_links" in data
+    assert len(data["idp_links"]) == 2
+    mock_idp_link_service.get_user_idp_links.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_user_idp_links_empty(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_idp_link_service.get_user_idp_links.return_value = Ok([])
+
+    with _mock_tenant_check_pass():
+        response = await client.get(f"/api/users/{USER_ID}/idp-links", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    assert response.json()["idp_links"] == []
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_links_owner_allowed(mock_validate, mock_idp_link_service, client):
+    """Owner role is also allowed for IdP link endpoints."""
+    mock_validate.return_value = OWNER_CLAIMS
+    mock_idp_link_service.get_user_idp_links.return_value = Ok([])
+
+    with _mock_tenant_check_pass():
+        response = await client.get(f"/api/users/{USER_ID}/idp-links", headers=AUTH_HEADER)
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_idp_link(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_idp_link_service.create_idp_link.return_value = Ok(SAMPLE_LINK)
+
+    with _mock_tenant_check_pass():
+        response = await client.post(
+            f"/api/users/{USER_ID}/idp-links",
+            headers=AUTH_HEADER,
+            json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub-123"},
+        )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["external_sub"] == "ext-sub-123"
+    mock_idp_link_service.create_idp_link.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_idp_link_with_metadata(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    metadata = {"source": "migration"}
+    mock_idp_link_service.create_idp_link.return_value = Ok({**SAMPLE_LINK, "metadata_": metadata})
+
+    with _mock_tenant_check_pass():
+        response = await client.post(
+            f"/api/users/{USER_ID}/idp-links",
+            headers=AUTH_HEADER,
+            json={
+                "provider_id": PROVIDER_ID,
+                "external_sub": "ext-sub-123",
+                "metadata": metadata,
+            },
+        )
+    assert response.status_code == 201
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_delete_idp_link(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_idp_link_service.delete_idp_link.return_value = Ok({"status": "deleted", "link_id": LINK_ID})
+
+    with _mock_tenant_check_pass():
+        response = await client.delete(
+            f"/api/users/{USER_ID}/idp-links/{LINK_ID}",
+            headers=AUTH_HEADER,
+        )
+    assert response.status_code == 204
+    assert response.content == b""
+
+
+# --- Error handling ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_link_user_not_found(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_idp_link_service.create_idp_link.return_value = Error(NotFound(message=f"User '{USER_ID}' not found"))
+
+    with _mock_tenant_check_pass():
+        response = await client.post(
+            f"/api/users/{USER_ID}/idp-links",
+            headers=AUTH_HEADER,
+            json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub"},
+        )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_link_conflict(mock_validate, mock_idp_link_service, client):
+    """Duplicate user+provider → 409."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_idp_link_service.create_idp_link.return_value = Error(Conflict(message="IdP link already exists"))
+
+    with _mock_tenant_check_pass():
+        response = await client.post(
+            f"/api/users/{USER_ID}/idp-links",
+            headers=AUTH_HEADER,
+            json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub"},
+        )
+    assert response.status_code == 409
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_delete_link_not_found(mock_validate, mock_idp_link_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_idp_link_service.delete_idp_link.return_value = Error(NotFound(message=f"IdP link '{LINK_ID}' not found"))
+
+    with _mock_tenant_check_pass():
+        response = await client.delete(
+            f"/api/users/{USER_ID}/idp-links/{LINK_ID}",
+            headers=AUTH_HEADER,
+        )
+    assert response.status_code == 404
+
+
+# --- Input validation ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_links_invalid_user_uuid(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.get("/api/users/not-a-uuid/idp-links", headers=AUTH_HEADER)
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_link_invalid_user_uuid(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/users/not-a-uuid/idp-links",
+        headers=AUTH_HEADER,
+        json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_delete_link_invalid_user_uuid(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.delete(
+        "/api/users/not-a-uuid/idp-links/{LINK_ID}",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_delete_link_invalid_link_uuid(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    with _mock_tenant_check_pass():
+        response = await client.delete(
+            f"/api/users/{USER_ID}/idp-links/not-a-uuid",
+            headers=AUTH_HEADER,
+        )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_link_empty_external_sub_rejected(mock_validate, client):
+    """external_sub requires min_length=1."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        f"/api/users/{USER_ID}/idp-links",
+        headers=AUTH_HEADER,
+        json={"provider_id": PROVIDER_ID, "external_sub": ""},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_link_metadata_too_many_keys_rejected(mock_validate, client):
+    """metadata with >20 keys is rejected."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    metadata = {f"key{i}": f"val{i}" for i in range(21)}
+    response = await client.post(
+        f"/api/users/{USER_ID}/idp-links",
+        headers=AUTH_HEADER,
+        json={"provider_id": PROVIDER_ID, "external_sub": "ext-sub", "metadata": metadata},
+    )
+    assert response.status_code == 422

--- a/backend/tests/unit/test_inbound_sync_service.py
+++ b/backend/tests/unit/test_inbound_sync_service.py
@@ -1,0 +1,647 @@
+"""Unit tests for InboundSyncService domain orchestration (Story 3.1).
+
+Tests cover:
+- sync_user_from_flow: new user creation, existing link update, email-only upsert,
+  validation errors, provider not found, email conflict, name splitting, duplicate link
+- process_webhook_event: user.created delegation, user.updated, user.deleted deactivation,
+  unknown event type ignored, missing fields skipped
+"""
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.errors.identity import Conflict, NotFound, ValidationError
+from app.models.identity.provider import Provider, ProviderType
+from app.models.identity.user import IdPLink, User, UserStatus
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.user import RepositoryConflictError, UserRepository
+from app.services.inbound_sync import InboundSyncService
+
+PROVIDER_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+def _make_provider(**overrides) -> Provider:
+    defaults = {"id": PROVIDER_ID, "name": "descope", "type": ProviderType.descope}
+    defaults.update(overrides)
+    return Provider(**defaults)
+
+
+def _make_user(**overrides) -> User:
+    defaults = {
+        "id": USER_ID,
+        "email": "alice@example.com",
+        "user_name": "alice@example.com",
+        "given_name": "Alice",
+        "family_name": "Smith",
+        "status": UserStatus.active,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _make_link(**overrides) -> IdPLink:
+    defaults = {
+        "id": uuid.uuid4(),
+        "user_id": USER_ID,
+        "provider_id": PROVIDER_ID,
+        "external_sub": "descope-user-123",
+        "external_email": "alice@example.com",
+    }
+    defaults.update(overrides)
+    return IdPLink(**defaults)
+
+
+def _build_service(
+    user_repo: AsyncMock | None = None,
+    link_repo: AsyncMock | None = None,
+    provider_repo: AsyncMock | None = None,
+) -> tuple[InboundSyncService, AsyncMock, AsyncMock, AsyncMock]:
+    if user_repo is None:
+        user_repo = AsyncMock(spec=UserRepository)
+    if link_repo is None:
+        link_repo = AsyncMock(spec=IdPLinkRepository)
+    if provider_repo is None:
+        provider_repo = AsyncMock(spec=ProviderRepository)
+    service = InboundSyncService(
+        user_repository=user_repo,
+        idp_link_repository=link_repo,
+        provider_repository=provider_repo,
+    )
+    return service, user_repo, link_repo, provider_repo
+
+
+@pytest.mark.anyio
+class TestSyncUserFromFlow:
+    """AC-3.1.1: sync_user_from_flow creates/updates canonical user + IdP link."""
+
+    async def test_new_user_created(self):
+        """New user + IdP link created when no existing link or user."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = None
+        user_repo.get_by_email.return_value = None
+        new_user = _make_user()
+        user_repo.create.return_value = new_user
+
+        result = await service.sync_user_from_flow(
+            user_id="descope-user-123",
+            email="alice@example.com",
+            name="Alice Smith",
+        )
+
+        assert result.is_ok()
+        assert result.ok["created"] is True
+        user_repo.create.assert_awaited_once()
+        link_repo.create.assert_awaited_once()
+        user_repo.commit.assert_awaited_once()
+
+    async def test_existing_link_updates_user(self):
+        """Existing IdP link → update existing user, return created=False."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        existing_link = _make_link()
+        link_repo.get_by_provider_and_sub.return_value = existing_link
+        existing_user = _make_user()
+        user_repo.get.return_value = existing_user
+
+        result = await service.sync_user_from_flow(
+            user_id="descope-user-123",
+            email="new-email@example.com",
+            given_name="Bob",
+            family_name="Jones",
+        )
+
+        assert result.is_ok()
+        assert result.ok["created"] is False
+        user_repo.update.assert_awaited_once()
+        user_repo.commit.assert_awaited_once()
+        # Should NOT create a new link
+        link_repo.create.assert_not_awaited()
+
+    async def test_existing_user_by_email_creates_link(self):
+        """User exists by email but no IdP link → create link, return created=False."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = None
+        existing_user = _make_user()
+        user_repo.get_by_email.return_value = existing_user
+
+        result = await service.sync_user_from_flow(
+            user_id="descope-user-456",
+            email="alice@example.com",
+        )
+
+        assert result.is_ok()
+        assert result.ok["created"] is False
+        link_repo.create.assert_awaited_once()
+        user_repo.create.assert_not_awaited()
+        user_repo.commit.assert_awaited_once()
+
+    async def test_missing_email_returns_validation_error(self):
+        service, _, _, _ = _build_service()
+
+        result = await service.sync_user_from_flow(user_id="u1", email="")
+
+        assert result.is_error()
+        assert isinstance(result.error, ValidationError)
+        assert "Email" in result.error.message
+
+    async def test_missing_user_id_returns_validation_error(self):
+        service, _, _, _ = _build_service()
+
+        result = await service.sync_user_from_flow(user_id="", email="a@b.com")
+
+        assert result.is_error()
+        assert isinstance(result.error, ValidationError)
+        assert "user_id" in result.error.message
+
+    async def test_provider_not_found_returns_not_found(self):
+        service, _, _, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = None
+
+        result = await service.sync_user_from_flow(
+            user_id="u1",
+            email="a@b.com",
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        assert "provider" in result.error.message.lower()
+
+    async def test_name_splitting_from_full_name(self):
+        """When given_name/family_name absent, split 'name' into parts."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = None
+        user_repo.get_by_email.return_value = None
+        new_user = _make_user()
+        user_repo.create.return_value = new_user
+
+        await service.sync_user_from_flow(
+            user_id="u1",
+            email="a@b.com",
+            name="Jane Doe",
+        )
+
+        created_user = user_repo.create.call_args[0][0]
+        assert created_user.given_name == "Jane"
+        assert created_user.family_name == "Doe"
+
+    async def test_name_splitting_single_name(self):
+        """Single-word name → given_name only, family_name empty."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = None
+        user_repo.get_by_email.return_value = None
+        new_user = _make_user()
+        user_repo.create.return_value = new_user
+
+        await service.sync_user_from_flow(
+            user_id="u1",
+            email="a@b.com",
+            name="Cher",
+        )
+
+        created_user = user_repo.create.call_args[0][0]
+        assert created_user.given_name == "Cher"
+        assert created_user.family_name == ""
+
+    async def test_email_conflict_on_create_returns_conflict(self):
+        """TOCTOU: get_by_email returns None but create raises IntegrityError."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = None
+        user_repo.get_by_email.return_value = None
+        user_repo.create.side_effect = RepositoryConflictError("duplicate key")
+
+        result = await service.sync_user_from_flow(
+            user_id="u1",
+            email="dup@example.com",
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_duplicate_link_returns_conflict(self):
+        """Link creation raises conflict for existing provider+subject pair."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = None
+        new_user = _make_user()
+        user_repo.get_by_email.return_value = None
+        user_repo.create.return_value = new_user
+        link_repo.create.side_effect = RepositoryConflictError("unique violation")
+
+        result = await service.sync_user_from_flow(
+            user_id="u1",
+            email="a@b.com",
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_email_conflict_on_update_returns_conflict(self):
+        """Existing link path: update user raises conflict."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = _make_link()
+        user_repo.get.return_value = _make_user()
+        user_repo.update.side_effect = RepositoryConflictError("dup email")
+
+        result = await service.sync_user_from_flow(
+            user_id="descope-user-123",
+            email="taken@example.com",
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_linked_user_missing_returns_not_found(self):
+        """Existing link but linked user row missing → NotFound."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = _make_link()
+        user_repo.get.return_value = None
+
+        result = await service.sync_user_from_flow(
+            user_id="descope-user-123",
+            email="a@b.com",
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+
+@pytest.mark.anyio
+class TestProcessWebhookEvent:
+    """AC-3.1.2: process_webhook_event routes by event type, idempotent."""
+
+    async def test_user_created_delegates_to_sync(self):
+        """user.created webhook calls sync_user_from_flow under the hood."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = None
+        user_repo.get_by_email.return_value = None
+        new_user = _make_user()
+        user_repo.create.return_value = new_user
+
+        result = await service.process_webhook_event(
+            event_type="user.created",
+            data={"email": "alice@example.com", "user_id": "ext-123", "name": "Alice"},
+        )
+
+        assert result.is_ok()
+        user_repo.create.assert_awaited_once()
+
+    async def test_user_created_missing_fields_skipped(self):
+        """user.created with missing email/user_id → skipped, not error."""
+        service, _, _, _ = _build_service()
+
+        result = await service.process_webhook_event(
+            event_type="user.created",
+            data={"name": "No email or id"},
+        )
+
+        assert result.is_ok()
+        assert result.ok["status"] == "skipped"
+
+    async def test_user_updated_known_user(self):
+        """user.updated for a linked user → update fields, return Ok."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link = _make_link()
+        link_repo.get_by_provider_and_sub.return_value = link
+        user = _make_user()
+        user_repo.get.return_value = user
+
+        result = await service.process_webhook_event(
+            event_type="user.updated",
+            data={"user_id": "descope-user-123", "email": "updated@example.com"},
+        )
+
+        assert result.is_ok()
+        assert result.ok["created"] is False
+        user_repo.update.assert_awaited_once()
+        user_repo.commit.assert_awaited_once()
+
+    async def test_user_updated_unknown_user_ignored(self):
+        """user.updated for unknown IdP link → ignored, return Ok."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = None
+
+        result = await service.process_webhook_event(
+            event_type="user.updated",
+            data={"user_id": "unknown-123"},
+        )
+
+        assert result.is_ok()
+        assert result.ok["status"] == "ignored"
+        user_repo.update.assert_not_awaited()
+
+    async def test_user_updated_missing_user_id_skipped(self):
+        service, _, _, _ = _build_service()
+
+        result = await service.process_webhook_event(
+            event_type="user.updated",
+            data={"email": "a@b.com"},
+        )
+
+        assert result.is_ok()
+        assert result.ok["status"] == "skipped"
+
+    async def test_user_updated_name_splitting(self):
+        """user.updated with name but no given/family → splits name."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = _make_link()
+        user = _make_user()
+        user_repo.get.return_value = user
+
+        await service.process_webhook_event(
+            event_type="user.updated",
+            data={"user_id": "descope-user-123", "name": "Jane Doe"},
+        )
+
+        assert user.given_name == "Jane"
+        assert user.family_name == "Doe"
+
+    async def test_user_deleted_deactivates_user(self):
+        """user.deleted for a linked user → set status=inactive."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link = _make_link()
+        link_repo.get_by_provider_and_sub.return_value = link
+        user = _make_user(status=UserStatus.active)
+        user_repo.get.return_value = user
+
+        result = await service.process_webhook_event(
+            event_type="user.deleted",
+            data={"user_id": "descope-user-123"},
+        )
+
+        assert result.is_ok()
+        assert result.ok["status"] == "deactivated"
+        assert user.status == UserStatus.inactive
+        user_repo.update.assert_awaited_once()
+        user_repo.commit.assert_awaited_once()
+
+    async def test_user_deleted_unknown_user_ignored(self):
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = None
+
+        result = await service.process_webhook_event(
+            event_type="user.deleted",
+            data={"user_id": "unknown-123"},
+        )
+
+        assert result.is_ok()
+        assert result.ok["status"] == "ignored"
+
+    async def test_user_deleted_missing_user_id_skipped(self):
+        service, _, _, _ = _build_service()
+
+        result = await service.process_webhook_event(
+            event_type="user.deleted",
+            data={},
+        )
+
+        assert result.is_ok()
+        assert result.ok["status"] == "skipped"
+
+    async def test_unknown_event_type_ignored(self):
+        """Unknown event types → log warning, return success."""
+        service, _, _, _ = _build_service()
+
+        result = await service.process_webhook_event(
+            event_type="tenant.created",
+            data={"tenant_id": "t1"},
+        )
+
+        assert result.is_ok()
+        assert result.ok["status"] == "ignored"
+        assert result.ok["event_type"] == "tenant.created"
+
+    async def test_user_deleted_linked_user_missing_returns_not_found(self):
+        """Link exists but linked user row gone → NotFound."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = _make_link()
+        user_repo.get.return_value = None
+
+        result = await service.process_webhook_event(
+            event_type="user.deleted",
+            data={"user_id": "descope-user-123"},
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_user_updated_conflict_returns_error(self):
+        """user.updated raising conflict on update → Conflict error."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = _make_link()
+        user_repo.get.return_value = _make_user()
+        user_repo.update.side_effect = RepositoryConflictError("dup")
+
+        result = await service.process_webhook_event(
+            event_type="user.updated",
+            data={"user_id": "descope-user-123", "email": "taken@test.com"},
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_user_deleted_conflict_returns_error(self):
+        """user.deleted raising conflict on update → Conflict error."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        link_repo.get_by_provider_and_sub.return_value = _make_link()
+        user_repo.get.return_value = _make_user(status=UserStatus.active)
+        user_repo.update.side_effect = RepositoryConflictError("constraint")
+
+        result = await service.process_webhook_event(
+            event_type="user.deleted",
+            data={"user_id": "descope-user-123"},
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+
+@pytest.mark.anyio
+class TestFlowSyncIdempotentReplay:
+    """AC-3.4.1: Replaying sync_user_from_flow with same data is idempotent."""
+
+    async def test_replay_returns_created_false_no_duplicate_user(self):
+        """Second call with same user_id finds existing link → update, no new user/link."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider = _make_provider()
+        provider_repo.get_by_type.return_value = provider
+        existing_user = _make_user()
+        existing_link = _make_link()
+
+        # Replay: link already exists from first sync
+        link_repo.get_by_provider_and_sub.return_value = existing_link
+        user_repo.get.return_value = existing_user
+
+        result = await service.sync_user_from_flow(
+            user_id="descope-user-123",
+            email="alice@example.com",
+            name="Alice Smith",
+        )
+
+        assert result.is_ok()
+        assert result.ok["created"] is False
+        # Must NOT create a new user or link
+        user_repo.create.assert_not_awaited()
+        link_repo.create.assert_not_awaited()
+        # Must update existing user and commit
+        user_repo.update.assert_awaited_once()
+        user_repo.commit.assert_awaited_once()
+
+    async def test_replay_preserves_user_fields(self):
+        """Replaying with identical data preserves user fields unchanged."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        user = _make_user(
+            email="alice@example.com",
+            given_name="Alice",
+            family_name="Smith",
+        )
+        link_repo.get_by_provider_and_sub.return_value = _make_link()
+        user_repo.get.return_value = user
+
+        result = await service.sync_user_from_flow(
+            user_id="descope-user-123",
+            email="alice@example.com",
+            given_name="Alice",
+            family_name="Smith",
+        )
+
+        assert result.is_ok()
+        assert result.ok["user"]["email"] == "alice@example.com"
+        assert result.ok["user"]["given_name"] == "Alice"
+        assert result.ok["user"]["family_name"] == "Smith"
+
+    async def test_two_calls_same_result_shape(self):
+        """First call (create) and second call (update) return same dict shape."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        user = _make_user()
+
+        # First call: no link, no user → create
+        link_repo.get_by_provider_and_sub.return_value = None
+        user_repo.get_by_email.return_value = None
+        user_repo.create.return_value = user
+
+        result1 = await service.sync_user_from_flow(
+            user_id="descope-user-123",
+            email="alice@example.com",
+            name="Alice Smith",
+        )
+
+        # Second call: link exists → update path
+        link_repo.get_by_provider_and_sub.return_value = _make_link()
+        user_repo.get.return_value = user
+
+        result2 = await service.sync_user_from_flow(
+            user_id="descope-user-123",
+            email="alice@example.com",
+            name="Alice Smith",
+        )
+
+        assert result1.is_ok()
+        assert result2.is_ok()
+        # Both return dict with "user" and "created" keys
+        assert set(result1.ok.keys()) == {"user", "created"}
+        assert set(result2.ok.keys()) == {"user", "created"}
+        assert result1.ok["created"] is True
+        assert result2.ok["created"] is False
+
+
+@pytest.mark.anyio
+class TestWebhookIdempotentReplay:
+    """AC-3.4.2: Replaying webhook events is idempotent."""
+
+    async def test_user_created_replay_no_duplicate(self):
+        """Replaying user.created when link already exists → update, not create."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        existing_user = _make_user()
+        existing_link = _make_link()
+
+        # Replay: link exists from first webhook
+        link_repo.get_by_provider_and_sub.return_value = existing_link
+        user_repo.get.return_value = existing_user
+
+        result = await service.process_webhook_event(
+            event_type="user.created",
+            data={
+                "user_id": "descope-user-123",
+                "email": "alice@example.com",
+                "name": "Alice Smith",
+            },
+        )
+
+        assert result.is_ok()
+        assert result.ok["created"] is False
+        user_repo.create.assert_not_awaited()
+        link_repo.create.assert_not_awaited()
+
+    async def test_user_updated_replay_safe(self):
+        """Replaying user.updated applies same fields again → no error."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        user = _make_user(email="updated@example.com")
+        link_repo.get_by_provider_and_sub.return_value = _make_link()
+        user_repo.get.return_value = user
+
+        # First call
+        result1 = await service.process_webhook_event(
+            event_type="user.updated",
+            data={"user_id": "descope-user-123", "email": "updated@example.com"},
+        )
+
+        # Reset mocks for second call
+        user_repo.update.reset_mock()
+        user_repo.commit.reset_mock()
+
+        # Replay with identical data
+        result2 = await service.process_webhook_event(
+            event_type="user.updated",
+            data={"user_id": "descope-user-123", "email": "updated@example.com"},
+        )
+
+        assert result1.is_ok()
+        assert result2.is_ok()
+        assert result2.ok["created"] is False
+        # Both calls succeed — idempotent
+        user_repo.update.assert_awaited_once()
+
+    async def test_user_deleted_replay_stays_inactive(self):
+        """Replaying user.deleted on already-inactive user → still deactivated, no error."""
+        service, user_repo, link_repo, provider_repo = _build_service()
+        provider_repo.get_by_type.return_value = _make_provider()
+        # User already inactive from first deletion event
+        user = _make_user(status=UserStatus.inactive)
+        link_repo.get_by_provider_and_sub.return_value = _make_link()
+        user_repo.get.return_value = user
+
+        result = await service.process_webhook_event(
+            event_type="user.deleted",
+            data={"user_id": "descope-user-123"},
+        )
+
+        assert result.is_ok()
+        assert result.ok["status"] == "deactivated"
+        # Status should remain inactive
+        assert user.status == UserStatus.inactive
+        user_repo.update.assert_awaited_once()
+        user_repo.commit.assert_awaited_once()

--- a/backend/tests/unit/test_internal_router.py
+++ b/backend/tests/unit/test_internal_router.py
@@ -1,0 +1,531 @@
+"""Unit tests for the internal router (Story 3.1 + Story 4.3).
+
+Tests cover:
+- POST /api/internal/users/sync — flow connector endpoint (with shared secret)
+- POST /api/internal/webhooks/descope — webhook endpoint with HMAC
+- AC-3.1.3: HMAC validation (valid, invalid, missing secret)
+- AC-3.1.4: Internal endpoints bypass JWT auth
+- Flow sync shared secret validation
+- Error handling via result_to_response
+- AC-4.3.1: GET /api/internal/identity — identity resolution endpoint
+- AC-4.3.4: Identity endpoint bypasses JWT auth
+"""
+
+import hashlib
+import hmac as hmac_mod
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from expression import Error, Ok
+from httpx import ASGITransport, AsyncClient
+
+from app.dependencies.identity import get_identity_resolution_service, get_inbound_sync_service
+from app.errors.identity import Conflict, NotFound, ValidationError
+from app.main import app
+from app.services.identity_resolution import IdentityResolutionService
+from app.services.inbound_sync import InboundSyncService
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _set_env(monkeypatch):
+    monkeypatch.setenv("DESCOPE_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("DESCOPE_MANAGEMENT_KEY", "test-management-key")
+
+
+@pytest.fixture
+def mock_sync_service():
+    return AsyncMock(spec=InboundSyncService)
+
+
+@pytest.fixture(autouse=True)
+def _override_services(mock_sync_service):
+    app.dependency_overrides[get_inbound_sync_service] = lambda: mock_sync_service
+    yield
+    app.dependency_overrides.pop(get_inbound_sync_service, None)
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+SAMPLE_USER_DICT = {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "email": "alice@example.com",
+    "user_name": "alice@example.com",
+    "given_name": "Alice",
+    "family_name": "Smith",
+    "status": "active",
+}
+
+WEBHOOK_SECRET = "test-webhook-secret-key"
+FLOW_SECRET = "test-flow-sync-secret"
+IDENTITY_KEY = "test-identity-key"
+
+
+def _compute_hmac(body: bytes, secret: str = WEBHOOK_SECRET) -> str:
+    return hmac_mod.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+# --- AC-3.1.4: Internal endpoints bypass JWT auth ---
+
+
+@pytest.mark.anyio
+@patch.dict("os.environ", {"DESCOPE_FLOW_SYNC_SECRET": FLOW_SECRET})
+async def test_flow_sync_no_jwt_required(mock_sync_service, client):
+    """Internal endpoints excluded from JWT — needs X-Flow-Secret, not Authorization."""
+    # Reload module-level secret
+    import app.routers.internal as mod
+
+    mod._FLOW_SYNC_SECRET = FLOW_SECRET
+    try:
+        mock_sync_service.sync_user_from_flow.return_value = Ok({"user": SAMPLE_USER_DICT, "created": True})
+
+        response = await client.post(
+            "/api/internal/users/sync",
+            json={"user_id": "ext-1", "email": "alice@example.com"},
+            headers={"X-Flow-Secret": FLOW_SECRET},
+        )
+
+        # Should NOT get 401 from JWT middleware — internal endpoints bypass JWT auth
+        assert response.status_code == 201
+        mock_sync_service.sync_user_from_flow.assert_awaited_once()
+    finally:
+        mod._FLOW_SYNC_SECRET = ""
+
+
+# --- Flow sync shared secret validation ---
+
+
+@pytest.mark.anyio
+async def test_flow_sync_missing_secret_header_returns_422(client):
+    """Missing X-Flow-Secret header → 422 (FastAPI header validation)."""
+    response = await client.post(
+        "/api/internal/users/sync",
+        json={"user_id": "ext-1", "email": "alice@example.com"},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_flow_sync_invalid_secret_returns_401(client):
+    """Invalid X-Flow-Secret → 401."""
+    import app.routers.internal as mod
+
+    mod._FLOW_SYNC_SECRET = FLOW_SECRET
+    try:
+        response = await client.post(
+            "/api/internal/users/sync",
+            json={"user_id": "ext-1", "email": "alice@example.com"},
+            headers={"X-Flow-Secret": "wrong-secret"},
+        )
+
+        assert response.status_code == 401
+    finally:
+        mod._FLOW_SYNC_SECRET = ""
+
+
+@pytest.mark.anyio
+async def test_flow_sync_unconfigured_secret_returns_401(client):
+    """DESCOPE_FLOW_SYNC_SECRET empty → 401."""
+    import app.routers.internal as mod
+
+    mod._FLOW_SYNC_SECRET = ""
+
+    response = await client.post(
+        "/api/internal/users/sync",
+        json={"user_id": "ext-1", "email": "alice@example.com"},
+        headers={"X-Flow-Secret": "any-value"},
+    )
+
+    assert response.status_code == 401
+
+
+# --- AC-3.1.1: Flow sync endpoint ---
+
+
+def _flow_sync_headers():
+    return {"X-Flow-Secret": FLOW_SECRET}
+
+
+@pytest.fixture(autouse=True)
+def _set_flow_secret():
+    import app.routers.internal as mod
+
+    mod._FLOW_SYNC_SECRET = FLOW_SECRET
+    yield
+    mod._FLOW_SYNC_SECRET = ""
+
+
+@pytest.mark.anyio
+async def test_flow_sync_new_user_returns_201(mock_sync_service, client):
+    mock_sync_service.sync_user_from_flow.return_value = Ok({"user": SAMPLE_USER_DICT, "created": True})
+
+    response = await client.post(
+        "/api/internal/users/sync",
+        json={"user_id": "ext-1", "email": "alice@example.com", "name": "Alice Smith"},
+        headers=_flow_sync_headers(),
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["user"]["email"] == "alice@example.com"
+    assert data["created"] is True
+
+
+@pytest.mark.anyio
+async def test_flow_sync_existing_user_returns_200(mock_sync_service, client):
+    mock_sync_service.sync_user_from_flow.return_value = Ok({"user": SAMPLE_USER_DICT, "created": False})
+
+    response = await client.post(
+        "/api/internal/users/sync",
+        json={"user_id": "ext-1", "email": "alice@example.com"},
+        headers=_flow_sync_headers(),
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_flow_sync_conflict_returns_409(mock_sync_service, client):
+    mock_sync_service.sync_user_from_flow.return_value = Error(Conflict(message="Email already exists"))
+
+    response = await client.post(
+        "/api/internal/users/sync",
+        json={"user_id": "ext-1", "email": "dup@example.com"},
+        headers=_flow_sync_headers(),
+    )
+
+    assert response.status_code == 409
+    assert response.headers["content-type"].startswith("application/problem+json")
+
+
+@pytest.mark.anyio
+async def test_flow_sync_not_found_returns_404(mock_sync_service, client):
+    """Provider not configured → NotFound."""
+    mock_sync_service.sync_user_from_flow.return_value = Error(NotFound(message="Descope provider not configured"))
+
+    response = await client.post(
+        "/api/internal/users/sync",
+        json={"user_id": "ext-1", "email": "a@b.com"},
+        headers=_flow_sync_headers(),
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_flow_sync_validation_error_returns_422(mock_sync_service, client):
+    mock_sync_service.sync_user_from_flow.return_value = Error(ValidationError(message="Email is required"))
+
+    response = await client.post(
+        "/api/internal/users/sync",
+        json={"user_id": "ext-1", "email": "a@b.com"},
+        headers=_flow_sync_headers(),
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_flow_sync_missing_required_field_returns_422(client):
+    """Pydantic validation: missing email → 422 before reaching service."""
+    response = await client.post(
+        "/api/internal/users/sync",
+        json={"user_id": "ext-1"},
+        headers=_flow_sync_headers(),
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_flow_sync_invalid_email_returns_422(client):
+    """Pydantic EmailStr validation: malformed email → 422."""
+    response = await client.post(
+        "/api/internal/users/sync",
+        json={"user_id": "ext-1", "email": "not-an-email"},
+        headers=_flow_sync_headers(),
+    )
+
+    assert response.status_code == 422
+
+
+# --- AC-3.1.2: Webhook endpoint ---
+
+
+@pytest.mark.anyio
+async def test_webhook_valid_hmac(mock_sync_service, client):
+    """Valid HMAC signature → request processed."""
+    import app.routers.internal as mod
+
+    mod._WEBHOOK_SECRET = WEBHOOK_SECRET
+    try:
+        mock_sync_service.process_webhook_event.return_value = Ok({"status": "ignored", "event_type": "tenant.created"})
+
+        import json
+
+        body_bytes = json.dumps({"event_type": "tenant.created", "data": {}}).encode()
+        sig = _compute_hmac(body_bytes)
+
+        response = await client.post(
+            "/api/internal/webhooks/descope",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Descope-Webhook-S256": sig,
+            },
+        )
+
+        assert response.status_code == 200
+        mock_sync_service.process_webhook_event.assert_awaited_once()
+    finally:
+        mod._WEBHOOK_SECRET = ""
+
+
+# --- AC-3.1.3: HMAC validation ---
+
+
+@pytest.mark.anyio
+async def test_webhook_invalid_hmac_returns_401(client):
+    """Invalid HMAC signature → 401."""
+    import app.routers.internal as mod
+
+    mod._WEBHOOK_SECRET = WEBHOOK_SECRET
+    try:
+        response = await client.post(
+            "/api/internal/webhooks/descope",
+            json={"event_type": "user.created", "data": {}},
+            headers={"X-Descope-Webhook-S256": "badbadbadbad"},
+        )
+
+        assert response.status_code == 401
+    finally:
+        mod._WEBHOOK_SECRET = ""
+
+
+@pytest.mark.anyio
+async def test_webhook_missing_hmac_header_returns_422(client):
+    """Missing X-Descope-Webhook-S256 header → 422 (FastAPI header validation)."""
+    response = await client.post(
+        "/api/internal/webhooks/descope",
+        json={"event_type": "user.created", "data": {}},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_webhook_missing_secret_returns_401(client):
+    """DESCOPE_WEBHOOK_SECRET empty → 401 (secret not configured)."""
+    import app.routers.internal as mod
+
+    mod._WEBHOOK_SECRET = ""
+
+    response = await client.post(
+        "/api/internal/webhooks/descope",
+        json={"event_type": "user.created", "data": {}},
+        headers={"X-Descope-Webhook-S256": "anysig"},
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_webhook_no_auth_required(mock_sync_service, client):
+    """Webhook endpoint also bypasses JWT auth (internal prefix)."""
+    # Even without secret env, the webhook handler should not return 401 from JWT
+    # It returns 422 because the HMAC header is missing (not 401 from JWT)
+    response = await client.post(
+        "/api/internal/webhooks/descope",
+        json={"event_type": "user.created", "data": {}},
+    )
+
+    # 422 from missing header, NOT 401 from JWT middleware
+    assert response.status_code == 422
+
+
+# --- AC-4.3.1 / AC-4.3.4: Identity resolution endpoint ---
+
+
+@pytest.fixture
+def mock_resolution_service():
+    return AsyncMock(spec=IdentityResolutionService)
+
+
+@pytest.fixture(autouse=True)
+def _override_resolution_service(mock_resolution_service):
+    app.dependency_overrides[get_identity_resolution_service] = lambda: mock_resolution_service
+    yield
+    app.dependency_overrides.pop(get_identity_resolution_service, None)
+
+
+@pytest.fixture(autouse=True)
+def _set_identity_key(monkeypatch):
+    """Set the INTERNAL_IDENTITY_KEY env var and patch the module-level variable."""
+    monkeypatch.setenv("INTERNAL_IDENTITY_KEY", IDENTITY_KEY)
+    import app.routers.internal as mod
+
+    monkeypatch.setattr(mod, "_IDENTITY_KEY", IDENTITY_KEY)
+
+
+SAMPLE_IDENTITY_PAYLOAD = {
+    "user": {
+        "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "email": "alice@example.com",
+        "user_name": "alice",
+        "given_name": "Alice",
+        "family_name": "Smith",
+        "status": "active",
+    },
+    "roles": [{"tenant_id": "t-1", "role_name": "admin", "permissions": ["read:users"]}],
+    "tenant_memberships": [{"tenant_id": "t-1", "tenant_name": "Acme"}],
+    "linked_idps": [{"provider_name": "descope", "external_sub": "ext-123"}],
+}
+
+
+@pytest.mark.anyio
+async def test_identity_resolution_success(mock_resolution_service, client):
+    """AC-4.3.1: GET /api/internal/identity returns full identity payload."""
+    mock_resolution_service.resolve.return_value = Ok(SAMPLE_IDENTITY_PAYLOAD)
+
+    response = await client.get(
+        "/api/internal/identity",
+        params={"sub": "ext-123", "provider": "descope"},
+        headers={"X-Identity-Key": IDENTITY_KEY},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["user"]["email"] == "alice@example.com"
+    assert len(data["roles"]) == 1
+    assert data["roles"][0]["role_name"] == "admin"
+    mock_resolution_service.resolve.assert_awaited_once_with(provider="descope", sub="ext-123")
+
+
+@pytest.mark.anyio
+async def test_identity_resolution_provider_not_found(mock_resolution_service, client):
+    """Unknown provider returns 404."""
+    mock_resolution_service.resolve.return_value = Error(NotFound(message="Provider 'unknown' not found"))
+
+    response = await client.get(
+        "/api/internal/identity",
+        params={"sub": "ext-123", "provider": "unknown"},
+        headers={"X-Identity-Key": IDENTITY_KEY},
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_identity_resolution_link_not_found(mock_resolution_service, client):
+    """No IdP link for sub+provider returns 404."""
+    mock_resolution_service.resolve.return_value = Error(
+        NotFound(message="No identity found for provider 'descope' with sub 'nonexistent'")
+    )
+
+    response = await client.get(
+        "/api/internal/identity",
+        params={"sub": "nonexistent", "provider": "descope"},
+        headers={"X-Identity-Key": IDENTITY_KEY},
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_identity_resolution_missing_sub_param(client):
+    """Missing 'sub' query parameter → 422."""
+    response = await client.get(
+        "/api/internal/identity",
+        params={"provider": "descope"},
+        headers={"X-Identity-Key": IDENTITY_KEY},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_identity_resolution_missing_provider_param(client):
+    """Missing 'provider' query parameter → 422."""
+    response = await client.get(
+        "/api/internal/identity",
+        params={"sub": "ext-123"},
+        headers={"X-Identity-Key": IDENTITY_KEY},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_identity_resolution_missing_both_params(client):
+    """Missing both query parameters → 422."""
+    response = await client.get(
+        "/api/internal/identity",
+        headers={"X-Identity-Key": IDENTITY_KEY},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_identity_missing_key_returns_422(client):
+    """Missing X-Identity-Key header → 422."""
+    response = await client.get(
+        "/api/internal/identity",
+        params={"sub": "ext-123", "provider": "descope"},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_identity_invalid_key_returns_401(client):
+    """Invalid X-Identity-Key → 401."""
+    response = await client.get(
+        "/api/internal/identity",
+        params={"sub": "ext-123", "provider": "descope"},
+        headers={"X-Identity-Key": "wrong-key"},
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_identity_unconfigured_key_returns_401(client, monkeypatch):
+    """Unconfigured INTERNAL_IDENTITY_KEY → 401."""
+    import app.routers.internal as mod
+
+    monkeypatch.setattr(mod, "_IDENTITY_KEY", "")
+
+    response = await client.get(
+        "/api/internal/identity",
+        params={"sub": "ext-123", "provider": "descope"},
+        headers={"X-Identity-Key": "any-key"},
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_identity_endpoint_bypasses_jwt(client):
+    """AC-4.3.4: /api/internal/identity bypasses JWT auth.
+
+    Without Authorization header but with valid identity key, does NOT return 401 from JWT middleware.
+    Returns 422 (missing params) which proves JWT was bypassed.
+    """
+    response = await client.get(
+        "/api/internal/identity",
+        headers={"X-Identity-Key": IDENTITY_KEY},
+    )
+
+    # 422 from missing query params, NOT 401 from JWT middleware
+    assert response.status_code == 422

--- a/backend/tests/unit/test_permission_service.py
+++ b/backend/tests/unit/test_permission_service.py
@@ -1,0 +1,317 @@
+"""Unit tests for PermissionService domain orchestration (Story 2.2).
+
+Tests cover:
+- create_permission: persist, commit, sync; duplicate → Conflict; sync fail → Ok
+- get_permission: found → Ok(dict); not found → NotFound
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from expression import Error, Ok
+
+from app.errors.identity import Conflict, NotFound
+from app.models.identity.role import Permission
+from app.repositories.permission import PermissionRepository
+from app.repositories.user import RepositoryConflictError
+from app.services.adapters.base import IdentityProviderAdapter, SyncError
+from app.services.cache_invalidation import CacheInvalidationPublisher
+from app.services.permission import PermissionService
+
+
+def _make_permission(**overrides) -> Permission:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": "documents.read",
+        "description": "Read documents",
+    }
+    defaults.update(overrides)
+    return Permission(**defaults)
+
+
+def _build_service(
+    repo: AsyncMock | None = None,
+    adapter: AsyncMock | None = None,
+) -> tuple[PermissionService, AsyncMock, AsyncMock]:
+    if repo is None:
+        repo = AsyncMock(spec=PermissionRepository)
+    if adapter is None:
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+    service = PermissionService(repository=repo, adapter=adapter)
+    return service, repo, adapter
+
+
+@pytest.mark.anyio
+class TestCreatePermission:
+    """AC-2.2.2: create_permission persists via repo, commits, syncs, returns Ok(dict)."""
+
+    async def test_create_permission_success(self):
+        service, repo, adapter = _build_service()
+        repo.get_by_name.return_value = None
+        perm = _make_permission()
+        repo.create.return_value = perm
+        adapter.sync_permission.return_value = Ok(None)
+
+        result = await service.create_permission(name=perm.name, description=perm.description)
+
+        assert result.is_ok()
+        repo.create.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+        adapter.sync_permission.assert_awaited_once()
+
+    async def test_create_permission_commit_before_sync(self):
+        service, repo, adapter = _build_service()
+        repo.get_by_name.return_value = None
+        perm = _make_permission()
+        repo.create.return_value = perm
+        adapter.sync_permission.return_value = Ok(None)
+
+        call_order = []
+        repo.commit.side_effect = lambda: call_order.append("commit")
+        adapter.sync_permission.side_effect = lambda **kw: (call_order.append("sync"), Ok(None))[1]
+
+        await service.create_permission(name=perm.name)
+
+        assert call_order == ["commit", "sync"]
+
+    async def test_create_permission_duplicate_name_returns_conflict(self):
+        """AC-2.2.5: duplicate name → Conflict."""
+        service, repo, _adapter = _build_service()
+        repo.get_by_name.return_value = _make_permission()
+
+        result = await service.create_permission(name="documents.read")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        repo.create.assert_not_awaited()
+
+    async def test_create_permission_integrity_error_returns_conflict(self):
+        """TOCTOU race: get_by_name returns None but flush raises IntegrityError."""
+        service, repo, _adapter = _build_service()
+        repo.get_by_name.return_value = None
+        repo.create.side_effect = RepositoryConflictError("duplicate key")
+
+        result = await service.create_permission(name="documents.read")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_create_permission_sync_failure_still_returns_ok(self):
+        service, repo, adapter = _build_service()
+        repo.get_by_name.return_value = None
+        perm = _make_permission()
+        repo.create.return_value = perm
+        adapter.sync_permission.return_value = Error(SyncError(message="Descope down", operation="sync_permission"))
+
+        with patch("app.services.permission.logger") as mock_logger:
+            result = await service.create_permission(name=perm.name)
+
+        assert result.is_ok()
+        repo.commit.assert_awaited_once()
+        mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.anyio
+class TestGetPermission:
+    async def test_get_permission_found(self):
+        service, repo, _adapter = _build_service()
+        perm = _make_permission()
+        repo.get.return_value = perm
+
+        result = await service.get_permission(permission_id=perm.id)
+
+        assert result.is_ok()
+        assert result.ok["name"] == perm.name
+
+    async def test_get_permission_not_found(self):
+        service, repo, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.get_permission(permission_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+
+@pytest.mark.anyio
+class TestListPermissions:
+    """Story 2.3: list_permissions delegates to repository."""
+
+    async def test_list_permissions_returns_list(self):
+        service, repo, _adapter = _build_service()
+        perms = [_make_permission(name="read"), _make_permission(name="write")]
+        repo.list_all.return_value = perms
+
+        result = await service.list_permissions()
+
+        assert result.is_ok()
+        assert len(result.ok) == 2
+        repo.list_all.assert_awaited_once()
+
+    async def test_list_permissions_empty(self):
+        service, repo, _adapter = _build_service()
+        repo.list_all.return_value = []
+
+        result = await service.list_permissions()
+
+        assert result.is_ok()
+        assert result.ok == []
+
+
+@pytest.mark.anyio
+class TestUpdatePermission:
+    """Story 2.3: update_permission updates fields, commits, syncs."""
+
+    async def test_update_permission_success(self):
+        service, repo, adapter = _build_service()
+        perm = _make_permission(name="reports.read")
+        repo.get.return_value = perm
+        repo.get_by_name.return_value = None
+        repo.update.return_value = perm
+        adapter.sync_permission.return_value = Ok(None)
+
+        result = await service.update_permission(permission_id=perm.id, name="reports.view", description="View reports")
+
+        assert result.is_ok()
+        repo.update.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+        adapter.sync_permission.assert_awaited_once()
+
+    async def test_update_permission_not_found(self):
+        service, repo, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.update_permission(permission_id=uuid.uuid4(), name="new")
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_update_permission_name_conflict(self):
+        service, repo, _adapter = _build_service()
+        perm = _make_permission(name="reports.read")
+        existing = _make_permission(name="reports.write")
+        repo.get.return_value = perm
+        repo.get_by_name.return_value = existing
+
+        result = await service.update_permission(permission_id=perm.id, name="reports.write")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_update_permission_integrity_error(self):
+        service, repo, _adapter = _build_service()
+        perm = _make_permission()
+        repo.get.return_value = perm
+        repo.get_by_name.return_value = None
+        repo.update.side_effect = RepositoryConflictError("duplicate key")
+
+        result = await service.update_permission(permission_id=perm.id, name="new")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_update_permission_sync_failure_still_returns_ok(self):
+        """AC-2.4.2: sync failure on update → log warning, still return Ok."""
+        service, repo, adapter = _build_service()
+        perm = _make_permission(name="reports.read")
+        repo.get.return_value = perm
+        repo.get_by_name.return_value = None
+        repo.update.return_value = perm
+        adapter.sync_permission.return_value = Error(SyncError(message="Descope down", operation="sync_permission"))
+
+        with patch("app.services.permission.logger") as mock_logger:
+            result = await service.update_permission(permission_id=perm.id, name="reports.view")
+
+        assert result.is_ok()
+        repo.commit.assert_awaited_once()
+        mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.anyio
+class TestDeletePermission:
+    """Story 2.3: delete_permission removes from DB, commits, syncs deletion."""
+
+    async def test_delete_permission_success(self):
+        service, repo, adapter = _build_service()
+        perm = _make_permission(name="reports.read")
+        repo.get.return_value = perm
+        repo.delete.return_value = True
+        adapter.delete_permission.return_value = Ok(None)
+
+        result = await service.delete_permission(permission_id=perm.id)
+
+        assert result.is_ok()
+        assert result.ok["status"] == "deleted"
+        assert result.ok["name"] == "reports.read"
+        repo.commit.assert_awaited_once()
+        adapter.delete_permission.assert_awaited_once()
+
+    async def test_delete_permission_not_found(self):
+        service, repo, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.delete_permission(permission_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_delete_permission_sync_failure_still_ok(self):
+        service, repo, adapter = _build_service()
+        perm = _make_permission()
+        repo.get.return_value = perm
+        repo.delete.return_value = True
+        adapter.delete_permission.return_value = Error(SyncError(message="down", operation="delete_permission"))
+
+        with patch("app.services.permission.logger") as mock_logger:
+            result = await service.delete_permission(permission_id=perm.id)
+
+        assert result.is_ok()
+        mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.anyio
+class TestCacheInvalidationPublishing:
+    """AC-3.3.1: PermissionService publishes cache invalidation events after commit."""
+
+    async def test_create_permission_publishes_event(self):
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        repo = AsyncMock(spec=PermissionRepository)
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+        service = PermissionService(repository=repo, adapter=adapter, publisher=publisher)
+        repo.get_by_name.return_value = None
+        perm = _make_permission()
+        repo.create.return_value = perm
+        adapter.sync_permission.return_value = Ok(None)
+
+        result = await service.create_permission(name=perm.name)
+
+        assert result.is_ok()
+        publisher.publish.assert_awaited_once_with(entity_type="permission", entity_id=perm.id, operation="create")
+
+    async def test_delete_permission_publishes_event(self):
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        repo = AsyncMock(spec=PermissionRepository)
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+        service = PermissionService(repository=repo, adapter=adapter, publisher=publisher)
+        perm = _make_permission()
+        repo.get.return_value = perm
+        repo.delete.return_value = True
+        adapter.delete_permission.return_value = Ok(None)
+
+        result = await service.delete_permission(permission_id=perm.id)
+
+        assert result.is_ok()
+        publisher.publish.assert_awaited_once_with(entity_type="permission", entity_id=perm.id, operation="delete")
+
+    async def test_no_publish_on_failure(self):
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        repo = AsyncMock(spec=PermissionRepository)
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+        service = PermissionService(repository=repo, adapter=adapter, publisher=publisher)
+        repo.get.return_value = None  # Permission not found
+
+        result = await service.delete_permission(permission_id=uuid.uuid4())
+
+        assert result.is_error()
+        publisher.publish.assert_not_awaited()

--- a/backend/tests/unit/test_permissions_router.py
+++ b/backend/tests/unit/test_permissions_router.py
@@ -1,12 +1,20 @@
-"""Unit tests for the permissions router."""
+"""Unit tests for the permissions router.
 
+Story 2.3: tests rewired endpoints that use PermissionService via DI
+instead of get_descope_client().
+"""
+
+import uuid
 from unittest.mock import AsyncMock, patch
 
-import httpx
 import pytest
+from expression import Error, Ok
 from httpx import ASGITransport, AsyncClient
 
+from app.dependencies.identity import get_permission_service
+from app.errors.identity import Conflict, SyncFailed
 from app.main import app
+from app.services.permission import PermissionService
 
 
 @pytest.fixture
@@ -21,33 +29,49 @@ def _set_env(monkeypatch):
 
 
 @pytest.fixture
+def mock_permission_service():
+    return AsyncMock(spec=PermissionService)
+
+
+@pytest.fixture(autouse=True)
+def _override_permission_service(mock_permission_service):
+    app.dependency_overrides[get_permission_service] = lambda: mock_permission_service
+    yield
+    app.dependency_overrides.pop(get_permission_service, None)
+
+
+@pytest.fixture
 async def client():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
 
 
+TENANT_ID = "51c5957b-684a-453f-8ab1-8f239999c4d8"
+
 ADMIN_CLAIMS = {
     "sub": "user123",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {"roles": ["admin"], "permissions": ["settings.manage"]},
+        TENANT_ID: {"roles": ["admin"], "permissions": ["settings.manage"]},
     },
 }
 
 VIEWER_CLAIMS = {
     "sub": "user456",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {"roles": ["viewer"], "permissions": ["projects.read"]},
+        TENANT_ID: {"roles": ["viewer"], "permissions": ["projects.read"]},
     },
 }
 
 AUTH_HEADER = {"Authorization": "Bearer valid.token"}
 
+PERM_ID = str(uuid.uuid4())
+
 SAMPLE_PERMISSIONS = [
-    {"name": "reports.read", "description": "View reports"},
-    {"name": "reports.write", "description": "Edit reports"},
+    {"id": str(uuid.uuid4()), "name": "reports.read", "description": "View reports"},
+    {"id": str(uuid.uuid4()), "name": "reports.write", "description": "Edit reports"},
 ]
 
 
@@ -92,32 +116,37 @@ async def test_delete_permission_rejects_viewer(mock_validate, client):
     assert response.status_code == 403
 
 
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_permissions_rejected_without_tenant(mock_validate, client):
+    mock_validate.return_value = {"sub": "user789", "tenants": {}}
+    response = await client.get("/api/permissions", headers=AUTH_HEADER)
+    assert response.status_code == 403
+
+
 # --- Happy path ---
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_permissions(mock_validate, mock_factory, client):
+async def test_list_permissions(mock_validate, mock_permission_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.list_permissions.return_value = SAMPLE_PERMISSIONS
-    mock_factory.return_value = mock_client
+    mock_permission_service.list_permissions.return_value = Ok(SAMPLE_PERMISSIONS)
 
     response = await client.get("/api/permissions", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
-    assert data["permissions"] == SAMPLE_PERMISSIONS
-    mock_client.list_permissions.assert_called_once()
+    assert "permissions" in data
+    assert len(data["permissions"]) == 2
+    mock_permission_service.list_permissions.assert_awaited_once()
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_permission(mock_validate, mock_factory, client):
+async def test_create_permission(mock_validate, mock_permission_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    perm_dict = {"id": PERM_ID, "name": "reports.read", "description": "View reports"}
+    mock_permission_service.create_permission.return_value = Ok(perm_dict)
 
     response = await client.post(
         "/api/permissions",
@@ -128,16 +157,15 @@ async def test_create_permission(mock_validate, mock_factory, client):
     data = response.json()
     assert data["name"] == "reports.read"
     assert data["description"] == "View reports"
-    mock_client.create_permission.assert_called_once_with("reports.read", "View reports")
+    mock_permission_service.create_permission.assert_awaited_once_with(name="reports.read", description="View reports")
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_permission_default_description(mock_validate, mock_factory, client):
+async def test_create_permission_default_description(mock_validate, mock_permission_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    perm_dict = {"id": PERM_ID, "name": "reports.read", "description": ""}
+    mock_permission_service.create_permission.return_value = Ok(perm_dict)
 
     response = await client.post(
         "/api/permissions",
@@ -145,16 +173,18 @@ async def test_create_permission_default_description(mock_validate, mock_factory
         json={"name": "reports.read"},
     )
     assert response.status_code == 201
-    mock_client.create_permission.assert_called_once_with("reports.read", "")
+    mock_permission_service.create_permission.assert_awaited_once_with(name="reports.read", description="")
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_permission(mock_validate, mock_factory, client):
+async def test_update_permission(mock_validate, mock_permission_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    perm_id = str(uuid.uuid4())
+    mock_permission_service.list_permissions.return_value = Ok([{"id": perm_id, "name": "reports.read"}])
+    mock_permission_service.update_permission.return_value = Ok(
+        {"id": perm_id, "name": "reports.view", "description": "View reports"}
+    )
 
     response = await client.put(
         "/api/permissions/reports.read",
@@ -164,165 +194,67 @@ async def test_update_permission(mock_validate, mock_factory, client):
     assert response.status_code == 200
     data = response.json()
     assert data["name"] == "reports.view"
-    assert data["description"] == "View reports"
-    mock_client.update_permission.assert_called_once_with("reports.read", "reports.view", "View reports")
+    mock_permission_service.update_permission.assert_awaited_once()
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_permission(mock_validate, mock_factory, client):
+async def test_delete_permission(mock_validate, mock_permission_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    perm_id = str(uuid.uuid4())
+    mock_permission_service.list_permissions.return_value = Ok([{"id": perm_id, "name": "reports.read"}])
+    mock_permission_service.delete_permission.return_value = Ok({"status": "deleted", "name": "reports.read"})
 
     response = await client.delete("/api/permissions/reports.read", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "deleted"
     assert data["name"] == "reports.read"
-    mock_client.delete_permission.assert_called_once_with("reports.read")
 
 
 # --- Error handling ---
 
 
-def _make_http_status_error(status_code: int = 500) -> httpx.HTTPStatusError:
-    request = httpx.Request("POST", "https://api.descope.com/v1/mgmt/permission/create")
-    response = httpx.Response(status_code, request=request, text="error detail")
-    return httpx.HTTPStatusError(f"{status_code} Server Error", request=request, response=response)
-
-
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_permission_duplicate_returns_client_error(mock_validate, mock_factory, client):
-    """Descope returns 4xx for duplicate permission names — forwarded to caller."""
+async def test_create_permission_duplicate_returns_conflict(mock_validate, mock_permission_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_permission.side_effect = _make_http_status_error(400)
-    mock_factory.return_value = mock_client
+    mock_permission_service.create_permission.return_value = Error(
+        Conflict(message="Permission 'existing.perm' already exists")
+    )
 
     response = await client.post(
         "/api/permissions",
         headers=AUTH_HEADER,
         json={"name": "existing.perm"},
     )
-    assert response.status_code == 400
+    assert response.status_code == 409
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_permissions_descope_server_error(mock_validate, mock_factory, client):
-    """Descope 5xx → 502."""
+async def test_update_permission_not_found(mock_validate, mock_permission_service, client):
+    """Permission name not in list → 404."""
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.list_permissions.side_effect = _make_http_status_error(500)
-    mock_factory.return_value = mock_client
-
-    response = await client.get("/api/permissions", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_permission_network_error(mock_validate, mock_factory, client):
-    """Network error → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_permission.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/permissions",
-        headers=AUTH_HEADER,
-        json={"name": "test.perm"},
-    )
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_permission_descope_error(mock_validate, mock_factory, client):
-    """Descope 5xx on update → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.update_permission.side_effect = _make_http_status_error(500)
-    mock_factory.return_value = mock_client
+    mock_permission_service.list_permissions.return_value = Ok([])
 
     response = await client.put(
-        "/api/permissions/test.perm",
+        "/api/permissions/nonexistent",
         headers=AUTH_HEADER,
-        json={"new_name": "test.perm2"},
+        json={"new_name": "new-name"},
     )
-    assert response.status_code == 502
+    assert response.status_code == 404
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_permission_descope_error(mock_validate, mock_factory, client):
-    """Descope 5xx on delete → 502."""
+async def test_delete_permission_not_found(mock_validate, mock_permission_service, client):
+    """Permission name not in list → 404."""
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.delete_permission.side_effect = _make_http_status_error(500)
-    mock_factory.return_value = mock_client
+    mock_permission_service.list_permissions.return_value = Ok([])
 
-    response = await client.delete("/api/permissions/test.perm", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_permission_network_error(mock_validate, mock_factory, client):
-    """Network error on delete → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.delete_permission.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.delete("/api/permissions/test.perm", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_permission_network_error(mock_validate, mock_factory, client):
-    """Network error on update → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.update_permission.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.put(
-        "/api/permissions/test.perm",
-        headers=AUTH_HEADER,
-        json={"new_name": "test.perm2"},
-    )
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_permission_descope_401_becomes_502(mock_validate, mock_factory, client):
-    """Descope 401 (e.g. expired mgmt key) should not be forwarded — returns 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_permission.side_effect = _make_http_status_error(401)
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/permissions",
-        headers=AUTH_HEADER,
-        json={"name": "test.perm"},
-    )
-    assert response.status_code == 502
+    response = await client.delete("/api/permissions/nonexistent", headers=AUTH_HEADER)
+    assert response.status_code == 404
 
 
 # --- Input validation ---
@@ -352,12 +284,32 @@ async def test_update_permission_empty_new_name_rejected(mock_validate, client):
     assert response.status_code == 422
 
 
-# --- No tenant context ---
+# --- SyncFailed → 207 Multi-Status ---
 
 
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_permissions_rejected_without_tenant(mock_validate, client):
-    mock_validate.return_value = {"sub": "user789", "tenants": {}}
-    response = await client.get("/api/permissions", headers=AUTH_HEADER)
-    assert response.status_code == 403
+async def test_create_permission_sync_failed_returns_207(mock_validate, mock_permission_service, client):
+    """Service returns SyncFailed (DB write ok, IdP sync failed) → 207 Multi-Status."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_permission_service.create_permission.return_value = Error(
+        SyncFailed(
+            message="Descope sync failed for permission creation",
+            operation="create_permission",
+            underlying_error="httpx.ConnectError",
+        )
+    )
+
+    response = await client.post(
+        "/api/permissions",
+        headers=AUTH_HEADER,
+        json={"name": "new.perm"},
+    )
+    assert response.status_code == 207
+    assert response.headers["content-type"].startswith("application/problem+json")
+    body = response.json()
+    assert body["type"] == "/errors/sync-failed"
+    assert body["title"] == "Sync Partial Success"
+    assert body["status"] == 207
+    assert "succeeded" in body["detail"]
+    assert "synchronisation failed" in body["detail"]

--- a/backend/tests/unit/test_provider_service.py
+++ b/backend/tests/unit/test_provider_service.py
@@ -1,0 +1,258 @@
+"""Unit tests for ProviderService domain orchestration (Stories 4.1 + 4.2).
+
+Tests cover:
+- register_provider: happy path, duplicate name → Conflict, integrity error → Conflict
+- list_providers: returns providers with config_ref stripped; empty list
+- deactivate_provider: found → deactivated; already-inactive → idempotent Ok; not found → NotFound
+- get_provider_capabilities: found → capabilities list; not found → NotFound
+"""
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.errors.identity import Conflict, NotFound
+from app.models.identity.provider import Provider, ProviderType
+from app.repositories.provider import ProviderRepository
+from app.repositories.user import RepositoryConflictError
+from app.services.provider import ProviderService
+
+
+def _make_provider(**overrides) -> Provider:
+    """Create a Provider with sensible defaults."""
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": "descope-prod",
+        "type": ProviderType.descope,
+        "issuer_url": "https://api.descope.com/P123",
+        "base_url": "https://api.descope.com",
+        "capabilities": ["sso", "mfa", "rbac"],
+        "config_ref": "infisical://descope-prod",
+        "active": True,
+    }
+    defaults.update(overrides)
+    return Provider(**defaults)
+
+
+def _build_service(
+    repo: AsyncMock | None = None,
+) -> tuple[ProviderService, AsyncMock]:
+    """Build a ProviderService with a mocked repository."""
+    if repo is None:
+        repo = AsyncMock(spec=ProviderRepository)
+    service = ProviderService(repository=repo)
+    return service, repo
+
+
+@pytest.mark.anyio
+class TestRegisterProvider:
+    """AC-4.1.2: register_provider stores config_ref, not credentials."""
+
+    async def test_register_success(self):
+        service, repo = _build_service()
+        provider = _make_provider()
+        repo.get_by_name.return_value = None
+        repo.create.return_value = provider
+
+        result = await service.register_provider(
+            name=provider.name,
+            type=provider.type,
+            issuer_url=provider.issuer_url,
+            base_url=provider.base_url,
+            capabilities=provider.capabilities,
+            config_ref=provider.config_ref,
+        )
+
+        assert result.is_ok()
+        assert result.ok["name"] == provider.name
+        assert "config_ref" not in result.ok  # config_ref stripped at service layer
+        repo.get_by_name.assert_awaited_once_with(provider.name)
+        repo.create.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+
+    async def test_register_duplicate_name_returns_conflict(self):
+        service, repo = _build_service()
+        repo.get_by_name.return_value = _make_provider()
+
+        result = await service.register_provider(
+            name="descope-prod",
+            type=ProviderType.descope,
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        assert "already exists" in result.error.message
+        repo.create.assert_not_awaited()
+
+    async def test_register_integrity_error_returns_conflict(self):
+        """TOCTOU race: get_by_name returns None but create raises IntegrityError."""
+        service, repo = _build_service()
+        repo.get_by_name.return_value = None
+        repo.create.side_effect = RepositoryConflictError("duplicate key")
+
+        result = await service.register_provider(
+            name="descope-prod",
+            type=ProviderType.descope,
+        )
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        repo.commit.assert_not_awaited()
+
+    async def test_register_defaults_empty_capabilities(self):
+        """Capabilities default to empty list when None is passed."""
+        service, repo = _build_service()
+        repo.get_by_name.return_value = None
+        provider = _make_provider(capabilities=[])
+        repo.create.return_value = provider
+
+        result = await service.register_provider(
+            name="bare-provider",
+            type=ProviderType.oidc,
+        )
+
+        assert result.is_ok()
+        # Verify the Provider constructor received empty list
+        created_arg = repo.create.call_args[0][0]
+        assert created_arg.capabilities == []
+
+
+@pytest.mark.anyio
+class TestListProviders:
+    """AC-4.2.2: list_providers returns all providers with config_ref stripped."""
+
+    async def test_list_returns_providers_without_config_ref(self):
+        service, repo = _build_service()
+        providers = [
+            _make_provider(name="alpha-provider"),
+            _make_provider(name="beta-provider"),
+        ]
+        repo.list_all.return_value = providers
+
+        result = await service.list_providers()
+
+        assert result.is_ok()
+        assert len(result.ok) == 2
+        for d in result.ok:
+            assert "config_ref" not in d
+        repo.list_all.assert_awaited_once()
+
+    async def test_list_empty(self):
+        service, repo = _build_service()
+        repo.list_all.return_value = []
+
+        result = await service.list_providers()
+
+        assert result.is_ok()
+        assert result.ok == []
+
+    async def test_list_preserves_other_fields(self):
+        """All fields except config_ref are preserved in the response."""
+        service, repo = _build_service()
+        provider = _make_provider(
+            name="test-provider",
+            capabilities=["sso", "mfa"],
+            config_ref="infisical://secret",
+        )
+        repo.list_all.return_value = [provider]
+
+        result = await service.list_providers()
+
+        assert result.is_ok()
+        d = result.ok[0]
+        assert d["name"] == "test-provider"
+        assert d["capabilities"] == ["sso", "mfa"]
+        assert "config_ref" not in d
+
+
+@pytest.mark.anyio
+class TestDeactivateProvider:
+    """AC-4.1.2: deactivate_provider sets active=False, idempotent for already-inactive."""
+
+    async def test_deactivate_success(self):
+        service, repo = _build_service()
+        provider = _make_provider(active=True)
+        repo.get.return_value = provider
+        repo.update.return_value = provider
+
+        result = await service.deactivate_provider(provider_id=provider.id)
+
+        assert result.is_ok()
+        assert provider.active is False
+        assert "config_ref" not in result.ok  # config_ref stripped at service layer
+        repo.update.assert_awaited_once_with(provider)
+        repo.commit.assert_awaited_once()
+
+    async def test_deactivate_already_inactive_is_idempotent(self):
+        """Deactivating an already-inactive provider short-circuits without writing."""
+        service, repo = _build_service()
+        provider = _make_provider(active=False)
+        repo.get.return_value = provider
+
+        result = await service.deactivate_provider(provider_id=provider.id)
+
+        assert result.is_ok()
+        assert provider.active is False
+        assert "config_ref" not in result.ok  # config_ref stripped at service layer
+        repo.update.assert_not_awaited()
+        repo.commit.assert_not_awaited()
+
+    async def test_deactivate_not_found(self):
+        service, repo = _build_service()
+        repo.get.return_value = None
+
+        result = await service.deactivate_provider(provider_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        repo.update.assert_not_awaited()
+
+    async def test_deactivate_conflict_returns_error(self):
+        """RepositoryConflictError on update is caught and returned as Conflict."""
+        service, repo = _build_service()
+        provider = _make_provider(active=True)
+        repo.get.return_value = provider
+        repo.update.side_effect = RepositoryConflictError("constraint violation")
+
+        result = await service.deactivate_provider(provider_id=provider.id)
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        repo.commit.assert_not_awaited()
+
+
+@pytest.mark.anyio
+class TestGetProviderCapabilities:
+    """AC-4.1.2: get_provider_capabilities returns the capabilities list."""
+
+    async def test_get_capabilities_success(self):
+        service, repo = _build_service()
+        capabilities = ["sso", "mfa", "rbac"]
+        provider = _make_provider(capabilities=capabilities)
+        repo.get.return_value = provider
+
+        result = await service.get_provider_capabilities(provider_id=provider.id)
+
+        assert result.is_ok()
+        assert result.ok == capabilities
+        repo.get.assert_awaited_once_with(provider.id)
+
+    async def test_get_capabilities_empty(self):
+        service, repo = _build_service()
+        provider = _make_provider(capabilities=[])
+        repo.get.return_value = provider
+
+        result = await service.get_provider_capabilities(provider_id=provider.id)
+
+        assert result.is_ok()
+        assert result.ok == []
+
+    async def test_get_capabilities_not_found(self):
+        service, repo = _build_service()
+        repo.get.return_value = None
+
+        result = await service.get_provider_capabilities(provider_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)

--- a/backend/tests/unit/test_providers_router.py
+++ b/backend/tests/unit/test_providers_router.py
@@ -1,0 +1,349 @@
+"""Unit tests for the providers router (Story 4.2).
+
+Tests cover:
+- Auth enforcement: unauthenticated → 401, wrong role → 403, no tenant → 403
+- Happy paths: list, register, deactivate, capabilities
+- Error handling: Conflict → 409, NotFound → 404
+- Input validation: invalid UUID → 422, active=true rejected
+- Security: config_ref stripped from all responses
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from expression import Error, Ok
+from httpx import ASGITransport, AsyncClient
+
+from app.dependencies.identity import get_provider_service
+from app.errors.identity import Conflict, NotFound
+from app.main import app
+from app.services.provider import ProviderService
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _set_env(monkeypatch):
+    monkeypatch.setenv("DESCOPE_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("DESCOPE_MANAGEMENT_KEY", "test-management-key")
+
+
+@pytest.fixture
+def mock_provider_service():
+    return AsyncMock(spec=ProviderService)
+
+
+@pytest.fixture(autouse=True)
+def _override_services(mock_provider_service):
+    app.dependency_overrides[get_provider_service] = lambda: mock_provider_service
+    yield
+    app.dependency_overrides.pop(get_provider_service, None)
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+TENANT_ID = "51c5957b-684a-453f-8ab1-8f239999c4d8"
+
+OPERATOR_CLAIMS = {
+    "sub": "operator1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["operator"], "permissions": []},
+    },
+}
+
+ADMIN_CLAIMS = {
+    "sub": "admin1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["admin"], "permissions": []},
+    },
+}
+
+VIEWER_CLAIMS = {
+    "sub": "viewer1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["viewer"], "permissions": []},
+    },
+}
+
+AUTH_HEADER = {"Authorization": "Bearer valid.token"}
+
+SAMPLE_PROVIDER = {
+    "id": str(uuid.uuid4()),
+    "name": "descope-prod",
+    "type": "descope",
+    "issuer_url": "https://api.descope.com/P123",
+    "base_url": "https://api.descope.com",
+    "capabilities": ["sso", "mfa"],
+    "active": True,
+}
+
+
+# --- Auth enforcement ---
+
+
+@pytest.mark.anyio
+async def test_list_providers_rejects_unauthenticated(client):
+    response = await client.get("/api/providers")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_register_provider_rejects_unauthenticated(client):
+    response = await client.post("/api/providers", json={"name": "test", "type": "descope"})
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_deactivate_provider_rejects_unauthenticated(client):
+    pid = str(uuid.uuid4())
+    response = await client.patch(f"/api/providers/{pid}", json={"active": False})
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_capabilities_rejects_unauthenticated(client):
+    pid = str(uuid.uuid4())
+    response = await client.get(f"/api/providers/{pid}/capabilities")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_providers_rejected_for_admin(mock_validate, client):
+    """Operator-only endpoints reject admin role."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.get("/api/providers", headers=AUTH_HEADER)
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_register_provider_rejected_for_viewer(mock_validate, client):
+    mock_validate.return_value = VIEWER_CLAIMS
+    response = await client.post(
+        "/api/providers",
+        headers=AUTH_HEADER,
+        json={"name": "test", "type": "descope"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_providers_rejected_without_tenant(mock_validate, client):
+    mock_validate.return_value = {"sub": "user1", "tenants": {}}
+    response = await client.get("/api/providers", headers=AUTH_HEADER)
+    assert response.status_code == 403
+
+
+# --- Happy paths ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_providers(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    providers = [SAMPLE_PROVIDER, {**SAMPLE_PROVIDER, "name": "ory-prod"}]
+    mock_provider_service.list_providers.return_value = Ok(providers)
+
+    response = await client.get("/api/providers", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+    mock_provider_service.list_providers.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_providers_empty(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    mock_provider_service.list_providers.return_value = Ok([])
+
+    response = await client.get("/api/providers", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_register_provider(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    # Service layer now strips config_ref before returning
+    mock_provider_service.register_provider.return_value = Ok(SAMPLE_PROVIDER)
+
+    response = await client.post(
+        "/api/providers",
+        headers=AUTH_HEADER,
+        json={"name": "descope-prod", "type": "descope", "config_ref": "infisical://secret"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "descope-prod"
+    assert "config_ref" not in data
+    mock_provider_service.register_provider.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_provider(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    pid = str(uuid.uuid4())
+    # Service layer now strips config_ref before returning
+    mock_provider_service.deactivate_provider.return_value = Ok({**SAMPLE_PROVIDER, "id": pid, "active": False})
+
+    response = await client.patch(
+        f"/api/providers/{pid}",
+        headers=AUTH_HEADER,
+        json={"active": False},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["active"] is False
+    assert "config_ref" not in data
+    mock_provider_service.deactivate_provider.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_get_capabilities(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    pid = str(uuid.uuid4())
+    mock_provider_service.get_provider_capabilities.return_value = Ok(["sso", "mfa", "rbac"])
+
+    response = await client.get(
+        f"/api/providers/{pid}/capabilities",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 200
+    assert response.json() == ["sso", "mfa", "rbac"]
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_get_capabilities_empty(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    pid = str(uuid.uuid4())
+    mock_provider_service.get_provider_capabilities.return_value = Ok([])
+
+    response = await client.get(
+        f"/api/providers/{pid}/capabilities",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+# --- Error handling ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_register_provider_conflict(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    mock_provider_service.register_provider.return_value = Error(
+        Conflict(message="Provider 'descope-prod' already exists")
+    )
+
+    response = await client.post(
+        "/api/providers",
+        headers=AUTH_HEADER,
+        json={"name": "descope-prod", "type": "descope"},
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_provider_not_found(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    pid = str(uuid.uuid4())
+    mock_provider_service.deactivate_provider.return_value = Error(NotFound(message=f"Provider '{pid}' not found"))
+
+    response = await client.patch(
+        f"/api/providers/{pid}",
+        headers=AUTH_HEADER,
+        json={"active": False},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_capabilities_not_found(mock_validate, mock_provider_service, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    pid = str(uuid.uuid4())
+    mock_provider_service.get_provider_capabilities.return_value = Error(
+        NotFound(message=f"Provider '{pid}' not found")
+    )
+
+    response = await client.get(
+        f"/api/providers/{pid}/capabilities",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 404
+
+
+# --- Input validation ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_invalid_uuid_returns_422(mock_validate, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    response = await client.patch(
+        "/api/providers/not-a-uuid",
+        headers=AUTH_HEADER,
+        json={"active": False},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_capabilities_invalid_uuid_returns_422(mock_validate, client):
+    mock_validate.return_value = OPERATOR_CLAIMS
+    response = await client.get(
+        "/api/providers/not-a-uuid/capabilities",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_active_true_rejected(mock_validate, client):
+    """PATCH /providers/{id} only supports active=false."""
+    mock_validate.return_value = OPERATOR_CLAIMS
+    pid = str(uuid.uuid4())
+    response = await client.patch(
+        f"/api/providers/{pid}",
+        headers=AUTH_HEADER,
+        json={"active": True},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_register_provider_empty_name_rejected(mock_validate, client):
+    """Name field requires min_length=1."""
+    mock_validate.return_value = OPERATOR_CLAIMS
+    response = await client.post(
+        "/api/providers",
+        headers=AUTH_HEADER,
+        json={"name": "", "type": "descope"},
+    )
+    assert response.status_code == 422

--- a/backend/tests/unit/test_reconciliation_router.py
+++ b/backend/tests/unit/test_reconciliation_router.py
@@ -1,0 +1,175 @@
+"""Unit tests for the reconciliation router (Story 3.2).
+
+Tests cover:
+- POST /api/internal/reconciliation/run — trigger endpoint
+- Flow sync secret validation (missing, invalid, unconfigured)
+- Success response, ProviderError → 502, Conflict → 409
+- Internal endpoint bypasses JWT auth
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from expression import Error, Ok
+from httpx import ASGITransport, AsyncClient
+
+from app.dependencies.identity import get_reconciliation_service
+from app.errors.identity import Conflict, ProviderError
+from app.main import app
+from app.services.reconciliation import ReconciliationService
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _set_env(monkeypatch):
+    monkeypatch.setenv("DESCOPE_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("DESCOPE_MANAGEMENT_KEY", "test-management-key")
+
+
+FLOW_SECRET = "test-flow-sync-secret"
+
+
+@pytest.fixture
+def mock_recon_service():
+    return AsyncMock(spec=ReconciliationService)
+
+
+@pytest.fixture(autouse=True)
+def _override_services(mock_recon_service):
+    app.dependency_overrides[get_reconciliation_service] = lambda: mock_recon_service
+    yield
+    app.dependency_overrides.pop(get_reconciliation_service, None)
+
+
+@pytest.fixture(autouse=True)
+def _set_flow_secret():
+    import app.routers.internal as mod
+
+    mod._FLOW_SYNC_SECRET = FLOW_SECRET
+    yield
+    mod._FLOW_SYNC_SECRET = ""
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _headers():
+    return {"X-Flow-Secret": FLOW_SECRET}
+
+
+# --- Auth enforcement ---
+
+
+@pytest.mark.anyio
+async def test_reconciliation_no_jwt_required(mock_recon_service, client):
+    """Internal endpoint bypasses JWT auth — needs X-Flow-Secret, not Authorization."""
+    mock_recon_service.run.return_value = Ok({"status": "completed", "stats": {}})
+
+    response = await client.post(
+        "/api/internal/reconciliation/run",
+        headers=_headers(),
+    )
+
+    assert response.status_code == 200
+    mock_recon_service.run.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_reconciliation_missing_secret_header_returns_422(client):
+    """Missing X-Flow-Secret header → 422 (FastAPI header validation)."""
+    response = await client.post("/api/internal/reconciliation/run")
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_reconciliation_invalid_secret_returns_401(client):
+    """Invalid X-Flow-Secret → 401."""
+    response = await client.post(
+        "/api/internal/reconciliation/run",
+        headers={"X-Flow-Secret": "wrong-secret"},
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_reconciliation_unconfigured_secret_returns_401(client):
+    """DESCOPE_FLOW_SYNC_SECRET empty → 401."""
+    import app.routers.internal as mod
+
+    mod._FLOW_SYNC_SECRET = ""
+
+    response = await client.post(
+        "/api/internal/reconciliation/run",
+        headers={"X-Flow-Secret": "any-value"},
+    )
+
+    assert response.status_code == 401
+
+
+# --- Success ---
+
+
+@pytest.mark.anyio
+async def test_reconciliation_success_returns_stats(mock_recon_service, client):
+    stats = {
+        "tenants_created": 1,
+        "tenants_updated": 0,
+        "permissions_created": 2,
+        "permissions_updated": 0,
+        "roles_created": 1,
+        "roles_updated": 0,
+        "users_created": 3,
+        "users_updated": 1,
+        "links_created": 3,
+    }
+    mock_recon_service.run.return_value = Ok({"status": "completed", "stats": stats})
+
+    response = await client.post(
+        "/api/internal/reconciliation/run",
+        headers=_headers(),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "completed"
+    assert data["stats"]["users_created"] == 3
+
+
+# --- Error responses ---
+
+
+@pytest.mark.anyio
+async def test_reconciliation_provider_error_returns_502(mock_recon_service, client):
+    """Descope API unavailable → 502 Problem Detail."""
+    mock_recon_service.run.return_value = Error(ProviderError(message="Descope API unavailable"))
+
+    response = await client.post(
+        "/api/internal/reconciliation/run",
+        headers=_headers(),
+    )
+
+    assert response.status_code == 502
+    assert response.headers["content-type"].startswith("application/problem+json")
+
+
+@pytest.mark.anyio
+async def test_reconciliation_conflict_returns_409(mock_recon_service, client):
+    """Reconciliation conflict → 409."""
+    mock_recon_service.run.return_value = Error(Conflict(message="Lock contention"))
+
+    response = await client.post(
+        "/api/internal/reconciliation/run",
+        headers=_headers(),
+    )
+
+    assert response.status_code == 409

--- a/backend/tests/unit/test_reconciliation_service.py
+++ b/backend/tests/unit/test_reconciliation_service.py
@@ -1,0 +1,869 @@
+"""Unit tests for ReconciliationService domain orchestration (Story 3.2).
+
+Tests cover:
+- run: full reconciliation pass, advisory lock, Descope fetch failure, commit failure
+- _reconcile_tenants: create, update, skip empty name, conflict on create
+- _reconcile_permissions: create, update, skip empty name, conflict on create
+- _reconcile_roles: create, update, skip empty name, conflict on create
+- _reconcile_users: create user + IdP link, update user, status mapping,
+  name splitting, skip missing email/userId, provider not configured,
+  conflict on create/update, duplicate link skip
+"""
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.errors.identity import ProviderError
+from app.models.identity.provider import Provider, ProviderType
+from app.models.identity.role import Permission, Role
+from app.models.identity.tenant import Tenant, TenantStatus
+from app.models.identity.user import User, UserStatus
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.permission import PermissionRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.role import RoleRepository
+from app.repositories.tenant import TenantRepository
+from app.repositories.user import RepositoryConflictError, UserRepository
+from app.services.cache_invalidation import CacheInvalidationPublisher
+from app.services.descope import DescopeManagementClient
+from app.services.reconciliation import ReconciliationService
+
+
+@asynccontextmanager
+async def _noop_nested():
+    """Mock for session.begin_nested() — savepoint that lets exceptions propagate."""
+    yield
+
+
+PROVIDER_ID = uuid.uuid4()
+
+
+def _make_provider(**overrides) -> Provider:
+    defaults = {"id": PROVIDER_ID, "name": "descope", "type": ProviderType.descope}
+    defaults.update(overrides)
+    return Provider(**defaults)
+
+
+def _make_user(**overrides) -> User:
+    defaults = {
+        "id": uuid.uuid4(),
+        "email": "alice@example.com",
+        "user_name": "alice@example.com",
+        "given_name": "Alice",
+        "family_name": "Smith",
+        "status": UserStatus.active,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _make_tenant(**overrides) -> Tenant:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"tenant-{uuid.uuid4().hex[:8]}",
+        "domains": [],
+        "status": TenantStatus.active,
+    }
+    defaults.update(overrides)
+    return Tenant(**defaults)
+
+
+def _make_role(**overrides) -> Role:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"role-{uuid.uuid4().hex[:8]}",
+        "description": "A role",
+        "tenant_id": None,
+    }
+    defaults.update(overrides)
+    return Role(**defaults)
+
+
+def _make_permission(**overrides) -> Permission:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"perm-{uuid.uuid4().hex[:8]}",
+        "description": "A permission",
+    }
+    defaults.update(overrides)
+    return Permission(**defaults)
+
+
+def _build_service(
+    session: AsyncMock | None = None,
+    acquire_lock: AsyncMock | None = None,
+    descope_client: AsyncMock | None = None,
+    user_repo: AsyncMock | None = None,
+    role_repo: AsyncMock | None = None,
+    perm_repo: AsyncMock | None = None,
+    tenant_repo: AsyncMock | None = None,
+    link_repo: AsyncMock | None = None,
+    provider_repo: AsyncMock | None = None,
+) -> tuple[ReconciliationService, dict[str, AsyncMock]]:
+    if session is None:
+        session = AsyncMock()
+        session.begin_nested = _noop_nested
+    if acquire_lock is None:
+        acquire_lock = AsyncMock()
+    if descope_client is None:
+        descope_client = AsyncMock(spec=DescopeManagementClient)
+    if user_repo is None:
+        user_repo = AsyncMock(spec=UserRepository)
+    if role_repo is None:
+        role_repo = AsyncMock(spec=RoleRepository)
+    if perm_repo is None:
+        perm_repo = AsyncMock(spec=PermissionRepository)
+    if tenant_repo is None:
+        tenant_repo = AsyncMock(spec=TenantRepository)
+    if link_repo is None:
+        link_repo = AsyncMock(spec=IdPLinkRepository)
+    if provider_repo is None:
+        provider_repo = AsyncMock(spec=ProviderRepository)
+
+    service = ReconciliationService(
+        session=session,
+        acquire_lock=acquire_lock,
+        descope_client=descope_client,
+        user_repository=user_repo,
+        role_repository=role_repo,
+        permission_repository=perm_repo,
+        tenant_repository=tenant_repo,
+        idp_link_repository=link_repo,
+        provider_repository=provider_repo,
+    )
+    mocks = {
+        "session": session,
+        "acquire_lock": acquire_lock,
+        "descope": descope_client,
+        "user_repo": user_repo,
+        "role_repo": role_repo,
+        "perm_repo": perm_repo,
+        "tenant_repo": tenant_repo,
+        "link_repo": link_repo,
+        "provider_repo": provider_repo,
+    }
+    return service, mocks
+
+
+def _empty_descope_state(mocks: dict[str, AsyncMock]) -> None:
+    """Configure Descope client to return empty lists for all entity types."""
+    mocks["descope"].search_all_users.return_value = []
+    mocks["descope"].list_roles.return_value = []
+    mocks["descope"].list_permissions.return_value = []
+    mocks["descope"].list_tenants.return_value = []
+
+
+def _empty_canonical_state(mocks: dict[str, AsyncMock]) -> None:
+    """Configure repos to return empty lists for all entity types."""
+    mocks["tenant_repo"].list_all.return_value = []
+    mocks["perm_repo"].list_all.return_value = []
+    mocks["role_repo"].list_by_tenant.return_value = []
+    mocks["user_repo"].list_all.return_value = []
+    mocks["provider_repo"].get_by_type.return_value = _make_provider()
+
+
+@pytest.mark.anyio
+class TestRun:
+    """AC-3.2.1 through AC-3.2.5: Full reconciliation orchestration."""
+
+    async def test_run_empty_state_returns_zero_stats(self):
+        """No Descope entities, no canonical entities → all stats zero."""
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+
+        result = await service.run()
+
+        assert result.is_ok()
+        stats = result.ok["stats"]
+        assert all(v == 0 for v in stats.values())
+        assert result.ok["status"] == "completed"
+        mocks["session"].commit.assert_awaited_once()
+
+    async def test_run_advisory_lock_failure_returns_error(self):
+        """AC-3.2.2: Lock acquisition failure → ProviderError, no modifications."""
+        lock_fn = AsyncMock(side_effect=RuntimeError("lock unavailable"))
+        service, mocks = _build_service(acquire_lock=lock_fn)
+
+        result = await service.run()
+
+        assert result.is_error()
+        assert isinstance(result.error, ProviderError)
+        assert "lock" in result.error.message.lower()
+        # No Descope calls should be made
+        mocks["descope"].search_all_users.assert_not_awaited()
+
+    async def test_run_descope_fetch_failure_aborts(self):
+        """AC-3.2.3: Descope API failure → ProviderError, no canonical changes."""
+        service, mocks = _build_service()
+        mocks["descope"].search_all_users.side_effect = RuntimeError("connection refused")
+
+        result = await service.run()
+
+        assert result.is_error()
+        assert isinstance(result.error, ProviderError)
+        assert "unavailable" in result.error.message.lower()
+        # No repo calls should happen
+        mocks["tenant_repo"].list_all.assert_not_awaited()
+        mocks["session"].commit.assert_not_awaited()
+
+    async def test_run_descope_partial_fetch_failure_aborts(self):
+        """If list_tenants succeeds but list_roles fails → still abort."""
+        service, mocks = _build_service()
+        mocks["descope"].search_all_users.return_value = []
+        mocks["descope"].list_roles.side_effect = RuntimeError("timeout")
+
+        result = await service.run()
+
+        assert result.is_error()
+        assert isinstance(result.error, ProviderError)
+        mocks["session"].commit.assert_not_awaited()
+
+    async def test_run_commit_failure_returns_error(self):
+        """Commit failure after successful reconciliation → ProviderError."""
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["session"].commit.side_effect = RuntimeError("database gone")
+
+        result = await service.run()
+
+        assert result.is_error()
+        assert isinstance(result.error, ProviderError)
+        assert "commit" in result.error.message.lower()
+
+    async def test_run_creates_tenants_permissions_roles_users(self):
+        """Full pass creates all entity types."""
+        service, mocks = _build_service()
+        mocks["descope"].list_tenants.return_value = [{"name": "Acme", "selfProvisioningDomains": ["acme.com"]}]
+        mocks["descope"].list_permissions.return_value = [{"name": "docs.read", "description": "Read docs"}]
+        mocks["descope"].list_roles.return_value = [{"name": "admin", "description": "Admin role"}]
+        mocks["descope"].search_all_users.return_value = [
+            {"userId": "ext-1", "email": "a@b.com", "name": "Alice Smith", "status": "enabled"}
+        ]
+
+        # Canonical state is empty
+        mocks["tenant_repo"].list_all.return_value = []
+        mocks["perm_repo"].list_all.return_value = []
+        mocks["role_repo"].list_by_tenant.return_value = []
+        mocks["user_repo"].list_all.return_value = []
+        provider = _make_provider()
+        mocks["provider_repo"].get_by_type.return_value = provider
+        mocks["link_repo"].get_by_provider_and_sub.return_value = None
+
+        result = await service.run()
+
+        assert result.is_ok()
+        stats = result.ok["stats"]
+        assert stats["tenants_created"] == 1
+        assert stats["permissions_created"] == 1
+        assert stats["roles_created"] == 1
+        assert stats["users_created"] == 1
+        assert stats["links_created"] == 1
+        mocks["session"].commit.assert_awaited_once()
+
+    async def test_run_reconciles_in_dependency_order(self):
+        """Tenants → permissions → roles → users (dependency order)."""
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+
+        call_order: list[str] = []
+        mocks["tenant_repo"].list_all.side_effect = lambda: (call_order.append("tenants"), [])[-1]
+        mocks["perm_repo"].list_all.side_effect = lambda: (call_order.append("permissions"), [])[-1]
+        mocks["role_repo"].list_by_tenant.side_effect = lambda tenant_id: (call_order.append("roles"), [])[-1]
+        mocks["user_repo"].list_all.side_effect = lambda: (call_order.append("users"), [])[-1]
+        mocks["provider_repo"].get_by_type.return_value = _make_provider()
+
+        await service.run()
+
+        assert call_order == ["tenants", "permissions", "roles", "users"]
+
+
+@pytest.mark.anyio
+class TestReconcileTenants:
+    """AC-3.2.1: Tenant drift detection and resolution."""
+
+    async def test_create_new_tenant(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].list_tenants.return_value = [{"name": "Acme", "selfProvisioningDomains": ["acme.com"]}]
+        mocks["tenant_repo"].list_all.return_value = []
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["tenants_created"] == 1
+        mocks["tenant_repo"].create.assert_awaited_once()
+        created = mocks["tenant_repo"].create.call_args[0][0]
+        assert created.name == "Acme"
+        assert created.domains == ["acme.com"]
+
+    async def test_update_tenant_domains(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        existing = _make_tenant(name="Acme", domains=["old.com"])
+        mocks["descope"].list_tenants.return_value = [{"name": "Acme", "selfProvisioningDomains": ["new.com"]}]
+        mocks["tenant_repo"].list_all.return_value = [existing]
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["tenants_updated"] == 1
+        assert existing.domains == ["new.com"]
+        mocks["tenant_repo"].update.assert_awaited_once()
+
+    async def test_no_change_tenant_not_updated(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        existing = _make_tenant(name="Acme", domains=["acme.com"])
+        mocks["descope"].list_tenants.return_value = [{"name": "Acme", "selfProvisioningDomains": ["acme.com"]}]
+        mocks["tenant_repo"].list_all.return_value = [existing]
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["tenants_updated"] == 0
+        mocks["tenant_repo"].update.assert_not_awaited()
+
+    async def test_skip_empty_tenant_name(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].list_tenants.return_value = [{"name": "", "selfProvisioningDomains": []}]
+        mocks["tenant_repo"].list_all.return_value = []
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["tenants_created"] == 0
+        mocks["tenant_repo"].create.assert_not_awaited()
+
+    async def test_tenant_conflict_on_create_skips(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].list_tenants.return_value = [{"name": "Acme"}]
+        mocks["tenant_repo"].list_all.return_value = []
+        mocks["tenant_repo"].create.side_effect = RepositoryConflictError("duplicate")
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["tenants_created"] == 0
+
+    async def test_missing_domains_defaults_to_empty_list(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].list_tenants.return_value = [{"name": "Acme"}]
+        mocks["tenant_repo"].list_all.return_value = []
+
+        await service.run()
+
+        created = mocks["tenant_repo"].create.call_args[0][0]
+        assert created.domains == []
+
+
+@pytest.mark.anyio
+class TestReconcilePermissions:
+    """AC-3.2.1: Permission drift detection and resolution."""
+
+    async def test_create_new_permission(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].list_permissions.return_value = [{"name": "docs.read", "description": "Read documents"}]
+        mocks["perm_repo"].list_all.return_value = []
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["permissions_created"] == 1
+        created = mocks["perm_repo"].create.call_args[0][0]
+        assert created.name == "docs.read"
+        assert created.description == "Read documents"
+
+    async def test_update_permission_description(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        existing = _make_permission(name="docs.read", description="Old desc")
+        mocks["descope"].list_permissions.return_value = [{"name": "docs.read", "description": "New desc"}]
+        mocks["perm_repo"].list_all.return_value = [existing]
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["permissions_updated"] == 1
+        assert existing.description == "New desc"
+
+    async def test_no_change_permission_not_updated(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        existing = _make_permission(name="docs.read", description="Same")
+        mocks["descope"].list_permissions.return_value = [{"name": "docs.read", "description": "Same"}]
+        mocks["perm_repo"].list_all.return_value = [existing]
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["permissions_updated"] == 0
+
+    async def test_skip_empty_permission_name(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].list_permissions.return_value = [{"name": ""}]
+        mocks["perm_repo"].list_all.return_value = []
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["permissions_created"] == 0
+
+    async def test_permission_conflict_on_create_skips(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].list_permissions.return_value = [{"name": "docs.read"}]
+        mocks["perm_repo"].list_all.return_value = []
+        mocks["perm_repo"].create.side_effect = RepositoryConflictError("duplicate")
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["permissions_created"] == 0
+
+
+@pytest.mark.anyio
+class TestReconcileRoles:
+    """AC-3.2.1: Role drift detection and resolution (global roles only)."""
+
+    async def test_create_new_role(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].list_roles.return_value = [{"name": "admin", "description": "Administrator"}]
+        mocks["role_repo"].list_by_tenant.return_value = []
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["roles_created"] == 1
+        created = mocks["role_repo"].create.call_args[0][0]
+        assert created.name == "admin"
+        assert created.tenant_id is None  # Global role
+
+    async def test_update_role_description(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        existing = _make_role(name="admin", description="Old")
+        mocks["descope"].list_roles.return_value = [{"name": "admin", "description": "New"}]
+        mocks["role_repo"].list_by_tenant.return_value = [existing]
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["roles_updated"] == 1
+        assert existing.description == "New"
+
+    async def test_no_change_role_not_updated(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        existing = _make_role(name="admin", description="Same")
+        mocks["descope"].list_roles.return_value = [{"name": "admin", "description": "Same"}]
+        mocks["role_repo"].list_by_tenant.return_value = [existing]
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["roles_updated"] == 0
+
+    async def test_skip_empty_role_name(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].list_roles.return_value = [{"name": ""}]
+        mocks["role_repo"].list_by_tenant.return_value = []
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["roles_created"] == 0
+
+    async def test_role_conflict_on_create_skips(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].list_roles.return_value = [{"name": "admin"}]
+        mocks["role_repo"].list_by_tenant.return_value = []
+        mocks["role_repo"].create.side_effect = RepositoryConflictError("duplicate")
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["roles_created"] == 0
+
+
+@pytest.mark.anyio
+class TestReconcileUsers:
+    """AC-3.2.1 + AC-3.2.5: User drift detection, resolution, and IdP link management."""
+
+    async def test_create_new_user_with_idp_link(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        new_user = _make_user(email="alice@example.com")
+        mocks["user_repo"].create.return_value = new_user
+        mocks["descope"].search_all_users.return_value = [
+            {"userId": "ext-1", "email": "alice@example.com", "name": "Alice Smith", "status": "enabled"}
+        ]
+        mocks["user_repo"].list_all.return_value = []
+        mocks["link_repo"].get_by_provider_and_sub.return_value = None
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["users_created"] == 1
+        assert result.ok["stats"]["links_created"] == 1
+        mocks["user_repo"].create.assert_awaited_once()
+        mocks["link_repo"].create.assert_awaited_once()
+
+    async def test_update_existing_user_name(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        existing = _make_user(email="alice@example.com", given_name="Old", family_name="Name")
+        mocks["descope"].search_all_users.return_value = [
+            {
+                "userId": "ext-1",
+                "email": "alice@example.com",
+                "givenName": "New",
+                "familyName": "Name2",
+                "status": "enabled",
+            }
+        ]
+        mocks["user_repo"].list_all.return_value = [existing]
+        mocks["link_repo"].get_by_provider_and_sub.return_value = MagicMock()  # Existing link
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["users_updated"] == 1
+        assert existing.given_name == "New"
+        assert existing.family_name == "Name2"
+
+    async def test_update_user_status_disabled_to_inactive(self):
+        """Descope disabled → canonical inactive."""
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        existing = _make_user(email="alice@example.com", status=UserStatus.active)
+        mocks["descope"].search_all_users.return_value = [
+            {"userId": "ext-1", "email": "alice@example.com", "status": "disabled"}
+        ]
+        mocks["user_repo"].list_all.return_value = [existing]
+        mocks["link_repo"].get_by_provider_and_sub.return_value = MagicMock()
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["users_updated"] == 1
+        assert existing.status == UserStatus.inactive
+
+    async def test_update_user_status_enabled_to_active(self):
+        """Descope enabled → canonical active."""
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        existing = _make_user(email="alice@example.com", status=UserStatus.inactive)
+        mocks["descope"].search_all_users.return_value = [
+            {"userId": "ext-1", "email": "alice@example.com", "status": "enabled"}
+        ]
+        mocks["user_repo"].list_all.return_value = [existing]
+        mocks["link_repo"].get_by_provider_and_sub.return_value = MagicMock()
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["users_updated"] == 1
+        assert existing.status == UserStatus.active
+
+    async def test_invited_user_mapped_to_provisioned(self):
+        """Descope invited → canonical provisioned (not inactive)."""
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        new_user = _make_user(email="invite@example.com", status=UserStatus.provisioned)
+        mocks["user_repo"].create.return_value = new_user
+        mocks["descope"].search_all_users.return_value = [
+            {"userId": "ext-1", "email": "invite@example.com", "status": "invited"}
+        ]
+        mocks["user_repo"].list_all.return_value = []
+        mocks["link_repo"].get_by_provider_and_sub.return_value = None
+
+        result = await service.run()
+
+        assert result.is_ok()
+        created = mocks["user_repo"].create.call_args[0][0]
+        assert created.status == UserStatus.provisioned
+
+    async def test_no_change_user_not_updated(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        existing = _make_user(
+            email="alice@example.com",
+            given_name="Alice",
+            family_name="Smith",
+            status=UserStatus.active,
+        )
+        mocks["descope"].search_all_users.return_value = [
+            {
+                "userId": "ext-1",
+                "email": "alice@example.com",
+                "givenName": "Alice",
+                "familyName": "Smith",
+                "status": "enabled",
+            }
+        ]
+        mocks["user_repo"].list_all.return_value = [existing]
+        mocks["link_repo"].get_by_provider_and_sub.return_value = MagicMock()
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["users_updated"] == 0
+        mocks["user_repo"].update.assert_not_awaited()
+
+    async def test_name_splitting_from_full_name(self):
+        """Descope user with name but no givenName/familyName → split name."""
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        new_user = _make_user()
+        mocks["user_repo"].create.return_value = new_user
+        mocks["descope"].search_all_users.return_value = [
+            {"userId": "ext-1", "email": "a@b.com", "name": "Jane Doe", "status": "enabled"}
+        ]
+        mocks["user_repo"].list_all.return_value = []
+        mocks["link_repo"].get_by_provider_and_sub.return_value = None
+
+        await service.run()
+
+        created = mocks["user_repo"].create.call_args[0][0]
+        assert created.given_name == "Jane"
+        assert created.family_name == "Doe"
+
+    async def test_name_splitting_single_word(self):
+        """Single-word name → given_name only, family_name empty."""
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        new_user = _make_user()
+        mocks["user_repo"].create.return_value = new_user
+        mocks["descope"].search_all_users.return_value = [
+            {"userId": "ext-1", "email": "a@b.com", "name": "Cher", "status": "enabled"}
+        ]
+        mocks["user_repo"].list_all.return_value = []
+        mocks["link_repo"].get_by_provider_and_sub.return_value = None
+
+        await service.run()
+
+        created = mocks["user_repo"].create.call_args[0][0]
+        assert created.given_name == "Cher"
+        assert created.family_name == ""
+
+    async def test_skip_user_missing_email(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].search_all_users.return_value = [{"userId": "ext-1", "email": "", "status": "enabled"}]
+        mocks["user_repo"].list_all.return_value = []
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["users_created"] == 0
+        mocks["user_repo"].create.assert_not_awaited()
+
+    async def test_skip_user_missing_user_id(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].search_all_users.return_value = [{"userId": "", "email": "a@b.com", "status": "enabled"}]
+        mocks["user_repo"].list_all.return_value = []
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["users_created"] == 0
+
+    async def test_provider_not_configured_skips_users(self):
+        """No Descope provider row → skip user reconciliation, return Ok."""
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["provider_repo"].get_by_type.return_value = None
+        mocks["descope"].search_all_users.return_value = [{"userId": "ext-1", "email": "a@b.com", "status": "enabled"}]
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["users_created"] == 0
+        mocks["user_repo"].create.assert_not_awaited()
+
+    async def test_user_conflict_on_create_skips(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].search_all_users.return_value = [{"userId": "ext-1", "email": "a@b.com", "status": "enabled"}]
+        mocks["user_repo"].list_all.return_value = []
+        mocks["user_repo"].create.side_effect = RepositoryConflictError("duplicate")
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["users_created"] == 0
+
+    async def test_user_conflict_on_update_skips(self):
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        existing = _make_user(email="a@b.com", given_name="Old")
+        mocks["descope"].search_all_users.return_value = [
+            {"userId": "ext-1", "email": "a@b.com", "givenName": "New", "status": "enabled"}
+        ]
+        mocks["user_repo"].list_all.return_value = [existing]
+        mocks["user_repo"].update.side_effect = RepositoryConflictError("constraint")
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["users_updated"] == 0
+
+    async def test_idp_link_conflict_skips(self):
+        """Duplicate IdP link on create → skip, continue."""
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        new_user = _make_user()
+        mocks["user_repo"].create.return_value = new_user
+        mocks["descope"].search_all_users.return_value = [{"userId": "ext-1", "email": "a@b.com", "status": "enabled"}]
+        mocks["user_repo"].list_all.return_value = []
+        mocks["link_repo"].get_by_provider_and_sub.return_value = None
+        mocks["link_repo"].create.side_effect = RepositoryConflictError("dup link")
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["users_created"] == 1
+        assert result.ok["stats"]["links_created"] == 0
+
+    async def test_existing_link_not_recreated(self):
+        """If IdP link already exists → don't create a new one."""
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        existing = _make_user(email="a@b.com", given_name="Alice", family_name="Smith", status=UserStatus.active)
+        mocks["descope"].search_all_users.return_value = [
+            {"userId": "ext-1", "email": "a@b.com", "givenName": "Alice", "familyName": "Smith", "status": "enabled"}
+        ]
+        mocks["user_repo"].list_all.return_value = [existing]
+        mocks["link_repo"].get_by_provider_and_sub.return_value = MagicMock()  # Existing link
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["links_created"] == 0
+        mocks["link_repo"].create.assert_not_awaited()
+
+    async def test_multiple_users_processed(self):
+        """Multiple Descope users are all reconciled."""
+        service, mocks = _build_service()
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        user1 = _make_user(email="a@b.com")
+        user2 = _make_user(email="c@d.com")
+        mocks["user_repo"].create.side_effect = [user1, user2]
+        mocks["descope"].search_all_users.return_value = [
+            {"userId": "ext-1", "email": "a@b.com", "status": "enabled"},
+            {"userId": "ext-2", "email": "c@d.com", "status": "enabled"},
+        ]
+        mocks["user_repo"].list_all.return_value = []
+        mocks["link_repo"].get_by_provider_and_sub.return_value = None
+
+        result = await service.run()
+
+        assert result.is_ok()
+        assert result.ok["stats"]["users_created"] == 2
+        assert result.ok["stats"]["links_created"] == 2
+
+
+@pytest.mark.anyio
+class TestCacheInvalidationPublishing:
+    """AC-3.3.1: ReconciliationService publishes batch event after successful run with changes."""
+
+    async def test_publish_batch_after_changes(self):
+        """Batch event published when reconciliation produces changes."""
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        service, mocks = _build_service()
+        service._publisher = publisher
+
+        _empty_canonical_state(mocks)
+        mocks["descope"].list_tenants.return_value = [{"name": "Acme", "selfProvisioningDomains": []}]
+        mocks["descope"].list_permissions.return_value = []
+        mocks["descope"].list_roles.return_value = []
+        mocks["descope"].search_all_users.return_value = []
+        mocks["tenant_repo"].get_by_name.return_value = None
+        tenant = _make_tenant(name="Acme")
+        mocks["tenant_repo"].create.return_value = tenant
+
+        result = await service.run()
+
+        assert result.is_ok()
+        publisher.publish_batch.assert_awaited_once()
+        call_kwargs = publisher.publish_batch.call_args[1]
+        assert call_kwargs["operation"] == "reconcile"
+        assert call_kwargs["stats"]["tenants_created"] == 1
+
+    async def test_no_publish_when_zero_changes(self):
+        """No batch event when reconciliation finds no drift."""
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        service, mocks = _build_service()
+        service._publisher = publisher
+
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+
+        result = await service.run()
+
+        assert result.is_ok()
+        publisher.publish_batch.assert_not_awaited()
+
+    async def test_no_publish_on_commit_failure(self):
+        """Publisher not called when commit fails."""
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        service, mocks = _build_service()
+        service._publisher = publisher
+
+        _empty_descope_state(mocks)
+        _empty_canonical_state(mocks)
+        mocks["descope"].list_tenants.return_value = [{"name": "Acme", "selfProvisioningDomains": []}]
+        mocks["tenant_repo"].get_by_name.return_value = None
+        mocks["tenant_repo"].create.return_value = _make_tenant(name="Acme")
+        mocks["session"].commit.side_effect = RuntimeError("db gone")
+
+        result = await service.run()
+
+        assert result.is_error()
+        publisher.publish_batch.assert_not_awaited()

--- a/backend/tests/unit/test_role_service.py
+++ b/backend/tests/unit/test_role_service.py
@@ -1,0 +1,678 @@
+"""Unit tests for RoleService domain orchestration (Story 2.2).
+
+Tests cover:
+- create_role: persist, commit, sync; duplicate → Conflict; sync failure → Ok
+- get_role: found → Ok(dict); not found → NotFound
+- map_permission_to_role: success; not found; duplicate → Conflict
+- assign_role_to_user: success; not found; duplicate → Conflict; sync fail → Ok
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from expression import Error, Ok
+
+from app.errors.identity import Conflict, NotFound
+from app.models.identity.assignment import UserTenantRole
+from app.models.identity.role import Permission, Role, RolePermission
+from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.permission import PermissionRepository
+from app.repositories.role import RoleRepository
+from app.repositories.user import RepositoryConflictError
+from app.services.adapters.base import IdentityProviderAdapter, SyncError
+from app.services.cache_invalidation import CacheInvalidationPublisher
+from app.services.role import RoleService
+
+TENANT_ID = uuid.uuid4()
+
+
+def _make_role(**overrides) -> Role:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": "admin",
+        "description": "Admin role",
+        "tenant_id": None,
+    }
+    defaults.update(overrides)
+    return Role(**defaults)
+
+
+def _make_permission(**overrides) -> Permission:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": "documents.read",
+        "description": "Read documents",
+    }
+    defaults.update(overrides)
+    return Permission(**defaults)
+
+
+def _build_service(
+    repo: AsyncMock | None = None,
+    perm_repo: AsyncMock | None = None,
+    assignment_repo: AsyncMock | None = None,
+    adapter: AsyncMock | None = None,
+) -> tuple[RoleService, AsyncMock, AsyncMock, AsyncMock, AsyncMock]:
+    if repo is None:
+        repo = AsyncMock(spec=RoleRepository)
+    if perm_repo is None:
+        perm_repo = AsyncMock(spec=PermissionRepository)
+    if assignment_repo is None:
+        assignment_repo = AsyncMock(spec=UserTenantRoleRepository)
+    if adapter is None:
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+    service = RoleService(
+        repository=repo,
+        permission_repository=perm_repo,
+        assignment_repository=assignment_repo,
+        adapter=adapter,
+    )
+    return service, repo, perm_repo, assignment_repo, adapter
+
+
+@pytest.mark.anyio
+class TestCreateRole:
+    """AC-2.2.1: create_role persists via repo, commits, syncs, returns Ok(dict)."""
+
+    async def test_create_role_success(self):
+        service, repo, _perm, _assign, adapter = _build_service()
+        repo.get_by_name.return_value = None
+        role = _make_role()
+        repo.create.return_value = role
+        adapter.sync_role.return_value = Ok(None)
+
+        result = await service.create_role(name=role.name, description=role.description)
+
+        assert result.is_ok()
+        repo.create.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+        adapter.sync_role.assert_awaited_once()
+
+    async def test_create_role_with_tenant(self):
+        service, repo, _perm, _assign, adapter = _build_service()
+        repo.get_by_name.return_value = None
+        role = _make_role(tenant_id=TENANT_ID)
+        repo.create.return_value = role
+        adapter.sync_role.return_value = Ok(None)
+
+        result = await service.create_role(name=role.name, description=role.description, tenant_id=TENANT_ID)
+
+        assert result.is_ok()
+        repo.get_by_name.assert_awaited_once_with(role.name, TENANT_ID)
+
+    async def test_create_role_commit_before_sync(self):
+        service, repo, _perm, _assign, adapter = _build_service()
+        repo.get_by_name.return_value = None
+        role = _make_role()
+        repo.create.return_value = role
+        adapter.sync_role.return_value = Ok(None)
+
+        call_order = []
+        repo.commit.side_effect = lambda: call_order.append("commit")
+        adapter.sync_role.side_effect = lambda **kw: (call_order.append("sync"), Ok(None))[1]
+
+        await service.create_role(name=role.name)
+
+        assert call_order == ["commit", "sync"]
+
+    async def test_create_role_duplicate_name_returns_conflict(self):
+        """AC-2.2.5: duplicate name within scope → Conflict."""
+        service, repo, _perm, _assign, _adapter = _build_service()
+        repo.get_by_name.return_value = _make_role()
+
+        result = await service.create_role(name="admin")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        repo.create.assert_not_awaited()
+
+    async def test_create_role_integrity_error_returns_conflict(self):
+        """TOCTOU race: get_by_name returns None but flush raises IntegrityError."""
+        service, repo, _perm, _assign, _adapter = _build_service()
+        repo.get_by_name.return_value = None
+        repo.create.side_effect = RepositoryConflictError("duplicate key")
+
+        result = await service.create_role(name="admin")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_create_role_sync_failure_still_returns_ok(self):
+        service, repo, _perm, _assign, adapter = _build_service()
+        repo.get_by_name.return_value = None
+        role = _make_role()
+        repo.create.return_value = role
+        adapter.sync_role.return_value = Error(SyncError(message="Descope down", operation="sync_role"))
+
+        with patch("app.services.role.logger") as mock_logger:
+            result = await service.create_role(name=role.name)
+
+        assert result.is_ok()
+        repo.commit.assert_awaited_once()
+        mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.anyio
+class TestGetRole:
+    async def test_get_role_found(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        role = _make_role()
+        repo.get.return_value = role
+
+        result = await service.get_role(role_id=role.id)
+
+        assert result.is_ok()
+        assert result.ok["name"] == role.name
+
+    async def test_get_role_not_found(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.get_role(role_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+
+@pytest.mark.anyio
+class TestMapPermissionToRole:
+    """AC-2.2.2: map_permission_to_role creates mapping, syncs role with permissions."""
+
+    async def test_map_permission_success(self):
+        service, repo, perm_repo, _assign, adapter = _build_service()
+        role = _make_role()
+        perm = _make_permission()
+        mapping = RolePermission(role_id=role.id, permission_id=perm.id)
+
+        repo.get.return_value = role
+        perm_repo.get.return_value = perm
+        repo.add_permission.return_value = mapping
+        repo.get_permissions.return_value = [perm]
+        adapter.sync_role.return_value = Ok(None)
+
+        result = await service.map_permission_to_role(role_id=role.id, permission_id=perm.id)
+
+        assert result.is_ok()
+        assert result.ok["role_id"] == str(role.id)
+        assert result.ok["permission_id"] == str(perm.id)
+        repo.commit.assert_awaited_once()
+        adapter.sync_role.assert_awaited_once()
+
+    async def test_map_permission_fetches_permissions_before_commit(self):
+        """get_permissions must happen before commit to avoid post-commit query issues."""
+        service, repo, perm_repo, _assign, adapter = _build_service()
+        role = _make_role()
+        perm = _make_permission()
+        mapping = RolePermission(role_id=role.id, permission_id=perm.id)
+
+        repo.get.return_value = role
+        perm_repo.get.return_value = perm
+        repo.add_permission.return_value = mapping
+        repo.get_permissions.return_value = [perm]
+        adapter.sync_role.return_value = Ok(None)
+
+        call_order = []
+        repo.get_permissions.side_effect = lambda rid: (call_order.append("get_perms"), [perm])[1]
+        repo.commit.side_effect = lambda: call_order.append("commit")
+        adapter.sync_role.side_effect = lambda **kw: (call_order.append("sync"), Ok(None))[1]
+
+        await service.map_permission_to_role(role_id=role.id, permission_id=perm.id)
+
+        assert call_order == ["get_perms", "commit", "sync"]
+
+    async def test_map_permission_role_not_found(self):
+        service, repo, _perm_repo, _assign, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.map_permission_to_role(role_id=uuid.uuid4(), permission_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        assert "Role" in result.error.message
+
+    async def test_map_permission_permission_not_found(self):
+        service, repo, perm_repo, _assign, _adapter = _build_service()
+        repo.get.return_value = _make_role()
+        perm_repo.get.return_value = None
+
+        result = await service.map_permission_to_role(role_id=uuid.uuid4(), permission_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+        assert "Permission" in result.error.message
+
+    async def test_map_permission_duplicate_returns_conflict(self):
+        service, repo, perm_repo, _assign, _adapter = _build_service()
+        repo.get.return_value = _make_role()
+        perm_repo.get.return_value = _make_permission()
+        repo.add_permission.side_effect = RepositoryConflictError("duplicate mapping")
+
+        result = await service.map_permission_to_role(role_id=uuid.uuid4(), permission_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_map_permission_sync_includes_permission_names(self):
+        """Sync payload should include all permission names for the role."""
+        service, repo, perm_repo, _assign, adapter = _build_service()
+        role = _make_role()
+        perm1 = _make_permission(name="read")
+        perm2 = _make_permission(name="write")
+        mapping = RolePermission(role_id=role.id, permission_id=perm1.id)
+
+        repo.get.return_value = role
+        perm_repo.get.return_value = perm1
+        repo.add_permission.return_value = mapping
+        repo.get_permissions.return_value = [perm1, perm2]
+        adapter.sync_role.return_value = Ok(None)
+
+        await service.map_permission_to_role(role_id=role.id, permission_id=perm1.id)
+
+        sync_call = adapter.sync_role.call_args
+        assert sync_call.kwargs["data"]["permission_names"] == ["read", "write"]
+
+    async def test_map_permission_sync_failure_still_returns_ok(self):
+        """AC-2.4.2: sync failure on map_permission → log warning, still return Ok."""
+        service, repo, perm_repo, _assign, adapter = _build_service()
+        role = _make_role()
+        perm = _make_permission()
+        mapping = RolePermission(role_id=role.id, permission_id=perm.id)
+
+        repo.get.return_value = role
+        perm_repo.get.return_value = perm
+        repo.add_permission.return_value = mapping
+        repo.get_permissions.return_value = [perm]
+        adapter.sync_role.return_value = Error(SyncError(message="Descope down", operation="sync_role"))
+
+        with patch("app.services.role.logger") as mock_logger:
+            result = await service.map_permission_to_role(role_id=role.id, permission_id=perm.id)
+
+        assert result.is_ok()
+        repo.commit.assert_awaited_once()
+        mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.anyio
+class TestAssignRoleToUser:
+    """AC-2.2.4: assign_role_to_user creates assignment, syncs via adapter."""
+
+    async def test_assign_role_success(self):
+        service, repo, _perm, assign_repo, adapter = _build_service()
+        role = _make_role()
+        user_id = uuid.uuid4()
+        assignment = UserTenantRole(user_id=user_id, tenant_id=TENANT_ID, role_id=role.id)
+
+        repo.get.return_value = role
+        assign_repo.get.return_value = None
+        assign_repo.create.return_value = assignment
+        adapter.sync_role_assignment.return_value = Ok(None)
+
+        result = await service.assign_role_to_user(user_id=user_id, tenant_id=TENANT_ID, role_id=role.id)
+
+        assert result.is_ok()
+        assert result.ok["user_id"] == str(user_id)
+        assert result.ok["tenant_id"] == str(TENANT_ID)
+        assert result.ok["role_id"] == str(role.id)
+        assign_repo.commit.assert_awaited_once()
+        adapter.sync_role_assignment.assert_awaited_once()
+        sync_call = adapter.sync_role_assignment.call_args
+        assert sync_call.kwargs["data"] == {"role_name": role.name}
+
+    async def test_assign_role_not_found(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.assign_role_to_user(user_id=uuid.uuid4(), tenant_id=TENANT_ID, role_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_assign_role_existing_assignment_returns_conflict(self):
+        service, repo, _perm, assign_repo, _adapter = _build_service()
+        role = _make_role()
+        repo.get.return_value = role
+        assign_repo.get.return_value = UserTenantRole(user_id=uuid.uuid4(), tenant_id=TENANT_ID, role_id=role.id)
+
+        result = await service.assign_role_to_user(user_id=uuid.uuid4(), tenant_id=TENANT_ID, role_id=role.id)
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        assign_repo.create.assert_not_awaited()
+
+    async def test_assign_role_integrity_error_returns_conflict(self):
+        """TOCTOU race: get returns None but create raises IntegrityError."""
+        service, repo, _perm, assign_repo, _adapter = _build_service()
+        repo.get.return_value = _make_role()
+        assign_repo.get.return_value = None
+        assign_repo.create.side_effect = RepositoryConflictError("duplicate assignment")
+
+        result = await service.assign_role_to_user(user_id=uuid.uuid4(), tenant_id=TENANT_ID, role_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_assign_role_sync_failure_still_returns_ok(self):
+        service, repo, _perm, assign_repo, adapter = _build_service()
+        role = _make_role()
+        user_id = uuid.uuid4()
+        assignment = UserTenantRole(user_id=user_id, tenant_id=TENANT_ID, role_id=role.id)
+
+        repo.get.return_value = role
+        assign_repo.get.return_value = None
+        assign_repo.create.return_value = assignment
+        adapter.sync_role_assignment.return_value = Error(
+            SyncError(message="Descope down", operation="sync_role_assignment")
+        )
+
+        with patch("app.services.role.logger") as mock_logger:
+            result = await service.assign_role_to_user(user_id=user_id, tenant_id=TENANT_ID, role_id=role.id)
+
+        assert result.is_ok()
+        assign_repo.commit.assert_awaited_once()
+        mock_logger.warning.assert_called_once()
+
+    async def test_assign_role_with_assigned_by(self):
+        service, repo, _perm, assign_repo, adapter = _build_service()
+        role = _make_role()
+        user_id = uuid.uuid4()
+        assigner_id = uuid.uuid4()
+        assignment = UserTenantRole(
+            user_id=user_id,
+            tenant_id=TENANT_ID,
+            role_id=role.id,
+            assigned_by=assigner_id,
+        )
+
+        repo.get.return_value = role
+        assign_repo.get.return_value = None
+        assign_repo.create.return_value = assignment
+        adapter.sync_role_assignment.return_value = Ok(None)
+
+        result = await service.assign_role_to_user(
+            user_id=user_id,
+            tenant_id=TENANT_ID,
+            role_id=role.id,
+            assigned_by=assigner_id,
+        )
+
+        assert result.is_ok()
+        assert result.ok["assigned_by"] == str(assigner_id)
+
+
+@pytest.mark.anyio
+class TestListRoles:
+    """Story 2.3: list_roles delegates to repository."""
+
+    async def test_list_roles_returns_list(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        roles = [_make_role(name="admin"), _make_role(name="viewer")]
+        repo.list_by_tenant.return_value = roles
+
+        result = await service.list_roles()
+
+        assert result.is_ok()
+        assert len(result.ok) == 2
+        repo.list_by_tenant.assert_awaited_once_with(None)
+
+    async def test_list_roles_with_tenant(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        repo.list_by_tenant.return_value = []
+
+        result = await service.list_roles(tenant_id=TENANT_ID)
+
+        assert result.is_ok()
+        repo.list_by_tenant.assert_awaited_once_with(TENANT_ID)
+
+    async def test_list_roles_empty(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        repo.list_by_tenant.return_value = []
+
+        result = await service.list_roles()
+
+        assert result.is_ok()
+        assert result.ok == []
+
+
+@pytest.mark.anyio
+class TestUpdateRole:
+    """Story 2.3: update_role updates fields, commits, syncs."""
+
+    async def test_update_role_success(self):
+        service, repo, _perm, _assign, adapter = _build_service()
+        role = _make_role(name="editor")
+        repo.get.return_value = role
+        repo.get_by_name.return_value = None
+        repo.update.return_value = role
+        adapter.sync_role.return_value = Ok(None)
+
+        result = await service.update_role(role_id=role.id, name="senior-editor", description="Senior")
+
+        assert result.is_ok()
+        repo.update.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+        adapter.sync_role.assert_awaited_once()
+
+    async def test_update_role_not_found(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.update_role(role_id=uuid.uuid4(), name="new-name")
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_update_role_name_conflict(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        role = _make_role(name="editor")
+        existing = _make_role(name="admin")
+        repo.get.return_value = role
+        repo.get_by_name.return_value = existing
+
+        result = await service.update_role(role_id=role.id, name="admin")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_update_role_same_name_no_conflict(self):
+        service, repo, _perm, _assign, adapter = _build_service()
+        role = _make_role(name="editor")
+        repo.get.return_value = role
+        repo.get_by_name.return_value = role  # same role
+        repo.update.return_value = role
+        adapter.sync_role.return_value = Ok(None)
+
+        result = await service.update_role(role_id=role.id, name="editor")
+
+        assert result.is_ok()
+
+    async def test_update_role_integrity_error(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        role = _make_role()
+        repo.get.return_value = role
+        repo.get_by_name.return_value = None
+        repo.update.side_effect = RepositoryConflictError("duplicate key")
+
+        result = await service.update_role(role_id=role.id, name="new-name")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_update_role_sync_failure_still_returns_ok(self):
+        """AC-2.4.2: sync failure on update → log warning, still return Ok."""
+        service, repo, _perm, _assign, adapter = _build_service()
+        role = _make_role(name="editor")
+        repo.get.return_value = role
+        repo.get_by_name.return_value = None
+        repo.update.return_value = role
+        adapter.sync_role.return_value = Error(SyncError(message="Descope down", operation="sync_role"))
+
+        with patch("app.services.role.logger") as mock_logger:
+            result = await service.update_role(role_id=role.id, name="senior-editor")
+
+        assert result.is_ok()
+        repo.commit.assert_awaited_once()
+        mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.anyio
+class TestDeleteRole:
+    """Story 2.3: delete_role removes from DB, commits, syncs deletion."""
+
+    async def test_delete_role_success(self):
+        service, repo, _perm, _assign, adapter = _build_service()
+        role = _make_role(name="editor")
+        repo.get.return_value = role
+        repo.delete.return_value = True
+        adapter.delete_role.return_value = Ok(None)
+
+        result = await service.delete_role(role_id=role.id)
+
+        assert result.is_ok()
+        assert result.ok["status"] == "deleted"
+        assert result.ok["name"] == "editor"
+        repo.commit.assert_awaited_once()
+        adapter.delete_role.assert_awaited_once()
+
+    async def test_delete_role_not_found(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.delete_role(role_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_delete_role_sync_failure_still_ok(self):
+        service, repo, _perm, _assign, adapter = _build_service()
+        role = _make_role()
+        repo.get.return_value = role
+        repo.delete.return_value = True
+        adapter.delete_role.return_value = Error(SyncError(message="down", operation="delete_role"))
+
+        with patch("app.services.role.logger") as mock_logger:
+            result = await service.delete_role(role_id=role.id)
+
+        assert result.is_ok()
+        mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.anyio
+class TestUnassignRoleFromUser:
+    """Story 2.3: unassign_role_from_user removes assignment record."""
+
+    async def test_unassign_success(self):
+        service, repo, _perm, assign_repo, adapter = _build_service()
+        user_id = uuid.uuid4()
+        role = _make_role()
+        repo.get.return_value = role
+        assign_repo.delete.return_value = True
+        adapter.delete_role_assignment.return_value = Ok(None)
+
+        result = await service.unassign_role_from_user(user_id=user_id, tenant_id=TENANT_ID, role_id=role.id)
+
+        assert result.is_ok()
+        assert result.ok["status"] == "removed"
+        assign_repo.commit.assert_awaited_once()
+        adapter.delete_role_assignment.assert_awaited_once()
+
+    async def test_unassign_not_found(self):
+        service, repo, _perm, assign_repo, _adapter = _build_service()
+        repo.get.return_value = None
+        assign_repo.delete.return_value = False
+
+        result = await service.unassign_role_from_user(user_id=uuid.uuid4(), tenant_id=TENANT_ID, role_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_unassign_sync_failure_still_returns_ok(self):
+        service, repo, _perm, assign_repo, adapter = _build_service()
+        role = _make_role()
+        repo.get.return_value = role
+        assign_repo.delete.return_value = True
+        adapter.delete_role_assignment.return_value = Error(
+            SyncError(message="Descope down", operation="delete_role_assignment")
+        )
+
+        with patch("app.services.role.logger") as mock_logger:
+            result = await service.unassign_role_from_user(user_id=uuid.uuid4(), tenant_id=TENANT_ID, role_id=role.id)
+
+        assert result.is_ok()
+        assign_repo.commit.assert_awaited_once()
+        mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.anyio
+class TestCacheInvalidationPublishing:
+    """AC-3.3.1: RoleService publishes cache invalidation events after commit."""
+
+    async def test_create_role_publishes_event(self):
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        repo = AsyncMock(spec=RoleRepository)
+        perm_repo = AsyncMock(spec=PermissionRepository)
+        assign_repo = AsyncMock(spec=UserTenantRoleRepository)
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+        service = RoleService(
+            repository=repo,
+            permission_repository=perm_repo,
+            assignment_repository=assign_repo,
+            adapter=adapter,
+            publisher=publisher,
+        )
+        repo.get_by_name.return_value = None
+        role = _make_role(tenant_id=TENANT_ID)
+        repo.create.return_value = role
+        adapter.sync_role.return_value = Ok(None)
+
+        result = await service.create_role(name=role.name, tenant_id=TENANT_ID)
+
+        assert result.is_ok()
+        publisher.publish.assert_awaited_once_with(
+            entity_type="role", entity_id=role.id, operation="create", tenant_id=TENANT_ID
+        )
+
+    async def test_delete_role_publishes_event(self):
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        repo = AsyncMock(spec=RoleRepository)
+        perm_repo = AsyncMock(spec=PermissionRepository)
+        assign_repo = AsyncMock(spec=UserTenantRoleRepository)
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+        service = RoleService(
+            repository=repo,
+            permission_repository=perm_repo,
+            assignment_repository=assign_repo,
+            adapter=adapter,
+            publisher=publisher,
+        )
+        role = _make_role(tenant_id=TENANT_ID)
+        repo.get.return_value = role
+        repo.delete.return_value = True
+        adapter.delete_role.return_value = Ok(None)
+
+        result = await service.delete_role(role_id=role.id)
+
+        assert result.is_ok()
+        publisher.publish.assert_awaited_once_with(
+            entity_type="role", entity_id=role.id, operation="delete", tenant_id=TENANT_ID
+        )
+
+    async def test_no_publish_on_failure(self):
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        repo = AsyncMock(spec=RoleRepository)
+        perm_repo = AsyncMock(spec=PermissionRepository)
+        assign_repo = AsyncMock(spec=UserTenantRoleRepository)
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+        service = RoleService(
+            repository=repo,
+            permission_repository=perm_repo,
+            assignment_repository=assign_repo,
+            adapter=adapter,
+            publisher=publisher,
+        )
+        repo.get.return_value = None  # Role not found
+
+        result = await service.delete_role(role_id=uuid.uuid4())
+
+        assert result.is_error()
+        publisher.publish.assert_not_awaited()

--- a/backend/tests/unit/test_roles_router.py
+++ b/backend/tests/unit/test_roles_router.py
@@ -1,12 +1,20 @@
-"""Unit tests for the roles router endpoints."""
+"""Unit tests for the roles router endpoints.
 
+Story 2.3: tests rewired endpoints that use RoleService via DI
+instead of get_descope_client().
+"""
+
+import uuid
 from unittest.mock import AsyncMock, patch
 
-import httpx
 import pytest
+from expression import Error, Ok
 from httpx import ASGITransport, AsyncClient
 
+from app.dependencies.identity import get_role_service
+from app.errors.identity import Conflict, SyncFailed
 from app.main import app
+from app.services.role import RoleService
 
 
 @pytest.fixture
@@ -21,17 +29,31 @@ def _set_env(monkeypatch):
 
 
 @pytest.fixture
+def mock_role_service():
+    return AsyncMock(spec=RoleService)
+
+
+@pytest.fixture(autouse=True)
+def _override_role_service(mock_role_service):
+    app.dependency_overrides[get_role_service] = lambda: mock_role_service
+    yield
+    app.dependency_overrides.pop(get_role_service, None)
+
+
+@pytest.fixture
 async def client():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
 
 
+TENANT_ID = "51c5957b-684a-453f-8ab1-8f239999c4d8"
+
 ADMIN_CLAIMS = {
     "sub": "user123",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {
+        TENANT_ID: {
             "roles": ["admin"],
             "permissions": ["projects.create", "projects.read", "members.invite", "members.update_role"],
         },
@@ -40,9 +62,9 @@ ADMIN_CLAIMS = {
 
 VIEWER_CLAIMS = {
     "sub": "user456",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {
+        TENANT_ID: {
             "roles": ["viewer"],
             "permissions": ["projects.read", "documents.read"],
         },
@@ -51,9 +73,9 @@ VIEWER_CLAIMS = {
 
 OWNER_CLAIMS = {
     "sub": "owner1",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {
+        TENANT_ID: {
             "roles": ["owner"],
             "permissions": ["projects.create", "members.update_role", "billing.manage"],
         },
@@ -64,6 +86,18 @@ NO_TENANT_CLAIMS = {
     "sub": "user789",
     "tenants": {},
 }
+
+AUTH_HEADER = {"Authorization": "Bearer valid.token"}
+
+ROLE_ID = str(uuid.uuid4())
+
+SAMPLE_ROLES = [
+    {"id": str(uuid.uuid4()), "name": "editor", "description": "Can edit", "tenant_id": None},
+    {"id": str(uuid.uuid4()), "name": "viewer", "description": "Read only", "tenant_id": None},
+]
+
+
+# --- /roles/me (claims-based, no service) ---
 
 
 @pytest.mark.anyio
@@ -76,10 +110,10 @@ async def test_roles_me_rejects_unauthenticated(client):
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_roles_me_returns_current_roles(mock_validate, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.get("/api/roles/me", headers={"Authorization": "Bearer valid.token"})
+    response = await client.get("/api/roles/me", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
-    assert data["tenant_id"] == "tenant-abc"
+    assert data["tenant_id"] == TENANT_ID
     assert "admin" in data["roles"]
     assert "projects.create" in data["permissions"]
 
@@ -88,80 +122,15 @@ async def test_roles_me_returns_current_roles(mock_validate, client):
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_roles_me_returns_403_without_tenant(mock_validate, client):
     mock_validate.return_value = NO_TENANT_CLAIMS
-    response = await client.get("/api/roles/me", headers={"Authorization": "Bearer valid.token"})
-    assert response.status_code == 403
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_assign_roles_as_admin(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.resolve_login_id.return_value = "target-user@example.com"
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["member"]},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "roles_assigned"
-    mock_client.resolve_login_id.assert_called_once_with("target-user")
-    mock_client.assign_roles.assert_called_once_with("target-user@example.com", "tenant-abc", ["member"])
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_assign_roles_rejected_for_viewer(mock_validate, client):
-    mock_validate.return_value = VIEWER_CLAIMS
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["admin"]},
-    )
-    assert response.status_code == 403
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_remove_roles_as_admin(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.resolve_login_id.return_value = "target-user@example.com"
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/roles/remove",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["member"]},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "roles_removed"
-    mock_client.resolve_login_id.assert_called_once_with("target-user")
-    mock_client.remove_roles.assert_called_once_with("target-user@example.com", "tenant-abc", ["member"])
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_remove_roles_rejected_for_viewer(mock_validate, client):
-    mock_validate.return_value = VIEWER_CLAIMS
-    response = await client.post(
-        "/api/roles/remove",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["admin"]},
-    )
+    response = await client.get("/api/roles/me", headers=AUTH_HEADER)
     assert response.status_code == 403
 
 
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_roles_me_viewer(mock_validate, client):
-    """Viewer should see their own roles and permissions."""
     mock_validate.return_value = VIEWER_CLAIMS
-    response = await client.get("/api/roles/me", headers={"Authorization": "Bearer valid.token"})
+    response = await client.get("/api/roles/me", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
     assert "viewer" in data["roles"]
@@ -170,105 +139,14 @@ async def test_roles_me_viewer(mock_validate, client):
 
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_assign_roles_rejected_without_tenant(mock_validate, client):
-    """Role assignment should fail when user has no tenant context."""
-    mock_validate.return_value = NO_TENANT_CLAIMS
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["member"]},
-    )
-    assert response.status_code == 403
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_assign_roles_rejected_cross_tenant(mock_validate, client):
-    """Admin in tenant-abc cannot assign roles in tenant-other."""
+async def test_roles_me_not_captured_by_name_param(mock_validate, client):
+    """Ensure /roles/me is NOT interpreted as /roles/{name} with name='me'."""
     mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-other", "role_names": ["member"]},
-    )
-    assert response.status_code == 403
-    assert "different tenant" in response.json()["detail"]
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_admin_cannot_assign_owner_role(mock_validate, client):
-    """Admin should not be able to escalate to owner."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["owner"]},
-    )
-    assert response.status_code == 403
-    assert "owner" in response.json()["detail"].lower()
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_owner_can_assign_owner_role(mock_validate, mock_factory, client):
-    """Owner should be able to assign the owner role."""
-    mock_validate.return_value = OWNER_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.resolve_login_id.return_value = "target-user@example.com"
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["owner"]},
-    )
+    response = await client.get("/api/roles/me", headers=AUTH_HEADER)
     assert response.status_code == 200
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_assign_empty_role_names_rejected(mock_validate, client):
-    """Empty role_names list should be rejected by validation."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": []},
-    )
-    assert response.status_code == 422
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_remove_roles_rejected_cross_tenant(mock_validate, client):
-    """Admin cannot remove roles in a different tenant."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.post(
-        "/api/roles/remove",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-other", "role_names": ["member"]},
-    )
-    assert response.status_code == 403
-
-
-# =============================================================================
-# Role Definition CRUD Tests
-# =============================================================================
-
-AUTH_HEADER = {"Authorization": "Bearer valid.token"}
-
-SAMPLE_ROLES = [
-    {"name": "editor", "description": "Can edit", "permissionNames": ["docs.write"]},
-    {"name": "viewer", "description": "Read only", "permissionNames": ["docs.read"]},
-]
-
-
-def _make_http_status_error(status_code: int = 500) -> httpx.HTTPStatusError:
-    request = httpx.Request("POST", "https://api.descope.com/v1/mgmt/role/create")
-    response = httpx.Response(status_code, request=request, text="error detail")
-    return httpx.HTTPStatusError(f"{status_code} Server Error", request=request, response=response)
+    data = response.json()
+    assert "tenant_id" in data
+    assert "roles" in data
 
 
 # --- Auth enforcement for CRUD endpoints ---
@@ -312,53 +190,144 @@ async def test_delete_role_rejects_viewer(mock_validate, client):
     assert response.status_code == 403
 
 
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_roles_rejected_without_tenant(mock_validate, client):
+    mock_validate.return_value = NO_TENANT_CLAIMS
+    response = await client.get("/api/roles", headers=AUTH_HEADER)
+    assert response.status_code == 403
+
+
+# --- Role assign/remove auth ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_assign_roles_rejected_for_viewer(mock_validate, client):
+    mock_validate.return_value = VIEWER_CLAIMS
+    response = await client.post(
+        "/api/roles/assign",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["admin"]},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_remove_roles_rejected_for_viewer(mock_validate, client):
+    mock_validate.return_value = VIEWER_CLAIMS
+    response = await client.post(
+        "/api/roles/remove",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["admin"]},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_assign_roles_rejected_without_tenant(mock_validate, client):
+    mock_validate.return_value = NO_TENANT_CLAIMS
+    response = await client.post(
+        "/api/roles/assign",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["member"]},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_assign_roles_rejected_cross_tenant(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/roles/assign",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": "tenant-other", "role_names": ["member"]},
+    )
+    assert response.status_code == 403
+    assert "different tenant" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_admin_cannot_assign_owner_role(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/roles/assign",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["owner"]},
+    )
+    assert response.status_code == 403
+    assert "owner" in response.json()["detail"].lower()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_assign_empty_role_names_rejected(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/roles/assign",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": []},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_remove_roles_rejected_cross_tenant(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/roles/remove",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": "tenant-other", "role_names": ["member"]},
+    )
+    assert response.status_code == 403
+
+
 # --- Happy path ---
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_roles(mock_validate, mock_factory, client):
+async def test_list_roles(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.list_roles.return_value = SAMPLE_ROLES
-    mock_factory.return_value = mock_client
+    mock_role_service.list_roles.return_value = Ok(SAMPLE_ROLES)
 
     response = await client.get("/api/roles", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
-    assert data["roles"] == SAMPLE_ROLES
-    mock_client.list_roles.assert_called_once()
+    assert "roles" in data
+    assert len(data["roles"]) == 2
+    mock_role_service.list_roles.assert_awaited_once()
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role(mock_validate, mock_factory, client):
+async def test_create_role(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    role_dict = {"id": ROLE_ID, "name": "editor", "description": "Can edit", "tenant_id": None}
+    mock_role_service.create_role.return_value = Ok(role_dict)
 
     response = await client.post(
         "/api/roles",
         headers=AUTH_HEADER,
-        json={"name": "editor", "description": "Can edit", "permission_names": ["docs.write"]},
+        json={"name": "editor", "description": "Can edit"},
     )
     assert response.status_code == 201
     data = response.json()
     assert data["name"] == "editor"
-    assert data["description"] == "Can edit"
-    assert data["permission_names"] == ["docs.write"]
-    mock_client.create_role.assert_called_once_with("editor", "Can edit", ["docs.write"])
+    mock_role_service.create_role.assert_awaited_once_with(name="editor", description="Can edit", permission_names=None)
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role_default_fields(mock_validate, mock_factory, client):
+async def test_create_role_default_fields(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    role_dict = {"id": ROLE_ID, "name": "viewer", "description": "", "tenant_id": None}
+    mock_role_service.create_role.return_value = Ok(role_dict)
 
     response = await client.post(
         "/api/roles",
@@ -366,224 +335,126 @@ async def test_create_role_default_fields(mock_validate, mock_factory, client):
         json={"name": "viewer"},
     )
     assert response.status_code == 201
-    data = response.json()
-    assert data["description"] == ""
-    assert data["permission_names"] == []
-    mock_client.create_role.assert_called_once_with("viewer", "", None)
+    mock_role_service.create_role.assert_awaited_once_with(name="viewer", description="", permission_names=None)
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role(mock_validate, mock_factory, client):
+async def test_update_role(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "editor"}])
+    mock_role_service.update_role.return_value = Ok(
+        {"id": role_id, "name": "senior-editor", "description": "Senior editor", "tenant_id": None}
+    )
 
     response = await client.put(
         "/api/roles/editor",
         headers=AUTH_HEADER,
-        json={
-            "new_name": "senior-editor",
-            "description": "Senior editor",
-            "permission_names": ["docs.write", "docs.admin"],
-        },
+        json={"new_name": "senior-editor", "description": "Senior editor"},
     )
     assert response.status_code == 200
     data = response.json()
     assert data["name"] == "senior-editor"
-    assert data["description"] == "Senior editor"
-    assert data["permission_names"] == ["docs.write", "docs.admin"]
-    mock_client.update_role.assert_called_once_with(
-        "editor", "senior-editor", "Senior editor", ["docs.write", "docs.admin"]
-    )
+    mock_role_service.update_role.assert_awaited_once()
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_role(mock_validate, mock_factory, client):
+async def test_delete_role(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "editor"}])
+    mock_role_service.delete_role.return_value = Ok({"status": "deleted", "name": "editor"})
 
     response = await client.delete("/api/roles/editor", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "deleted"
     assert data["name"] == "editor"
-    mock_client.delete_role.assert_called_once_with("editor")
-
-
-# --- Partial update ---
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role_partial_description_only(mock_validate, mock_factory, client):
-    """Omitting new_name and permission_names should not wipe them."""
+async def test_assign_roles_as_admin(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
-
-    response = await client.put(
-        "/api/roles/editor",
-        headers=AUTH_HEADER,
-        json={"description": "Updated desc"},
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "member"}])
+    mock_role_service.assign_role_to_user.return_value = Ok(
+        {"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_id": role_id}
     )
-    assert response.status_code == 200
-    data = response.json()
-    assert data["name"] == "editor"  # defaults to path param
-    assert data["description"] == "Updated desc"
-    assert data["permission_names"] is None  # not sent → unchanged
-    mock_client.update_role.assert_called_once_with("editor", "editor", "Updated desc", None)
 
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role_empty_body(mock_validate, mock_factory, client):
-    """Empty body is a no-op: name defaults to path param, others are None."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
-
-    response = await client.put(
-        "/api/roles/editor",
-        headers=AUTH_HEADER,
-        json={},
-    )
-    assert response.status_code == 200
-    data = response.json()
-    assert data["name"] == "editor"
-    mock_client.update_role.assert_called_once_with("editor", "editor", None, None)
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role_empty_permission_name_rejected(mock_validate, client):
-    """Empty strings in permission_names list should be rejected."""
-    mock_validate.return_value = ADMIN_CLAIMS
     response = await client.post(
-        "/api/roles",
+        "/api/roles/assign",
         headers=AUTH_HEADER,
-        json={"name": "test-role", "permission_names": ["", "docs.read"]},
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["member"]},
     )
-    assert response.status_code == 422
+    assert response.status_code == 200
+    assert response.json()["status"] == "roles_assigned"
+    mock_role_service.assign_role_to_user.assert_awaited_once()
 
 
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role_empty_permission_name_rejected(mock_validate, client):
-    """Empty strings in permission_names list should be rejected on update."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.put(
-        "/api/roles/editor",
-        headers=AUTH_HEADER,
-        json={"permission_names": ["", "docs.read"]},
+async def test_owner_can_assign_owner_role(mock_validate, mock_role_service, client):
+    mock_validate.return_value = OWNER_CLAIMS
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "owner"}])
+    mock_role_service.assign_role_to_user.return_value = Ok(
+        {"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_id": role_id}
     )
-    assert response.status_code == 422
+
+    response = await client.post(
+        "/api/roles/assign",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["owner"]},
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_remove_roles_as_admin(mock_validate, mock_role_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "member"}])
+    user_id = "dd98f159-658f-47f3-9ed2-99e85686b04c"
+    mock_role_service.unassign_role_from_user.return_value = Ok(
+        {"status": "removed", "user_id": user_id, "tenant_id": TENANT_ID, "role_id": role_id}
+    )
+
+    response = await client.post(
+        "/api/roles/remove",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["member"]},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "roles_removed"
 
 
 # --- Error handling ---
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role_duplicate_returns_client_error(mock_validate, mock_factory, client):
-    """Descope returns 400/409 for duplicate role names — forwarded to caller."""
+async def test_create_role_duplicate_returns_conflict(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_role.side_effect = _make_http_status_error(409)
-    mock_factory.return_value = mock_client
+    mock_role_service.create_role.return_value = Error(Conflict(message="Role 'editor' already exists in this scope"))
 
     response = await client.post(
         "/api/roles",
         headers=AUTH_HEADER,
-        json={"name": "existing-role"},
+        json={"name": "editor"},
     )
     assert response.status_code == 409
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role_bad_request_forwarded(mock_validate, mock_factory, client):
-    """Descope 400 on create → forwarded."""
+async def test_update_role_not_found(mock_validate, mock_role_service, client):
+    """Role name not found in list → 404."""
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_role.side_effect = _make_http_status_error(400)
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/roles",
-        headers=AUTH_HEADER,
-        json={"name": "bad-role"},
-    )
-    assert response.status_code == 400
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_roles_descope_server_error(mock_validate, mock_factory, client):
-    """Descope 5xx → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.list_roles.side_effect = _make_http_status_error(500)
-    mock_factory.return_value = mock_client
-
-    response = await client.get("/api/roles", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role_network_error(mock_validate, mock_factory, client):
-    """Network error → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_role.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/roles",
-        headers=AUTH_HEADER,
-        json={"name": "test-role"},
-    )
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role_descope_error(mock_validate, mock_factory, client):
-    """Descope 5xx on update → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.update_role.side_effect = _make_http_status_error(500)
-    mock_factory.return_value = mock_client
-
-    response = await client.put(
-        "/api/roles/editor",
-        headers=AUTH_HEADER,
-        json={"new_name": "senior-editor"},
-    )
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role_not_found(mock_validate, mock_factory, client):
-    """Descope 404 on update → forwarded."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.update_role.side_effect = _make_http_status_error(404)
-    mock_factory.return_value = mock_client
+    mock_role_service.list_roles.return_value = Ok([])
 
     response = await client.put(
         "/api/roles/nonexistent",
@@ -594,95 +465,29 @@ async def test_update_role_not_found(mock_validate, mock_factory, client):
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_role_descope_error(mock_validate, mock_factory, client):
-    """Descope 5xx on delete → 502."""
+async def test_delete_role_not_found(mock_validate, mock_role_service, client):
+    """Role name not found in list → 404."""
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.delete_role.side_effect = _make_http_status_error(500)
-    mock_factory.return_value = mock_client
-
-    response = await client.delete("/api/roles/editor", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_role_not_found(mock_validate, mock_factory, client):
-    """Descope 404 on delete → forwarded."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.delete_role.side_effect = _make_http_status_error(404)
-    mock_factory.return_value = mock_client
+    mock_role_service.list_roles.return_value = Ok([])
 
     response = await client.delete("/api/roles/nonexistent", headers=AUTH_HEADER)
     assert response.status_code == 404
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_role_network_error(mock_validate, mock_factory, client):
-    """Network error on delete → 502."""
+async def test_assign_role_not_found(mock_validate, mock_role_service, client):
+    """Role name not in list → 404."""
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.delete_role.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.delete("/api/roles/editor", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role_network_error(mock_validate, mock_factory, client):
-    """Network error on update → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.update_role.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.put(
-        "/api/roles/editor",
-        headers=AUTH_HEADER,
-        json={"new_name": "senior-editor"},
-    )
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_roles_network_error(mock_validate, mock_factory, client):
-    """Network error on list → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.list_roles.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.get("/api/roles", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role_descope_401_becomes_502(mock_validate, mock_factory, client):
-    """Descope 401 (e.g. expired mgmt key) should not be forwarded — returns 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_role.side_effect = _make_http_status_error(401)
-    mock_factory.return_value = mock_client
+    mock_role_service.list_roles.return_value = Ok([])
 
     response = await client.post(
-        "/api/roles",
+        "/api/roles/assign",
         headers=AUTH_HEADER,
-        json={"name": "test-role"},
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["nonexistent"]},
     )
-    assert response.status_code == 502
+    assert response.status_code == 404
 
 
 # --- Input validation ---
@@ -712,28 +517,56 @@ async def test_update_role_empty_new_name_rejected(mock_validate, client):
     assert response.status_code == 422
 
 
-# --- No tenant context ---
-
-
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_roles_rejected_without_tenant(mock_validate, client):
-    mock_validate.return_value = NO_TENANT_CLAIMS
-    response = await client.get("/api/roles", headers=AUTH_HEADER)
-    assert response.status_code == 403
-
-
-# --- Route ordering: /roles/me still works ---
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_roles_me_not_captured_by_name_param(mock_validate, client):
-    """Ensure /roles/me is NOT interpreted as /roles/{name} with name='me'."""
+async def test_create_role_empty_permission_name_rejected(mock_validate, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.get("/api/roles/me", headers=AUTH_HEADER)
-    assert response.status_code == 200
-    data = response.json()
-    # /roles/me returns tenant_id, roles, permissions — not a role definition
-    assert "tenant_id" in data
-    assert "roles" in data
+    response = await client.post(
+        "/api/roles",
+        headers=AUTH_HEADER,
+        json={"name": "test-role", "permission_names": ["", "docs.read"]},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_update_role_empty_permission_name_rejected(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.put(
+        "/api/roles/editor",
+        headers=AUTH_HEADER,
+        json={"permission_names": ["", "docs.read"]},
+    )
+    assert response.status_code == 422
+
+
+# --- SyncFailed → 207 Multi-Status ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_role_sync_failed_returns_207(mock_validate, mock_role_service, client):
+    """Service returns SyncFailed (DB write ok, IdP sync failed) → 207 Multi-Status."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_role_service.create_role.return_value = Error(
+        SyncFailed(
+            message="Descope sync failed for role creation",
+            operation="create_role",
+            underlying_error="httpx.ConnectError",
+        )
+    )
+
+    response = await client.post(
+        "/api/roles",
+        headers=AUTH_HEADER,
+        json={"name": "new-role"},
+    )
+    assert response.status_code == 207
+    assert response.headers["content-type"].startswith("application/problem+json")
+    body = response.json()
+    assert body["type"] == "/errors/sync-failed"
+    assert body["title"] == "Sync Partial Success"
+    assert body["status"] == 207
+    assert "succeeded" in body["detail"]
+    assert "synchronisation failed" in body["detail"]

--- a/backend/tests/unit/test_tenant_router.py
+++ b/backend/tests/unit/test_tenant_router.py
@@ -1,16 +1,23 @@
-"""Unit tests for the tenant router endpoints."""
+"""Unit tests for the tenant router endpoints.
+
+Story 2.3: create_tenant and get_current_tenant now use TenantService via DI.
+list_user_tenants stays claims-based. tenant resources stay direct SQLAlchemy.
+"""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
 import pytest
+from expression import Error, Ok
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
+from app.dependencies.identity import get_tenant_service
+from app.errors.identity import NotFound, SyncFailed
 from app.main import app
 from app.models.database import get_async_session
+from app.services.tenant import TenantService
 
 
 @pytest.fixture
@@ -24,8 +31,13 @@ def _set_env(monkeypatch):
     monkeypatch.setenv("DESCOPE_MANAGEMENT_KEY", "test-management-key")
 
 
+@pytest.fixture
+def mock_tenant_service():
+    return AsyncMock(spec=TenantService)
+
+
 @pytest.fixture(autouse=True)
-async def _test_db():
+async def _test_db(mock_tenant_service):
     """Use an in-memory async SQLite database for each test."""
     engine = create_async_engine("sqlite+aiosqlite://", echo=False)
     async with engine.begin() as conn:
@@ -38,8 +50,10 @@ async def _test_db():
             yield session
 
     app.dependency_overrides[get_async_session] = override_get_async_session
+    app.dependency_overrides[get_tenant_service] = lambda: mock_tenant_service
     yield
     app.dependency_overrides.pop(get_async_session, None)
+    app.dependency_overrides.pop(get_tenant_service, None)
     async with engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.drop_all)
     await engine.dispose()
@@ -52,32 +66,40 @@ async def client():
         yield c
 
 
+TENANT_UUID = "51c5957b-684a-453f-8ab1-8f239999c4d8"
+TENANT_UUID_2 = "dd98f159-658f-47f3-9ed2-99e85686b04c"
+
 MOCK_CLAIMS_ADMIN = {
     "sub": "user123",
-    "dct": "tenant-abc",
+    "dct": TENANT_UUID,
     "roles": ["admin"],
     "tenants": {
-        "tenant-abc": {"roles": ["admin"], "permissions": ["read", "write"]},
-        "tenant-xyz": {"roles": ["viewer"], "permissions": ["read"]},
+        TENANT_UUID: {"roles": ["admin"], "permissions": ["read", "write"]},
+        TENANT_UUID_2: {"roles": ["viewer"], "permissions": ["read"]},
     },
 }
 
 MOCK_CLAIMS_WITH_TENANT = {
     "sub": "user123",
-    "dct": "tenant-abc",
+    "dct": TENANT_UUID,
     "tenants": {
-        "tenant-abc": {"roles": ["admin"], "permissions": ["read", "write"]},
-        "tenant-xyz": {"roles": ["viewer"], "permissions": ["read"]},
+        TENANT_UUID: {"roles": ["admin"], "permissions": ["read", "write"]},
+        TENANT_UUID_2: {"roles": ["viewer"], "permissions": ["read"]},
     },
 }
 
 MOCK_CLAIMS_NO_TENANT = {
     "sub": "user123",
     "tenants": {
-        "tenant-abc": {"roles": ["admin"], "permissions": ["read"]},
-        "tenant-xyz": {"roles": ["viewer"], "permissions": ["read"]},
+        TENANT_UUID: {"roles": ["admin"], "permissions": ["read"]},
+        TENANT_UUID_2: {"roles": ["viewer"], "permissions": ["read"]},
     },
 }
+
+AUTH_HEADER = {"Authorization": "Bearer valid.token"}
+
+
+# --- Claims-based endpoints (unchanged) ---
 
 
 @pytest.mark.anyio
@@ -89,9 +111,8 @@ async def test_list_tenants_rejects_unauthenticated(client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_list_user_tenants_empty(mock_validate, client):
-    """User with no tenants claim should get an empty list."""
     mock_validate.return_value = {"sub": "user123"}
-    response = await client.get("/api/tenants", headers={"Authorization": "Bearer valid.token"})
+    response = await client.get("/api/tenants", headers=AUTH_HEADER)
     assert response.status_code == 200
     assert response.json()["tenants"] == []
 
@@ -100,123 +121,48 @@ async def test_list_user_tenants_empty(mock_validate, client):
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_list_user_tenants(mock_validate, client):
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
-    response = await client.get("/api/tenants", headers={"Authorization": "Bearer valid.token"})
+    response = await client.get("/api/tenants", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
     assert len(data["tenants"]) == 2
     ids = {t["id"] for t in data["tenants"]}
-    assert "tenant-abc" in ids
-    assert "tenant-xyz" in ids
+    assert TENANT_UUID in ids
+    assert TENANT_UUID_2 in ids
+
+
+# --- create_tenant (via TenantService) ---
 
 
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_get_current_tenant(mock_validate, client):
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
-    with patch("app.routers.tenants.get_descope_client") as mock_factory:
-        mock_client = AsyncMock()
-        mock_client.load_tenant.return_value = {"id": "tenant-abc", "name": "Acme Corp"}
-        mock_factory.return_value = mock_client
-
-        response = await client.get("/api/tenants/current", headers={"Authorization": "Bearer valid.token"})
-        assert response.status_code == 200
-        data = response.json()
-        assert data["tenant_id"] == "tenant-abc"
-        assert data["tenant"]["name"] == "Acme Corp"
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_get_current_tenant_returns_403_without_dct(mock_validate, client):
-    mock_validate.return_value = MOCK_CLAIMS_NO_TENANT
-    response = await client.get("/api/tenants/current", headers={"Authorization": "Bearer valid.token"})
-    assert response.status_code == 403
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_get_current_tenant_returns_null_on_404(mock_validate, client):
-    """When Descope API returns 404 for tenant, return tenant_id with null tenant."""
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
-    with patch("app.routers.tenants.get_descope_client") as mock_factory:
-        mock_client = AsyncMock()
-        req = httpx.Request("POST", "http://test")
-        response_404 = httpx.Response(404, request=req)
-        mock_client.load_tenant.side_effect = httpx.HTTPStatusError("Not Found", request=req, response=response_404)
-        mock_factory.return_value = mock_client
-
-        response = await client.get("/api/tenants/current", headers={"Authorization": "Bearer valid.token"})
-        assert response.status_code == 200
-        data = response.json()
-        assert data["tenant_id"] == "tenant-abc"
-        assert data["tenant"] is None
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_get_current_tenant_returns_502_on_api_error(mock_validate, client):
-    """When Descope API returns a non-404 error, return 502."""
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
-    with patch("app.routers.tenants.get_descope_client") as mock_factory:
-        mock_client = AsyncMock()
-        req = httpx.Request("POST", "http://test")
-        response_500 = httpx.Response(500, request=req)
-        mock_client.load_tenant.side_effect = httpx.HTTPStatusError("Server Error", request=req, response=response_500)
-        mock_factory.return_value = mock_client
-
-        response = await client.get("/api/tenants/current", headers={"Authorization": "Bearer valid.token"})
-        assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_get_current_tenant_returns_502_on_network_error(mock_validate, client):
-    """When a network error occurs, return 502."""
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
-    with patch("app.routers.tenants.get_descope_client") as mock_factory:
-        mock_client = AsyncMock()
-        mock_client.load_tenant.side_effect = httpx.RequestError("Connection refused")
-        mock_factory.return_value = mock_client
-
-        response = await client.get("/api/tenants/current", headers={"Authorization": "Bearer valid.token"})
-        assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.tenants.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_tenant(mock_validate, mock_factory, client):
+async def test_create_tenant(mock_validate, mock_tenant_service, client):
     mock_validate.return_value = MOCK_CLAIMS_ADMIN
-    mock_client = AsyncMock()
-    mock_client.create_tenant.return_value = {"id": "new-tenant-id"}
-    mock_factory.return_value = mock_client
+    tenant_dict = {"id": "new-tenant-id", "name": "New Org", "domains": []}
+    mock_tenant_service.create_tenant.return_value = Ok(tenant_dict)
 
     response = await client.post(
         "/api/tenants",
-        headers={"Authorization": "Bearer valid.token"},
+        headers=AUTH_HEADER,
         json={"name": "New Org"},
     )
     assert response.status_code == 200
-    assert response.json()["id"] == "new-tenant-id"
+    mock_tenant_service.create_tenant.assert_awaited_once_with(name="New Org", domains=None)
 
 
 @pytest.mark.anyio
-@patch("app.routers.tenants.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_tenant_with_domains(mock_validate, mock_factory, client):
-    """Create tenant with self-provisioning domains."""
+async def test_create_tenant_with_domains(mock_validate, mock_tenant_service, client):
     mock_validate.return_value = MOCK_CLAIMS_ADMIN
-    mock_client = AsyncMock()
-    mock_client.create_tenant.return_value = {"id": "domain-tenant"}
-    mock_factory.return_value = mock_client
+    tenant_dict = {"id": "domain-tenant", "name": "Domain Corp", "domains": ["domain.com"]}
+    mock_tenant_service.create_tenant.return_value = Ok(tenant_dict)
 
     response = await client.post(
         "/api/tenants",
-        headers={"Authorization": "Bearer valid.token"},
+        headers=AUTH_HEADER,
         json={"name": "Domain Corp", "self_provisioning_domains": ["domain.com"]},
     )
     assert response.status_code == 200
-    mock_client.create_tenant.assert_called_once_with(name="Domain Corp", self_provisioning_domains=["domain.com"])
+    mock_tenant_service.create_tenant.assert_awaited_once_with(name="Domain Corp", domains=["domain.com"])
 
 
 @pytest.mark.anyio
@@ -228,11 +174,10 @@ async def test_create_tenant_rejects_unauthenticated(client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_create_tenant_rejects_non_admin(mock_validate, client):
-    """User without admin/owner role cannot create tenants."""
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT  # no top-level roles
     response = await client.post(
         "/api/tenants",
-        headers={"Authorization": "Bearer valid.token"},
+        headers=AUTH_HEADER,
         json={"name": "Sneaky Org"},
     )
     assert response.status_code == 403
@@ -241,14 +186,52 @@ async def test_create_tenant_rejects_non_admin(mock_validate, client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_create_tenant_rejects_empty_name(mock_validate, client):
-    """Empty tenant name should be rejected by validation."""
     mock_validate.return_value = MOCK_CLAIMS_ADMIN
     response = await client.post(
         "/api/tenants",
-        headers={"Authorization": "Bearer valid.token"},
+        headers=AUTH_HEADER,
         json={"name": ""},
     )
     assert response.status_code == 422
+
+
+# --- get_current_tenant (via TenantService) ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_get_current_tenant(mock_validate, mock_tenant_service, client):
+    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
+    tenant_dict = {"id": TENANT_UUID, "name": "Acme Corp", "domains": []}
+    mock_tenant_service.get_tenant.return_value = Ok(tenant_dict)
+
+    response = await client.get("/api/tenants/current", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["tenant_id"] == TENANT_UUID
+    assert data["tenant"]["name"] == "Acme Corp"
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_get_current_tenant_returns_403_without_dct(mock_validate, client):
+    mock_validate.return_value = MOCK_CLAIMS_NO_TENANT
+    response = await client.get("/api/tenants/current", headers=AUTH_HEADER)
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_get_current_tenant_not_found(mock_validate, mock_tenant_service, client):
+    """Tenant not found in canonical DB → 404."""
+    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
+    mock_tenant_service.get_tenant.return_value = Error(NotFound(message="Tenant 'tenant-abc' not found"))
+
+    response = await client.get("/api/tenants/current", headers=AUTH_HEADER)
+    assert response.status_code == 404
+
+
+# --- Tenant resources (direct SQLAlchemy, unchanged) ---
 
 
 @pytest.mark.anyio
@@ -256,8 +239,8 @@ async def test_create_tenant_rejects_empty_name(mock_validate, client):
 async def test_list_tenant_resources_empty(mock_validate, client):
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
     response = await client.get(
-        "/api/tenants/tenant-abc/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources",
+        headers=AUTH_HEADER,
     )
     assert response.status_code == 200
     assert response.json()["resources"] == []
@@ -268,21 +251,19 @@ async def test_list_tenant_resources_empty(mock_validate, client):
 async def test_create_and_list_tenant_resources(mock_validate, client):
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
 
-    # Create a resource
     create_resp = await client.post(
-        "/api/tenants/tenant-abc/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources",
+        headers=AUTH_HEADER,
         json={"name": "Test Resource", "description": "A test"},
     )
     assert create_resp.status_code == 200
     resource = create_resp.json()
     assert resource["name"] == "Test Resource"
-    assert resource["tenant_id"] == "tenant-abc"
+    assert resource["tenant_id"] == TENANT_UUID
 
-    # List resources
     list_resp = await client.get(
-        "/api/tenants/tenant-abc/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources",
+        headers=AUTH_HEADER,
     )
     assert list_resp.status_code == 200
     resources = list_resp.json()["resources"]
@@ -293,11 +274,10 @@ async def test_create_and_list_tenant_resources(mock_validate, client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_cannot_access_non_member_tenant_resources(mock_validate, client):
-    """User who is not a member of a tenant cannot access its resources."""
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT  # member of tenant-abc and tenant-xyz
+    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
     response = await client.get(
-        "/api/tenants/tenant-other/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        "/api/tenants/8a70c45c-dc5e-48ed-a8ea-34b0b35058a4/resources",
+        headers=AUTH_HEADER,
     )
     assert response.status_code == 403
 
@@ -305,11 +285,10 @@ async def test_cannot_access_non_member_tenant_resources(mock_validate, client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_cannot_create_resource_in_non_member_tenant(mock_validate, client):
-    """User who is not a member of a tenant cannot create resources in it."""
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT  # member of tenant-abc and tenant-xyz
+    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
     response = await client.post(
-        "/api/tenants/tenant-other/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        "/api/tenants/8a70c45c-dc5e-48ed-a8ea-34b0b35058a4/resources",
+        headers=AUTH_HEADER,
         json={"name": "Sneaky Resource"},
     )
     assert response.status_code == 403
@@ -318,11 +297,10 @@ async def test_cannot_create_resource_in_non_member_tenant(mock_validate, client
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_can_access_member_tenant_resources_without_dct(mock_validate, client):
-    """User can access resources for a tenant they are a member of, even if dct points elsewhere."""
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT  # dct=tenant-abc, member of tenant-xyz too
+    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
     response = await client.get(
-        "/api/tenants/tenant-xyz/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID_2}/resources",
+        headers=AUTH_HEADER,
     )
     assert response.status_code == 200
 
@@ -330,11 +308,10 @@ async def test_can_access_member_tenant_resources_without_dct(mock_validate, cli
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_create_resource_rejects_empty_name(mock_validate, client):
-    """Empty resource name should be rejected by validation."""
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
     response = await client.post(
-        "/api/tenants/tenant-abc/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources",
+        headers=AUTH_HEADER,
         json={"name": ""},
     )
     assert response.status_code == 422
@@ -343,11 +320,10 @@ async def test_create_resource_rejects_empty_name(mock_validate, client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_list_resources_with_pagination(mock_validate, client):
-    """Pagination params are accepted."""
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
     response = await client.get(
-        "/api/tenants/tenant-abc/resources?limit=10&offset=0",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources?limit=10&offset=0",
+        headers=AUTH_HEADER,
     )
     assert response.status_code == 200
 
@@ -355,7 +331,6 @@ async def test_list_resources_with_pagination(mock_validate, client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_create_resource_integrity_error_returns_409(mock_validate, client):
-    """IntegrityError (e.g. duplicate name) returns 409 Conflict."""
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
 
     async def _integrity_error_session():
@@ -371,8 +346,8 @@ async def test_create_resource_integrity_error_returns_409(mock_validate, client
     app.dependency_overrides[get_async_session] = _integrity_error_session
 
     response = await client.post(
-        "/api/tenants/tenant-abc/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources",
+        headers=AUTH_HEADER,
         json={"name": "Duplicate Resource"},
     )
     assert response.status_code == 409
@@ -382,7 +357,6 @@ async def test_create_resource_integrity_error_returns_409(mock_validate, client
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_create_resource_db_error_returns_500(mock_validate, client):
-    """Generic DB error returns 500."""
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
 
     async def _db_error_session():
@@ -396,8 +370,39 @@ async def test_create_resource_db_error_returns_500(mock_validate, client):
     app.dependency_overrides[get_async_session] = _db_error_session
 
     response = await client.post(
-        "/api/tenants/tenant-abc/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources",
+        headers=AUTH_HEADER,
         json={"name": "Some Resource"},
     )
     assert response.status_code == 500
+
+
+# --- SyncFailed → 207 Multi-Status ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_create_tenant_sync_failed_returns_207(mock_validate, mock_tenant_service, client):
+    """Service returns SyncFailed (DB write ok, IdP sync failed) → 207 Multi-Status."""
+    mock_validate.return_value = MOCK_CLAIMS_ADMIN
+    mock_tenant_service.create_tenant.return_value = Error(
+        SyncFailed(
+            message="Descope sync failed for tenant creation",
+            operation="create_tenant",
+            underlying_error="httpx.ConnectError",
+        )
+    )
+
+    response = await client.post(
+        "/api/tenants",
+        headers=AUTH_HEADER,
+        json={"name": "New Org"},
+    )
+    assert response.status_code == 207
+    assert response.headers["content-type"].startswith("application/problem+json")
+    body = response.json()
+    assert body["type"] == "/errors/sync-failed"
+    assert body["title"] == "Sync Partial Success"
+    assert body["status"] == 207
+    assert "succeeded" in body["detail"]
+    assert "synchronisation failed" in body["detail"]

--- a/backend/tests/unit/test_tenant_service.py
+++ b/backend/tests/unit/test_tenant_service.py
@@ -1,0 +1,265 @@
+"""Unit tests for TenantService domain orchestration (Story 2.2).
+
+Tests cover:
+- create_tenant: persist, commit, sync; duplicate → Conflict; sync fail → Ok
+- get_tenant: found → Ok(dict); not found → NotFound
+- get_tenant_users_with_roles: success; tenant not found; empty result
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from expression import Error, Ok
+
+from app.errors.identity import Conflict, NotFound
+from app.models.identity.tenant import Tenant
+from app.repositories.tenant import TenantRepository
+from app.repositories.user import RepositoryConflictError
+from app.services.adapters.base import IdentityProviderAdapter, SyncError
+from app.services.cache_invalidation import CacheInvalidationPublisher
+from app.services.tenant import TenantService
+
+
+def _make_tenant(**overrides) -> Tenant:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": "Acme Corp",
+        "domains": ["acme.com"],
+    }
+    defaults.update(overrides)
+    return Tenant(**defaults)
+
+
+def _build_service(
+    repo: AsyncMock | None = None,
+    adapter: AsyncMock | None = None,
+) -> tuple[TenantService, AsyncMock, AsyncMock]:
+    if repo is None:
+        repo = AsyncMock(spec=TenantRepository)
+    if adapter is None:
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+    service = TenantService(repository=repo, adapter=adapter)
+    return service, repo, adapter
+
+
+@pytest.mark.anyio
+class TestCreateTenant:
+    """AC-2.2.3: create_tenant persists via repo, commits, syncs, returns Ok(dict)."""
+
+    async def test_create_tenant_success(self):
+        service, repo, adapter = _build_service()
+        repo.get_by_name.return_value = None
+        tenant = _make_tenant()
+        repo.create.return_value = tenant
+        adapter.sync_tenant.return_value = Ok(None)
+
+        result = await service.create_tenant(name=tenant.name, domains=tenant.domains)
+
+        assert result.is_ok()
+        repo.create.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+        adapter.sync_tenant.assert_awaited_once()
+
+    async def test_create_tenant_commit_before_sync(self):
+        service, repo, adapter = _build_service()
+        repo.get_by_name.return_value = None
+        tenant = _make_tenant()
+        repo.create.return_value = tenant
+        adapter.sync_tenant.return_value = Ok(None)
+
+        call_order = []
+        repo.commit.side_effect = lambda: call_order.append("commit")
+        adapter.sync_tenant.side_effect = lambda **kw: (call_order.append("sync"), Ok(None))[1]
+
+        await service.create_tenant(name=tenant.name)
+
+        assert call_order == ["commit", "sync"]
+
+    async def test_create_tenant_duplicate_name_returns_conflict(self):
+        service, repo, _adapter = _build_service()
+        repo.get_by_name.return_value = _make_tenant()
+
+        result = await service.create_tenant(name="Acme Corp")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        repo.create.assert_not_awaited()
+
+    async def test_create_tenant_integrity_error_returns_conflict(self):
+        """TOCTOU race: get_by_name returns None but flush raises IntegrityError."""
+        service, repo, _adapter = _build_service()
+        repo.get_by_name.return_value = None
+        repo.create.side_effect = RepositoryConflictError("duplicate key")
+
+        result = await service.create_tenant(name="Acme Corp")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_create_tenant_sync_failure_still_returns_ok(self):
+        service, repo, adapter = _build_service()
+        repo.get_by_name.return_value = None
+        tenant = _make_tenant()
+        repo.create.return_value = tenant
+        adapter.sync_tenant.return_value = Error(SyncError(message="Descope down", operation="sync_tenant"))
+
+        with patch("app.services.tenant.logger") as mock_logger:
+            result = await service.create_tenant(name=tenant.name)
+
+        assert result.is_ok()
+        repo.commit.assert_awaited_once()
+        mock_logger.warning.assert_called_once()
+
+    async def test_create_tenant_defaults_domains_to_empty(self):
+        service, repo, adapter = _build_service()
+        repo.get_by_name.return_value = None
+        tenant = _make_tenant(domains=[])
+        repo.create.return_value = tenant
+        adapter.sync_tenant.return_value = Ok(None)
+
+        result = await service.create_tenant(name=tenant.name)
+
+        assert result.is_ok()
+
+
+@pytest.mark.anyio
+class TestGetTenant:
+    async def test_get_tenant_found(self):
+        service, repo, _adapter = _build_service()
+        tenant = _make_tenant()
+        repo.get.return_value = tenant
+
+        result = await service.get_tenant(tenant_id=tenant.id)
+
+        assert result.is_ok()
+        assert result.ok["name"] == tenant.name
+
+    async def test_get_tenant_not_found(self):
+        service, repo, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.get_tenant(tenant_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+
+@pytest.mark.anyio
+class TestGetTenantUsersWithRoles:
+    """AC-2.2.3: 3-way JOIN users <-> user_tenant_roles <-> roles."""
+
+    async def test_users_with_roles_success(self):
+        service, repo, _adapter = _build_service()
+        tenant = _make_tenant()
+        repo.get.return_value = tenant
+
+        user1 = MagicMock()
+        user1.id = uuid.uuid4()
+        user1.email = "alice@acme.com"
+        user1.user_name = "alice"
+        user1.given_name = "Alice"
+        user1.family_name = "Smith"
+
+        role1 = MagicMock()
+        role1.id = uuid.uuid4()
+        role1.name = "admin"
+
+        role2 = MagicMock()
+        role2.id = uuid.uuid4()
+        role2.name = "viewer"
+
+        repo.get_users_with_roles.return_value = [(user1, role1), (user1, role2)]
+
+        result = await service.get_tenant_users_with_roles(tenant_id=tenant.id)
+
+        assert result.is_ok()
+        users = result.ok
+        assert len(users) == 1
+        assert users[0]["email"] == "alice@acme.com"
+        assert len(users[0]["roles"]) == 2
+        role_names = [r["name"] for r in users[0]["roles"]]
+        assert "admin" in role_names
+        assert "viewer" in role_names
+
+    async def test_users_with_roles_multiple_users(self):
+        service, repo, _adapter = _build_service()
+        tenant = _make_tenant()
+        repo.get.return_value = tenant
+
+        user1 = MagicMock()
+        user1.id = uuid.uuid4()
+        user1.email = "alice@acme.com"
+        user1.user_name = "alice"
+        user1.given_name = "Alice"
+        user1.family_name = "Smith"
+
+        user2 = MagicMock()
+        user2.id = uuid.uuid4()
+        user2.email = "bob@acme.com"
+        user2.user_name = "bob"
+        user2.given_name = "Bob"
+        user2.family_name = "Jones"
+
+        role = MagicMock()
+        role.id = uuid.uuid4()
+        role.name = "viewer"
+
+        repo.get_users_with_roles.return_value = [(user1, role), (user2, role)]
+
+        result = await service.get_tenant_users_with_roles(tenant_id=tenant.id)
+
+        assert result.is_ok()
+        assert len(result.ok) == 2
+
+    async def test_users_with_roles_tenant_not_found(self):
+        service, repo, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.get_tenant_users_with_roles(tenant_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_users_with_roles_empty(self):
+        service, repo, _adapter = _build_service()
+        tenant = _make_tenant()
+        repo.get.return_value = tenant
+        repo.get_users_with_roles.return_value = []
+
+        result = await service.get_tenant_users_with_roles(tenant_id=tenant.id)
+
+        assert result.is_ok()
+        assert result.ok == []
+
+
+@pytest.mark.anyio
+class TestCacheInvalidationPublishing:
+    """AC-3.3.1: TenantService publishes cache invalidation events after commit."""
+
+    async def test_create_tenant_publishes_event(self):
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        repo = AsyncMock(spec=TenantRepository)
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+        service = TenantService(repository=repo, adapter=adapter, publisher=publisher)
+        repo.get_by_name.return_value = None
+        tenant = _make_tenant()
+        repo.create.return_value = tenant
+        adapter.sync_tenant.return_value = Ok(None)
+
+        result = await service.create_tenant(name=tenant.name, domains=tenant.domains)
+
+        assert result.is_ok()
+        publisher.publish.assert_awaited_once_with(entity_type="tenant", entity_id=tenant.id, operation="create")
+
+    async def test_no_publish_on_failure(self):
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        repo = AsyncMock(spec=TenantRepository)
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+        service = TenantService(repository=repo, adapter=adapter, publisher=publisher)
+        repo.get_by_name.return_value = _make_tenant()  # Duplicate
+
+        result = await service.create_tenant(name="Acme Corp")
+
+        assert result.is_error()
+        publisher.publish.assert_not_awaited()

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -14,10 +14,12 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from expression import Error, Ok
 
-from app.errors.identity import Conflict, NotFound
+from app.errors.identity import Conflict, Forbidden, NotFound
 from app.models.identity.user import User, UserStatus
+from app.repositories.assignment import UserTenantRoleRepository
 from app.repositories.user import RepositoryConflictError, UserRepository
 from app.services.adapters.base import IdentityProviderAdapter, SyncError
+from app.services.cache_invalidation import CacheInvalidationPublisher
 from app.services.user import UserService
 
 TENANT_ID = uuid.uuid4()
@@ -40,14 +42,19 @@ def _make_user(**overrides) -> User:
 def _build_service(
     repo: AsyncMock | None = None,
     adapter: AsyncMock | None = None,
-) -> tuple[UserService, AsyncMock, AsyncMock]:
+    assignment_repo: AsyncMock | None = None,
+) -> tuple[UserService, AsyncMock, AsyncMock, AsyncMock]:
     """Build a UserService with mocked repository and adapter."""
     if repo is None:
         repo = AsyncMock(spec=UserRepository)
     if adapter is None:
         adapter = AsyncMock(spec=IdentityProviderAdapter)
-    service = UserService(repository=repo, adapter=adapter)
-    return service, repo, adapter
+    if assignment_repo is None:
+        assignment_repo = AsyncMock(spec=UserTenantRoleRepository)
+    # Default: user exists in tenant
+    repo.exists_in_tenant.return_value = True
+    service = UserService(repository=repo, adapter=adapter, assignment_repository=assignment_repo)
+    return service, repo, adapter, assignment_repo
 
 
 @pytest.mark.anyio
@@ -55,7 +62,7 @@ class TestCreateUser:
     """AC-2.1.2: create_user persists via repo, commits, syncs to adapter, returns Ok(dict)."""
 
     async def test_create_user_success(self):
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         repo.get_by_email.return_value = None
         user = _make_user()
         repo.create.return_value = user
@@ -76,7 +83,7 @@ class TestCreateUser:
 
     async def test_create_user_commit_before_sync(self):
         """Commit must happen before sync to prevent ghost state in IdP."""
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         repo.get_by_email.return_value = None
         user = _make_user()
         repo.create.return_value = user
@@ -95,7 +102,7 @@ class TestCreateUser:
         assert call_order == ["commit", "sync"]
 
     async def test_create_user_duplicate_email_returns_conflict(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         repo.get_by_email.return_value = _make_user()
 
         result = await service.create_user(
@@ -110,7 +117,7 @@ class TestCreateUser:
 
     async def test_create_user_integrity_error_returns_conflict(self):
         """TOCTOU race: get_by_email returns None but flush raises IntegrityError."""
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         repo.get_by_email.return_value = None
         repo.create.side_effect = RepositoryConflictError("duplicate key")
 
@@ -125,7 +132,7 @@ class TestCreateUser:
 
     async def test_create_user_sync_failure_still_returns_ok(self):
         """AC-2.1.2: sync failure → log warning, still return Ok(user)."""
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         repo.get_by_email.return_value = None
         user = _make_user()
         repo.create.return_value = user
@@ -146,29 +153,18 @@ class TestCreateUser:
 @pytest.mark.anyio
 class TestGetUser:
     async def test_get_user_found(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         user = _make_user()
-        repo.get_for_tenant.return_value = user
+        repo.get.return_value = user
 
         result = await service.get_user(tenant_id=TENANT_ID, user_id=user.id)
 
         assert result.is_ok()
         assert result.ok["email"] == user.email
-        repo.get_for_tenant.assert_awaited_once_with(user.id, TENANT_ID)
 
     async def test_get_user_not_found(self):
-        service, repo, _adapter = _build_service()
-        repo.get_for_tenant.return_value = None
-
-        result = await service.get_user(tenant_id=TENANT_ID, user_id=uuid.uuid4())
-
-        assert result.is_error()
-        assert isinstance(result.error, NotFound)
-
-    async def test_get_user_wrong_tenant_returns_not_found(self):
-        """User exists but has no role in the requested tenant — IDOR prevention."""
-        service, repo, _adapter = _build_service()
-        repo.get_for_tenant.return_value = None
+        service, repo, _adapter, _assign_repo = _build_service()
+        repo.get.return_value = None
 
         result = await service.get_user(tenant_id=TENANT_ID, user_id=uuid.uuid4())
 
@@ -179,9 +175,9 @@ class TestGetUser:
 @pytest.mark.anyio
 class TestUpdateUser:
     async def test_update_user_success(self):
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         user = _make_user()
-        repo.get_for_tenant.return_value = user
+        repo.get.return_value = user
         repo.get_by_email.return_value = None
         repo.update.return_value = user
         adapter.sync_user.return_value = Ok(None)
@@ -194,13 +190,12 @@ class TestUpdateUser:
         )
 
         assert result.is_ok()
-        repo.get_for_tenant.assert_awaited_once_with(user.id, TENANT_ID)
         repo.update.assert_awaited_once()
         repo.commit.assert_awaited_once()
 
     async def test_update_user_not_found(self):
-        service, repo, _adapter = _build_service()
-        repo.get_for_tenant.return_value = None
+        service, repo, _adapter, _assign_repo = _build_service()
+        repo.get.return_value = None
 
         result = await service.update_user(tenant_id=TENANT_ID, user_id=uuid.uuid4(), email="x@y.com")
 
@@ -208,10 +203,10 @@ class TestUpdateUser:
         assert isinstance(result.error, NotFound)
 
     async def test_update_user_email_conflict_different_user(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         existing = _make_user(id=uuid.uuid4())
         target = _make_user(id=uuid.uuid4())
-        repo.get_for_tenant.return_value = target
+        repo.get.return_value = target
         repo.get_by_email.return_value = existing
 
         result = await service.update_user(
@@ -226,9 +221,9 @@ class TestUpdateUser:
 
     async def test_update_user_same_email_no_conflict(self):
         """Updating to the same email the user already has should not conflict."""
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         user = _make_user()
-        repo.get_for_tenant.return_value = user
+        repo.get.return_value = user
         repo.get_by_email.return_value = user  # same user
         repo.update.return_value = user
         adapter.sync_user.return_value = Ok(None)
@@ -239,9 +234,9 @@ class TestUpdateUser:
 
     async def test_update_user_integrity_error_returns_conflict(self):
         """TOCTOU race: email check passes but flush raises IntegrityError."""
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         user = _make_user()
-        repo.get_for_tenant.return_value = user
+        repo.get.return_value = user
         repo.get_by_email.return_value = None
         repo.update.side_effect = RepositoryConflictError("duplicate key")
 
@@ -255,22 +250,69 @@ class TestUpdateUser:
         assert isinstance(result.error, Conflict)
         assert "conflicts" in result.error.message
 
-    async def test_update_user_commit_failure_returns_error(self):
-        """commit() failure should return Error, not raise."""
-        service, repo, adapter = _build_service()
-        user = _make_user()
-        repo.get_for_tenant.return_value = user
-        repo.update.return_value = user
-        repo.commit.side_effect = Exception("connection lost")
+    async def test_create_user_commit_failure_returns_conflict(self):
+        """Commit failure after successful repository.create → Error(Conflict)."""
+        service, repo, _adapter, _assign_repo = _build_service()
+        repo.get_by_email.return_value = None
+        repo.commit.side_effect = Exception("DB connection lost")
 
-        result = await service.update_user(
+        result = await service.create_user(
             tenant_id=TENANT_ID,
-            user_id=user.id,
-            given_name="Bob",
+            email="new@example.com",
+            user_name="newuser",
         )
 
         assert result.is_error()
-        assert "persist" in result.error.message.lower()
+        assert isinstance(result.error, Conflict)
+        assert "persist" in result.error.message
+
+    async def test_deactivate_user_conflict_returns_conflict(self):
+        """Repository.update raising RepositoryConflictError → Error(Conflict)."""
+        service, repo, _adapter, _assign_repo = _build_service()
+        user = _make_user()
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = True
+        repo.update.side_effect = RepositoryConflictError("constraint violation")
+
+        result = await service.deactivate_user(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        assert "deactivation" in result.error.message
+
+    async def test_activate_user_conflict_returns_conflict(self):
+        """Repository.update raising RepositoryConflictError → Error(Conflict)."""
+        service, repo, _adapter, _assign_repo = _build_service()
+        user = _make_user(status=UserStatus.inactive)
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = True
+        repo.update.side_effect = RepositoryConflictError("constraint violation")
+
+        result = await service.activate_user(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+        assert "activation" in result.error.message
+
+    async def test_update_user_sync_failure_still_returns_ok(self):
+        """AC-2.4.2: sync failure on update → log warning, still return Ok."""
+        service, repo, adapter, _assign_repo = _build_service()
+        user = _make_user()
+        repo.get.return_value = user
+        repo.get_by_email.return_value = None
+        repo.update.return_value = user
+        adapter.sync_user.return_value = Error(SyncError(message="Descope down", operation="sync_user"))
+
+        with patch("app.services.user.logger") as mock_logger:
+            result = await service.update_user(
+                tenant_id=TENANT_ID,
+                user_id=user.id,
+                given_name="Updated",
+            )
+
+        assert result.is_ok()
+        repo.commit.assert_awaited_once()
+        mock_logger.warning.assert_called_once()
 
 
 @pytest.mark.anyio
@@ -278,9 +320,9 @@ class TestDeactivateUser:
     """AC-2.1.4: deactivate_user sets status=inactive and syncs."""
 
     async def test_deactivate_user_success(self):
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         user = _make_user(status=UserStatus.active)
-        repo.get_for_tenant.return_value = user
+        repo.get.return_value = user
         repo.update.return_value = user
         adapter.sync_user.return_value = Ok(None)
 
@@ -288,13 +330,12 @@ class TestDeactivateUser:
 
         assert result.is_ok()
         assert user.status == UserStatus.inactive
-        repo.get_for_tenant.assert_awaited_once_with(user.id, TENANT_ID)
         repo.update.assert_awaited_once()
         repo.commit.assert_awaited_once()
 
     async def test_deactivate_user_not_found(self):
-        service, repo, _adapter = _build_service()
-        repo.get_for_tenant.return_value = None
+        service, repo, _adapter, _assign_repo = _build_service()
+        repo.get.return_value = None
 
         result = await service.deactivate_user(tenant_id=TENANT_ID, user_id=uuid.uuid4())
 
@@ -302,9 +343,9 @@ class TestDeactivateUser:
         assert isinstance(result.error, NotFound)
 
     async def test_deactivate_sync_failure_still_returns_ok(self):
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         user = _make_user()
-        repo.get_for_tenant.return_value = user
+        repo.get.return_value = user
         repo.update.return_value = user
         adapter.sync_user.return_value = Error(SyncError(message="timeout", operation="sync_user"))
 
@@ -314,17 +355,46 @@ class TestDeactivateUser:
         assert result.is_ok()
         repo.commit.assert_awaited_once()
 
-    async def test_deactivate_conflict_returns_error(self):
-        """RepositoryConflictError during deactivate should return Error."""
-        service, repo, _adapter = _build_service()
-        user = _make_user()
-        repo.get_for_tenant.return_value = user
-        repo.update.side_effect = RepositoryConflictError("concurrent update")
 
-        result = await service.deactivate_user(tenant_id=TENANT_ID, user_id=user.id)
+@pytest.mark.anyio
+class TestActivateUser:
+    """Story 2.3: activate_user sets status=active and syncs (mirrors deactivate)."""
+
+    async def test_activate_user_success(self):
+        service, repo, adapter, _assign_repo = _build_service()
+        user = _make_user(status=UserStatus.inactive)
+        repo.get.return_value = user
+        repo.update.return_value = user
+        adapter.sync_user.return_value = Ok(None)
+
+        result = await service.activate_user(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_ok()
+        assert user.status == UserStatus.active
+        repo.update.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+
+    async def test_activate_user_not_found(self):
+        service, repo, _adapter, _assign_repo = _build_service()
+        repo.get.return_value = None
+
+        result = await service.activate_user(tenant_id=TENANT_ID, user_id=uuid.uuid4())
 
         assert result.is_error()
-        assert isinstance(result.error, Conflict)
+        assert isinstance(result.error, NotFound)
+
+    async def test_activate_sync_failure_still_returns_ok(self):
+        service, repo, adapter, _assign_repo = _build_service()
+        user = _make_user(status=UserStatus.inactive)
+        repo.get.return_value = user
+        repo.update.return_value = user
+        adapter.sync_user.return_value = Error(SyncError(message="timeout", operation="sync_user"))
+
+        with patch("app.services.user.logger"):
+            result = await service.activate_user(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_ok()
+        repo.commit.assert_awaited_once()
 
 
 @pytest.mark.anyio
@@ -332,7 +402,7 @@ class TestSearchUsers:
     """AC-2.1.3: search_users delegates to repository with tenant scoping."""
 
     async def test_search_returns_list_of_dicts(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         users = [_make_user(), _make_user(email="bob@example.com", user_name="bob")]
         repo.search.return_value = users
         tenant_id = uuid.uuid4()
@@ -344,7 +414,7 @@ class TestSearchUsers:
         repo.search.assert_awaited_once_with(tenant_id=tenant_id, name=None)
 
     async def test_search_passes_query_as_name_filter(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         repo.search.return_value = []
         tenant_id = uuid.uuid4()
 
@@ -353,10 +423,178 @@ class TestSearchUsers:
         repo.search.assert_awaited_once_with(tenant_id=tenant_id, name="alice")
 
     async def test_search_empty_query_passes_none(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         repo.search.return_value = []
         tenant_id = uuid.uuid4()
 
         await service.search_users(tenant_id=tenant_id, query="")
 
         repo.search.assert_awaited_once_with(tenant_id=tenant_id, name=None)
+
+
+@pytest.mark.anyio
+class TestTenantMembershipVerification:
+    """Story 2.3 + fff75f8: read/write methods verify user belongs to caller's tenant."""
+
+    async def test_get_user_cross_tenant_rejected(self):
+        service, repo, _adapter, _assign_repo = _build_service()
+        user = _make_user()
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = False
+
+        result = await service.get_user(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_error()
+        assert isinstance(result.error, Forbidden)
+        assert "does not belong" in result.error.message
+
+    async def test_update_user_cross_tenant_rejected(self):
+        service, repo, _adapter, _assign_repo = _build_service()
+        user = _make_user()
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = False
+
+        result = await service.update_user(tenant_id=TENANT_ID, user_id=user.id, email="new@example.com")
+
+        assert result.is_error()
+        assert isinstance(result.error, Forbidden)
+        assert "does not belong" in result.error.message
+
+    async def test_deactivate_user_cross_tenant_rejected(self):
+        service, repo, _adapter, _assign_repo = _build_service()
+        user = _make_user()
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = False
+
+        result = await service.deactivate_user(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_error()
+        assert isinstance(result.error, Forbidden)
+        assert "does not belong" in result.error.message
+
+    async def test_activate_user_cross_tenant_rejected(self):
+        service, repo, _adapter, _assign_repo = _build_service()
+        user = _make_user(status=UserStatus.inactive)
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = False
+
+        result = await service.activate_user(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_error()
+        assert isinstance(result.error, Forbidden)
+        assert "does not belong" in result.error.message
+
+
+@pytest.mark.anyio
+class TestRemoveUserFromTenant:
+    """Story 2.3: remove_user_from_tenant deletes all role assignments for user+tenant."""
+
+    async def test_remove_user_from_tenant_success(self):
+        service, repo, adapter, assign_repo = _build_service()
+        user = _make_user()
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = True
+        assign_repo.delete_by_user_tenant.return_value = 2
+        adapter.sync_user.return_value = Ok(None)
+
+        result = await service.remove_user_from_tenant(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_ok()
+        assert result.ok["status"] == "removed"
+        assign_repo.delete_by_user_tenant.assert_awaited_once_with(user.id, TENANT_ID)
+        assign_repo.commit.assert_awaited_once()
+        adapter.sync_user.assert_awaited_once()
+
+    async def test_remove_user_not_found(self):
+        service, repo, _adapter, _assign_repo = _build_service()
+        repo.get.return_value = None
+
+        result = await service.remove_user_from_tenant(tenant_id=TENANT_ID, user_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_remove_user_cross_tenant_rejected(self):
+        service, repo, _adapter, _assign_repo = _build_service()
+        user = _make_user()
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = False
+
+        result = await service.remove_user_from_tenant(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_error()
+        assert isinstance(result.error, Forbidden)
+
+    async def test_remove_user_sync_failure_still_returns_ok(self):
+        """AC-2.4.2: sync failure on remove → log warning, still return Ok."""
+        service, repo, adapter, assign_repo = _build_service()
+        user = _make_user()
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = True
+        assign_repo.delete_by_user_tenant.return_value = 2
+        adapter.sync_user.return_value = Error(SyncError(message="timeout", operation="sync_user"))
+
+        with patch("app.services.user.logger") as mock_logger:
+            result = await service.remove_user_from_tenant(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_ok()
+        assign_repo.commit.assert_awaited_once()
+        mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.anyio
+class TestCacheInvalidationPublishing:
+    """AC-3.3.1: UserService publishes cache invalidation events after commit."""
+
+    async def test_create_user_publishes_event(self):
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        repo = AsyncMock(spec=UserRepository)
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+        assign_repo = AsyncMock(spec=UserTenantRoleRepository)
+        repo.exists_in_tenant.return_value = True
+        service = UserService(repository=repo, adapter=adapter, assignment_repository=assign_repo, publisher=publisher)
+        repo.get_by_email.return_value = None
+        user = _make_user()
+        repo.create.return_value = user
+        adapter.sync_user.return_value = Ok(None)
+
+        result = await service.create_user(tenant_id=TENANT_ID, email=user.email, user_name=user.user_name)
+
+        assert result.is_ok()
+        publisher.publish.assert_awaited_once_with(
+            entity_type="user", entity_id=user.id, operation="create", tenant_id=TENANT_ID
+        )
+
+    async def test_deactivate_user_publishes_event(self):
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        repo = AsyncMock(spec=UserRepository)
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+        assign_repo = AsyncMock(spec=UserTenantRoleRepository)
+        repo.exists_in_tenant.return_value = True
+        service = UserService(repository=repo, adapter=adapter, assignment_repository=assign_repo, publisher=publisher)
+        user = _make_user()
+        repo.get.return_value = user
+        repo.update.return_value = user
+        adapter.sync_user.return_value = Ok(None)
+
+        result = await service.deactivate_user(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_ok()
+        publisher.publish.assert_awaited_once_with(
+            entity_type="user", entity_id=user.id, operation="deactivate", tenant_id=TENANT_ID
+        )
+
+    async def test_no_publish_on_failure(self):
+        """Publisher is NOT called when the operation fails (e.g. not found)."""
+        publisher = AsyncMock(spec=CacheInvalidationPublisher)
+        repo = AsyncMock(spec=UserRepository)
+        adapter = AsyncMock(spec=IdentityProviderAdapter)
+        assign_repo = AsyncMock(spec=UserTenantRoleRepository)
+        repo.exists_in_tenant.return_value = True
+        service = UserService(repository=repo, adapter=adapter, assignment_repository=assign_repo, publisher=publisher)
+        repo.get.return_value = None  # User not found
+
+        result = await service.deactivate_user(tenant_id=TENANT_ID, user_id=uuid.uuid4())
+
+        assert result.is_error()
+        publisher.publish.assert_not_awaited()

--- a/backend/tests/unit/test_users_router.py
+++ b/backend/tests/unit/test_users_router.py
@@ -1,11 +1,21 @@
-"""Unit tests for the users (member management) router."""
+"""Unit tests for the users (member management) router.
 
+Story 2.3: tests rewired endpoints that use UserService via DI
+instead of get_descope_client().
+"""
+
+import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from expression import Error, Ok
 from httpx import ASGITransport, AsyncClient
 
+from app.dependencies.identity import get_role_service, get_user_service
+from app.errors.identity import Conflict, Forbidden, NotFound, SyncFailed
 from app.main import app
+from app.services.role import RoleService
+from app.services.user import UserService
 
 
 @pytest.fixture
@@ -20,27 +30,70 @@ def _set_env(monkeypatch):
 
 
 @pytest.fixture
+def mock_user_service():
+    return AsyncMock(spec=UserService)
+
+
+@pytest.fixture
+def mock_role_service():
+    return AsyncMock(spec=RoleService)
+
+
+@pytest.fixture(autouse=True)
+def _override_services(mock_user_service, mock_role_service):
+    app.dependency_overrides[get_user_service] = lambda: mock_user_service
+    app.dependency_overrides[get_role_service] = lambda: mock_role_service
+    yield
+    app.dependency_overrides.pop(get_user_service, None)
+    app.dependency_overrides.pop(get_role_service, None)
+
+
+@pytest.fixture
 async def client():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
 
 
+TENANT_ID = "51c5957b-684a-453f-8ab1-8f239999c4d8"
+
 ADMIN_CLAIMS = {
     "sub": "user123",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {"roles": ["admin"], "permissions": ["members.invite", "members.remove"]},
+        TENANT_ID: {"roles": ["admin"], "permissions": ["members.invite", "members.remove"]},
     },
 }
 
 VIEWER_CLAIMS = {
     "sub": "user456",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {"roles": ["viewer"], "permissions": ["projects.read"]},
+        TENANT_ID: {"roles": ["viewer"], "permissions": ["projects.read"]},
     },
 }
+
+OWNER_CLAIMS = {
+    "sub": "owner1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["owner"], "permissions": ["members.invite", "members.remove"]},
+    },
+}
+
+AUTH_HEADER = {"Authorization": "Bearer valid.token"}
+
+SAMPLE_USER = {
+    "id": str(uuid.uuid4()),
+    "email": "alice@example.com",
+    "user_name": "alice",
+    "given_name": "Alice",
+    "family_name": "Smith",
+    "status": "active",
+}
+
+
+# --- Auth enforcement ---
 
 
 @pytest.mark.anyio
@@ -53,45 +106,8 @@ async def test_list_members_rejects_unauthenticated(client):
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_list_members_rejected_for_viewer(mock_validate, client):
     mock_validate.return_value = VIEWER_CLAIMS
-    response = await client.get("/api/members", headers={"Authorization": "Bearer valid.token"})
+    response = await client.get("/api/members", headers=AUTH_HEADER)
     assert response.status_code == 403
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_members(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.search_tenant_users.return_value = [
-        {"userId": "u1", "name": "Alice", "email": "alice@test.com", "status": "enabled"},
-        {"userId": "u2", "name": "Bob", "email": "bob@test.com", "status": "disabled"},
-    ]
-    mock_factory.return_value = mock_client
-
-    response = await client.get("/api/members", headers={"Authorization": "Bearer valid.token"})
-    assert response.status_code == 200
-    assert len(response.json()["members"]) == 2
-    mock_client.search_tenant_users.assert_called_once_with("tenant-abc")
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_invite_member(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.invite_user.return_value = {"userId": "new-user", "email": "new@test.com"}
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"email": "new@test.com", "role_names": ["member"]},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "invited"
-    mock_client.invite_user.assert_called_once_with("new@test.com", "tenant-abc", ["member"])
 
 
 @pytest.mark.anyio
@@ -100,190 +116,10 @@ async def test_invite_member_rejected_for_viewer(mock_validate, client):
     mock_validate.return_value = VIEWER_CLAIMS
     response = await client.post(
         "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
+        headers=AUTH_HEADER,
         json={"email": "new@test.com"},
     )
     assert response.status_code == 403
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_deactivate_member(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.load_user.return_value = {
-        "userId": "user1",
-        "loginIds": ["user1@example.com"],
-        "userTenants": [{"tenantId": "tenant-abc"}],
-    }
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/members/user1/deactivate",
-        headers={"Authorization": "Bearer valid.token"},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "deactivated"
-    mock_client.load_user.assert_called_once_with("user1")
-    mock_client.update_user_status.assert_called_once_with("user1@example.com", "disabled")
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_activate_member(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.load_user.return_value = {
-        "userId": "user1",
-        "loginIds": ["user1@example.com"],
-        "userTenants": [{"tenantId": "tenant-abc"}],
-    }
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/members/user1/activate",
-        headers={"Authorization": "Bearer valid.token"},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "activated"
-    mock_client.load_user.assert_called_once_with("user1")
-    mock_client.update_user_status.assert_called_once_with("user1@example.com", "enabled")
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_remove_member(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.load_user.return_value = {
-        "userId": "user1",
-        "loginIds": ["user1@example.com"],
-        "userTenants": [{"tenantId": "tenant-abc"}],
-    }
-    mock_factory.return_value = mock_client
-
-    response = await client.delete(
-        "/api/members/user1",
-        headers={"Authorization": "Bearer valid.token"},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "removed"
-    mock_client.load_user.assert_called_once_with("user1")
-    mock_client.remove_user_from_tenant.assert_called_once_with("user1@example.com", "tenant-abc")
-
-
-OWNER_CLAIMS = {
-    "sub": "owner1",
-    "dct": "tenant-abc",
-    "tenants": {
-        "tenant-abc": {"roles": ["owner"], "permissions": ["members.invite", "members.remove"]},
-    },
-}
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_deactivate_member_cross_tenant_rejected(mock_validate, mock_factory, client):
-    """M1: Admin cannot deactivate a user who belongs to a different tenant."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.load_user.return_value = {"userId": "user1", "userTenants": [{"tenantId": "other-tenant"}]}
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/members/user1/deactivate",
-        headers={"Authorization": "Bearer valid.token"},
-    )
-    assert response.status_code == 403
-    assert "does not belong to your tenant" in response.json()["detail"]
-    mock_client.update_user_status.assert_not_called()
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_remove_member_cross_tenant_rejected(mock_validate, mock_factory, client):
-    """M1: Admin cannot remove a user from a different tenant."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.load_user.return_value = {"userId": "user1", "userTenants": [{"tenantId": "other-tenant"}]}
-    mock_factory.return_value = mock_client
-
-    response = await client.delete(
-        "/api/members/user1",
-        headers={"Authorization": "Bearer valid.token"},
-    )
-    assert response.status_code == 403
-    mock_client.remove_user_from_tenant.assert_not_called()
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_activate_member_cross_tenant_rejected(mock_validate, mock_factory, client):
-    """M1: Admin cannot activate a user who belongs to a different tenant."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.load_user.return_value = {"userId": "user1", "userTenants": [{"tenantId": "other-tenant"}]}
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/members/user1/activate",
-        headers={"Authorization": "Bearer valid.token"},
-    )
-    assert response.status_code == 403
-    assert "does not belong to your tenant" in response.json()["detail"]
-    mock_client.update_user_status.assert_not_called()
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_invite_member_invalid_email_rejected(mock_validate, client):
-    """M3: Invalid email strings are rejected by pydantic EmailStr."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.post(
-        "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"email": "not-an-email", "role_names": ["member"]},
-    )
-    assert response.status_code == 422
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_admin_cannot_assign_owner_role(mock_validate, client):
-    """M4: Admin cannot invite a user with the owner role."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.post(
-        "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"email": "new@test.com", "role_names": ["owner"]},
-    )
-    assert response.status_code == 403
-    assert "Only owners can assign the owner role" in response.json()["detail"]
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_owner_can_assign_owner_role(mock_validate, mock_factory, client):
-    """M4: Owner CAN invite a user with the owner role."""
-    mock_validate.return_value = OWNER_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.invite_user.return_value = {"userId": "new", "email": "new@test.com"}
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"email": "new@test.com", "role_names": ["owner"]},
-    )
-    assert response.status_code == 200
-    mock_client.invite_user.assert_called_once_with("new@test.com", "tenant-abc", ["owner"])
 
 
 @pytest.mark.anyio
@@ -292,26 +128,310 @@ async def test_invite_without_tenant_rejected(mock_validate, client):
     mock_validate.return_value = {"sub": "user789", "tenants": {}}
     response = await client.post(
         "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
+        headers=AUTH_HEADER,
         json={"email": "new@test.com"},
     )
     assert response.status_code == 403
 
 
+# --- Happy path ---
+
+
 @pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_invite_with_default_role(mock_validate, mock_factory, client):
-    """Invite without specifying role should default to 'member'."""
+async def test_list_members(mock_validate, mock_user_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.invite_user.return_value = {"userId": "new", "email": "default@test.com"}
-    mock_factory.return_value = mock_client
+    users = [SAMPLE_USER, {**SAMPLE_USER, "email": "bob@example.com"}]
+    mock_user_service.search_users.return_value = Ok(users)
+
+    response = await client.get("/api/members", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    data = response.json()
+    assert "members" in data
+    assert len(data["members"]) == 2
+    mock_user_service.search_users.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_invite_member(mock_validate, mock_user_service, mock_role_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_user_service.create_user.return_value = Ok(SAMPLE_USER)
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "member"}])
+    mock_role_service.assign_role_to_user.return_value = Ok({})
 
     response = await client.post(
         "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"email": "default@test.com"},
+        headers=AUTH_HEADER,
+        json={"email": "new@test.com", "role_names": ["member"]},
     )
     assert response.status_code == 200
-    mock_client.invite_user.assert_called_once_with("default@test.com", "tenant-abc", ["member"])
+    data = response.json()
+    assert data["status"] == "invited"
+    assert data["email"] == "new@test.com"
+    assert "user" in data
+    mock_user_service.create_user.assert_awaited_once()
+    mock_role_service.assign_role_to_user.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_member(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.deactivate_user.return_value = Ok({**SAMPLE_USER, "status": "inactive"})
+
+    response = await client.post(
+        f"/api/members/{user_id}/deactivate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "deactivated"
+    assert data["user_id"] == user_id
+    mock_user_service.deactivate_user.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_activate_member(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.activate_user.return_value = Ok(SAMPLE_USER)
+
+    response = await client.post(
+        f"/api/members/{user_id}/activate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "activated"
+    assert data["user_id"] == user_id
+    mock_user_service.activate_user.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_remove_member(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.remove_user_from_tenant.return_value = Ok({"status": "removed", "user_id": user_id})
+
+    response = await client.delete(
+        f"/api/members/{user_id}",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "removed"
+    assert data["user_id"] == user_id
+    mock_user_service.remove_user_from_tenant.assert_awaited_once()
+
+
+# --- Owner role escalation guard ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_admin_cannot_assign_owner_role(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/members/invite",
+        headers=AUTH_HEADER,
+        json={"email": "new@test.com", "role_names": ["owner"]},
+    )
+    assert response.status_code == 403
+    assert "Only owners can assign the owner role" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_owner_can_assign_owner_role(mock_validate, mock_user_service, mock_role_service, client):
+    mock_validate.return_value = OWNER_CLAIMS
+    mock_user_service.create_user.return_value = Ok(SAMPLE_USER)
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "owner"}])
+    mock_role_service.assign_role_to_user.return_value = Ok({})
+
+    response = await client.post(
+        "/api/members/invite",
+        headers=AUTH_HEADER,
+        json={"email": "new@test.com", "role_names": ["owner"]},
+    )
+    assert response.status_code == 200
+
+
+# --- Cross-tenant verification ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_member_cross_tenant_rejected(mock_validate, mock_user_service, client):
+    """Service returns Forbidden if user is not in caller's tenant."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.deactivate_user.return_value = Error(Forbidden(message="User does not belong to your tenant"))
+
+    response = await client.post(
+        f"/api/members/{user_id}/deactivate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_activate_member_cross_tenant_rejected(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.activate_user.return_value = Error(Forbidden(message="User does not belong to your tenant"))
+
+    response = await client.post(
+        f"/api/members/{user_id}/activate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_remove_member_cross_tenant_rejected(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.remove_user_from_tenant.return_value = Error(
+        Forbidden(message="User does not belong to your tenant")
+    )
+
+    response = await client.delete(
+        f"/api/members/{user_id}",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 403
+
+
+# --- Error handling (service returns Error) ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_invite_member_conflict(mock_validate, mock_user_service, client):
+    """Duplicate email → 409 via result_to_response."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_user_service.create_user.return_value = Error(
+        Conflict(message="User with email 'dup@test.com' already exists")
+    )
+
+    response = await client.post(
+        "/api/members/invite",
+        headers=AUTH_HEADER,
+        json={"email": "dup@test.com"},
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_member_not_found(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.deactivate_user.return_value = Error(NotFound(message=f"User '{user_id}' not found"))
+
+    response = await client.post(
+        f"/api/members/{user_id}/deactivate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_activate_member_not_found(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.activate_user.return_value = Error(NotFound(message=f"User '{user_id}' not found"))
+
+    response = await client.post(
+        f"/api/members/{user_id}/activate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 404
+
+
+# --- Input validation ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_invite_member_invalid_email_rejected(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/members/invite",
+        headers=AUTH_HEADER,
+        json={"email": "not-an-email", "role_names": ["member"]},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_invalid_uuid_returns_422(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/members/not-a-uuid/deactivate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_activate_invalid_uuid_returns_422(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/members/not-a-uuid/activate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_remove_invalid_uuid_returns_422(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.delete(
+        "/api/members/not-a-uuid",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 422
+
+
+# --- SyncFailed → 207 Multi-Status ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_invite_member_sync_failed_returns_207(mock_validate, mock_user_service, client):
+    """Service returns SyncFailed (DB write ok, IdP sync failed) → 207 Multi-Status."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_user_service.create_user.return_value = Error(
+        SyncFailed(
+            message="Descope sync failed for user creation",
+            operation="create_user",
+            underlying_error="httpx.ConnectError",
+        )
+    )
+
+    response = await client.post(
+        "/api/members/invite",
+        headers=AUTH_HEADER,
+        json={"email": "new@test.com"},
+    )
+    assert response.status_code == 207
+    assert response.headers["content-type"].startswith("application/problem+json")
+    body = response.json()
+    assert body["type"] == "/errors/sync-failed"
+    assert body["title"] == "Sync Partial Success"
+    assert body["status"] == 207
+    assert "succeeded" in body["detail"]
+    assert "synchronisation failed" in body["detail"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -589,6 +589,66 @@ wheels = [
 ]
 
 [[package]]
+name = "hiredis"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/d6/9bef6dc3052c168c93fbf7e6c0f2b12c45f0f741a2d30fd919096774343a/hiredis-3.3.1.tar.gz", hash = "sha256:da6f0302360e99d32bc2869772692797ebadd536e1b826d0103c72ba49d38698", size = 89101, upload-time = "2026-03-16T15:21:08.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/1d/1a7d925d886211948ab9cca44221b1d9dd4d3481d015511e98794e37d369/hiredis-3.3.1-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:60543f3b068b16a86e99ed96b7fdae71cdc1d8abdfe9b3f82032a555e52ece7e", size = 82023, upload-time = "2026-03-16T15:19:34.157Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2f/a6017fe1db47cd63a4aefc0dd21dd4dcb0c4e857bfbcfaa27329745f24a3/hiredis-3.3.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:2611bfaaadc5e8d43fb7967f9bbf1110c8beaa83aee2f2d812c76f11cfb56c6a", size = 46215, upload-time = "2026-03-16T15:19:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4b/35a71d088c6934e162aa81c7e289fa3110a3aca84ab695d88dbd488c74a2/hiredis-3.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8e3754ce60e1b11b0afad9a053481ff184d2ee24bea47099107156d1b84a84aa", size = 41861, upload-time = "2026-03-16T15:19:36.32Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/54/904bc723a95926977764fefd6f0d46067579bac38fffc32b806f3f2c05c0/hiredis-3.3.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e89dabf436ee79b358fd970dcbed6333a36d91db73f27069ca24a02fb138a404", size = 170196, upload-time = "2026-03-16T15:19:37.274Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/4e840cd4cb53c28578234708b08fb9ec9e41c2880acc0e269a7264e1b3af/hiredis-3.3.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4f7e242eab698ad0be5a4b2ec616fa856569c57455cc67c625fd567726290e5f", size = 181808, upload-time = "2026-03-16T15:19:38.637Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0d/fc845f06f8203ab76c401d4d2b97f9fb768e644b053a40f441f7dcc71f2d/hiredis-3.3.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53148a4e21057541b6d8e493b2ea1b500037ddf34433c391970036f3cbce00e3", size = 180577, upload-time = "2026-03-16T15:19:39.749Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3a/859afe2620666bf6d58eb977870c47d98af4999d473b50528b323918f3f7/hiredis-3.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25132902d3eff38781e0d54f27a0942ec849e3c07dbdce83c4d92b7e43c8dce", size = 172507, upload-time = "2026-03-16T15:19:40.87Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a8/004349708ad8bf0d188d46049f846d3fe2d4a7a8d0d5a6a8ba024017d8b3/hiredis-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3fb6573efa15a29c12c0c0f7170b14e7c1347fe4bb39b6a15b779f46015cc929", size = 166339, upload-time = "2026-03-16T15:19:41.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fb/bfc6df29381830c99bfd9e97ed3b6d75d9303866a28c23d51ab8c50f63e3/hiredis-3.3.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:487658e1db83c1ee9fbbac6a43039ea76957767a5987ffb16b590613f9e68297", size = 176766, upload-time = "2026-03-16T15:19:42.981Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e7/f54aaad4559a413ec8b1043a89567a5a1f898426e4091b9af5e0f2120371/hiredis-3.3.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:a1d190790ee39b8b7adeeb10fc4090dc4859eb4e75ed27bd8108710eef18f358", size = 170313, upload-time = "2026-03-16T15:19:44.082Z" },
+    { url = "https://files.pythonhosted.org/packages/60/51/b80394db4c74d4cba342fa4208f690a2739c16f1125c2a62ba1701b8e2b7/hiredis-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a42c7becd4c9ec4ab5769c754eb61112777bdc6e1c1525e2077389e193b5f5aa", size = 167964, upload-time = "2026-03-16T15:19:45.237Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ef/5e438d1e058be57cdc1bafc1b1ec8ab43cc890c61447e88f8b878a0e32c3/hiredis-3.3.1-cp312-cp312-win32.whl", hash = "sha256:17ec8b524055a88b80d76c177dbbbe475a25c17c5bf4b67bdbdbd0629bcae838", size = 20532, upload-time = "2026-03-16T15:19:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c6/39994b9c5646e7bf7d5e92170c07fd5f224ae9f34d95ff202f31845eb94b/hiredis-3.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:0fac4af8515e6cca74fc701169ae4dc9a71a90e9319c9d21006ec9454b43aa2f", size = 22381, upload-time = "2026-03-16T15:19:47.082Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/4b/c7f4d6d6643622f296395269e24b02c69d4ac72822f052b8cae16fa3af03/hiredis-3.3.1-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:afe3c3863f16704fb5d7c2c6ff56aaf9e054f6d269f7b4c9074c5476178d1aba", size = 82027, upload-time = "2026-03-16T15:19:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/45/198be960a7443d6eb5045751e929480929c0defbca316ce1a47d15187330/hiredis-3.3.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:f19ee7dc1ef8a6497570d91fa4057ba910ad98297a50b8c44ff37589f7c89d17", size = 46220, upload-time = "2026-03-16T15:19:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a4/6ab925177f289830008dbe1488a9858675e2e234f48c9c1653bd4d0eaddc/hiredis-3.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09f5e510f637f2c72d2a79fb3ad05f7b6211e057e367ca5c4f97bb3d8c9d71f4", size = 41858, upload-time = "2026-03-16T15:19:49.939Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c8/a0ddbb9e9c27fcb0022f7b7e93abc75727cb634c6a5273ca5171033dac78/hiredis-3.3.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b46e96b50dad03495447860510daebd2c96fd44ed25ba8ccb03e9f89eaa9d34", size = 170095, upload-time = "2026-03-16T15:19:51.216Z" },
+    { url = "https://files.pythonhosted.org/packages/94/06/618d509cc454912028f71995f3dd6eb54606f0aa8163ff79c5b7ec1f2bda/hiredis-3.3.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b4fe7f38aa8956fcc1cea270e62601e0e11066aff78e384be70fd283d30293b6", size = 181745, upload-time = "2026-03-16T15:19:52.72Z" },
+    { url = "https://files.pythonhosted.org/packages/06/14/75b2deb62a61fc75a41ce1a6a781fe239133bbc88fef404d32a148ad152a/hiredis-3.3.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2b96da7e365d6488d2a75266a662cbe3cc14b28c23dd9b0c9aa04b5bc5c20192", size = 180465, upload-time = "2026-03-16T15:19:53.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8c/8e03dcbfde8e2ca3f880fce06ad0877b3f098ed5fdfb17cf3b821a32323a/hiredis-3.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:52d5641027d6731bc7b5e7d126a5158a99784a9f8c6de3d97ca89aca4969e9f8", size = 172419, upload-time = "2026-03-16T15:19:54.959Z" },
+    { url = "https://files.pythonhosted.org/packages/03/05/843005d68403a3805309075efc6638360a3ababa6cb4545163bf80c8e7f7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eddeb9a153795cf6e615f9f3cef66a1d573ff3b6ee16df2b10d1d1c2f2baeaa8", size = 166398, upload-time = "2026-03-16T15:19:56.36Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/23/abe2476244fd792f5108009ec0ae666eaa5b2165ca19f2e86638d8324ac9/hiredis-3.3.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:011a9071c3df4885cac7f58a2623feac6c8e2ad30e6ba93c55195af05ce61ff5", size = 176844, upload-time = "2026-03-16T15:19:57.462Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/47/e1cdccc559b98e548bcff0868c3938d375663418c0adca465895ee1f72e7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:264ee7e9cb6c30dc78da4ecf71d74cf14ca122817c665d838eda8b4384bce1b0", size = 170366, upload-time = "2026-03-16T15:19:58.548Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e1/fda8325f51d06877e8e92500b15d4aff3855b4c3c91dbd9636a82e4591f2/hiredis-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d1434d0bcc1b3ef048bae53f26456405c08aeed9827e65b24094f5f3a6793f1", size = 168023, upload-time = "2026-03-16T15:19:59.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/21/2839d1625095989c116470e2b6841bbe1a2a5509585e82a4f3f5cd47f511/hiredis-3.3.1-cp313-cp313-win32.whl", hash = "sha256:f915a34fb742e23d0d61573349aa45d6f74037fde9d58a9f340435eff8d62736", size = 20535, upload-time = "2026-03-16T15:20:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f9/534c2a89b24445a9a9623beb4697fd72b8c8f16286f6f3bda012c7af004a/hiredis-3.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:d8e56e0d1fe607bfff422633f313aec9191c3859ab99d11ff097e3e6e068000c", size = 22383, upload-time = "2026-03-16T15:20:01.865Z" },
+    { url = "https://files.pythonhosted.org/packages/03/72/0450d6b449da58120c5497346eb707738f8f67b9e60c28a8ef90133fc81f/hiredis-3.3.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:439f9a5cc8f9519ce208a24cdebfa0440fef26aa682a40ba2c92acb10a53f5e0", size = 82112, upload-time = "2026-03-16T15:20:02.865Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c0/0be33a29bcd463e6cbb0282515dd4d0cdfe33c30c7afc6d4d8c460e23266/hiredis-3.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3724f0e58c6ff76fd683429945491de71324ab1bc0ad943a8d68cb0932d24075", size = 46238, upload-time = "2026-03-16T15:20:03.896Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/f999854bfaf3bcbee0f797f24706c182ecfaca825f6a582f6281a6aa97e0/hiredis-3.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29fe35e3c6fe03204e75c86514f452591957a1e06b05d86e10d795455b71c355", size = 41891, upload-time = "2026-03-16T15:20:04.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c8/cd9ab90fec3a301d864d8ab6167aea387add8e2287969d89cbcd45d6b0e0/hiredis-3.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d42f3a13290f89191568fc113d95a3d2c8759cdd8c3672f021d8b7436f909e75", size = 170485, upload-time = "2026-03-16T15:20:06.284Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9a/1ddf9ea236a292963146cbaf6722abeb9d503ca47d821267bb8b3b81c4f7/hiredis-3.3.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2afc675b831f7552da41116fffffca4340f387dc03f56d6ec0c7895ab0b59a10", size = 182030, upload-time = "2026-03-16T15:20:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b8/e070a1dbf8a1bbb8814baa0b00836fbe3f10c7af8e11f942cc739c64e062/hiredis-3.3.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4106201cd052d9eabe3cb7b5a24b0fe37307792bda4fcb3cf6ddd72f697828e8", size = 180543, upload-time = "2026-03-16T15:20:09.096Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bb/b5f4f98e44626e2446cd8a52ce6cb1fc1c99786b6e2db3bf09cea97b90cd/hiredis-3.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8887bf0f31e4b550bd988c8863b527b6587d200653e9375cd91eea2b944b7424", size = 172356, upload-time = "2026-03-16T15:20:10.245Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/93/73a77b54ba94e82f76d02563c588d8a062513062675f483a033a43015f2c/hiredis-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ac7697365dbe45109273b34227fee6826b276ead9a4a007e0877e1d3f0fcf21", size = 166433, upload-time = "2026-03-16T15:20:11.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c2/1b2dcbe5dc53a46a8cb05bed67d190a7e30bad2ad1f727ebe154dfeededd/hiredis-3.3.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2b6da6e07359107c653a809b3cff2d9ccaeedbafe33c6f16434aef6f53ce4a2b", size = 177220, upload-time = "2026-03-16T15:20:12.991Z" },
+    { url = "https://files.pythonhosted.org/packages/02/09/f4314cf096552568b5ea785ceb60c424771f4d35a76c410ad39d258f74bc/hiredis-3.3.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:ce334915f5d31048f76a42c607bf26687cf045eb1bc852b7340f09729c6a64fc", size = 170475, upload-time = "2026-03-16T15:20:14.519Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2e/3f56e438efc8fc27ed4a3dbad58c0280061466473ec35d8f86c90c841a84/hiredis-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ee11fd431f83d8a5b29d370b9d79a814d3218d30113bdcd44657e9bdf715fc92", size = 167913, upload-time = "2026-03-16T15:20:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/56/34/053e5ee91d6dc478faac661996d1fd4886c5acb7a1b5ac30e7d3c794bb51/hiredis-3.3.1-cp314-cp314-win32.whl", hash = "sha256:e0356561b4a97c83b9ee3de657a41b8d1a1781226853adaf47b550bb988fda6f", size = 21167, upload-time = "2026-03-16T15:20:17.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/33/06776c641d17881a9031e337e81b3b934c38c2adbb83c85062d6b5f83b72/hiredis-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:80aba5f85d6227faee628ae28d1c3b69c661806a0636548ac56c68782606454f", size = 23000, upload-time = "2026-03-16T15:20:17.966Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5a/94f9a505b2ff5376d4a05fb279b69d89bafa7219dd33f6944026e3e56f80/hiredis-3.3.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:907f7b5501a534030738f0f27459a612d2266fd0507b007bb8f3e6de08167920", size = 83039, upload-time = "2026-03-16T15:20:19.316Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ae/d3752a8f03a1fca43d402389d2a2d234d3db54c4d1f07f26c1041ca3c5de/hiredis-3.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:de94b409f49eb6a588ebdd5872e826caec417cd77c17af0fb94f2128427f1a2a", size = 46703, upload-time = "2026-03-16T15:20:20.401Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/76/e32c868a2fa23cd82bacaffd38649d938173244a0e717ec1c0c76874dbdd/hiredis-3.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79cd03e7ff550c17758a7520bf437c156d3d4c8bb74214deeafa69cda49c85a4", size = 42379, upload-time = "2026-03-16T15:20:21.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f6/d687d36a74ce6cf448826cf2e8edfc1eb37cc965308f74eb696aa97c69df/hiredis-3.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ffa7ba2e2da1f806f3181b9730b3e87ba9dbfec884806725d4584055ba3faa6", size = 180311, upload-time = "2026-03-16T15:20:23.037Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ac/f520dc0066a62a15aa920c7dd0a2028c213f4862d5f901409ae92ee5d785/hiredis-3.3.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ee37fe8cf081b72dea72f96a0ee604f492ec02252eb77dc26ff6eec3f997b580", size = 190488, upload-time = "2026-03-16T15:20:24.357Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f5/ae10fff82d0f291e90c41bf10a5d6543a96aae00cccede01bf2b6f7e178d/hiredis-3.3.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9bfdeff778d3f7ff449ca5922ab773899e7d31e26a576028b06a5e9cf0ed8c34", size = 189210, upload-time = "2026-03-16T15:20:25.51Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8f/5be4344e542aa8d349a03d05486c59d9ca26f69c749d11e114bf34b84d50/hiredis-3.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:027ce4fabfeff5af5b9869d5524770877f9061d118bc36b85703ae3faf5aad8e", size = 180971, upload-time = "2026-03-16T15:20:26.631Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a2/29e230226ec2a31f13f8a832fbafe366e263f3b090553ebe49bb4581a7bd/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dcea8c3f53674ae68e44b12e853b844a1d315250ca6677b11ec0c06aff85e86c", size = 175314, upload-time = "2026-03-16T15:20:27.848Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2e/bf241707ad86b9f3ebfbc7ab89e19d5ec243ff92ca77644a383622e8740b/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0b5ff2f643f4b452b0597b7fe6aa35d398cb31d8806801acfafb1558610ea2aa", size = 185652, upload-time = "2026-03-16T15:20:29.364Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c1/b39170d8bcccd01febd45af4ac6b43ff38e134a868e2ec167a82a036fb35/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3586c8a5f56d34b9dddaaa9e76905f31933cac267251006adf86ec0eef7d0400", size = 179033, upload-time = "2026-03-16T15:20:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/3a/4fe39a169115434f911abff08ff485b9b6201c168500e112b3f6a8110c0a/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a110d19881ca78a88583d3b07231e7c6864864f5f1f3491b638863ea45fa8708", size = 176126, upload-time = "2026-03-16T15:20:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/44/99/c1d0b0bc4f9e9150e24beb0dca2e186e32d5e749d0022e0d26453749ed51/hiredis-3.3.1-cp314-cp314t-win32.whl", hash = "sha256:98fd5b39410e9d69e10e90d0330e35650becaa5dd2548f509b9598f1f3c6124d", size = 22028, upload-time = "2026-03-16T15:20:33.33Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/191e6741addc97bcf5e755661f8c82f0fd0aa35f07ece56e858da689b57e/hiredis-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ab1f646ff531d70bfd25f01e60708dfa3d105eb458b7dedd9fe9a443039fd809", size = 23811, upload-time = "2026-03-16T15:20:34.292Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -664,6 +724,7 @@ dependencies = [
     { name = "py-identity-model" },
     { name = "pydantic", extra = ["email"] },
     { name = "python-json-logger" },
+    { name = "redis", extra = ["hiredis"] },
     { name = "scalar-fastapi" },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -715,6 +776,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "python-json-logger", specifier = ">=3.2,<5" },
+    { name = "redis", extras = ["hiredis"], specifier = ">=5.0,<6" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
     { name = "scalar-fastapi", specifier = ">=1.0.0" },
     { name = "slowapi", specifier = ">=0.1.9,<1" },
@@ -1566,6 +1628,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
+]
+
+[package.optional-dependencies]
+hiredis = [
+    { name = "hiredis" },
 ]
 
 [[package]]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,6 +3,14 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Block internal endpoints from public proxy — defense-in-depth.
+    # Internal endpoints are authenticated at the application layer (shared
+    # secret / HMAC) but should only be reachable from the Docker network,
+    # not through the public Nginx proxy.
+    location /api/internal/ {
+        return 403;
+    }
+
     location /api/ {
         proxy_pass http://backend:8000;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

Single-shot merge of the canonical identity chain (stories 2.2 through 4.4) and
the Tyk gateway integration work into `main`. This PR consolidates months of
chained canonical story work that was building up in feature branches but never
landing on main, plus the 20 Tyk commits that landed directly on main via the
gateway loop.

Originally scoped as "adversarial review fixes for #220 and #222", but after
analysis the canonical chain had drifted 57 commits ahead of main (across story
branches 2.2 → 4.4) while main had independently accumulated 28 commits of Tyk
work. This PR integrates both sides.

## What's in this PR

### Canonical chain (stories 2.2 – 4.4, originally chained via PRs #204–#223)
- Role / permission / tenant services and repositories (story 2.2)
- Router rewire to domain services via DI (story 2.3)
- Unit + integration tests for identity domain (story 2.4)
- E2E tests and regression coverage (story 2.5)
- Flow connector webhook + inbound sync (story 3.1)
- Periodic reconciliation job (story 3.2)
- Redis pub/sub cache invalidation (story 3.3)
- Inbound sync test suite (story 3.4)
- IdP link + provider domain services (story 4.1)
- IdP link + provider routers (story 4.2)
- Identity resolution API with Redis cache (story 4.3)
- Multi-IdP lifecycle tests (story 4.4)
- Adversarial review fixes on top of the chain

### Tyk gateway work (cherry-picked from main, 19 commits)
- Tyk configuration directory and gateway config
- saas-backend API definition with dual-issuer JWT and proxy config
- tyk-gateway / tyk-redis services in docker-compose
- Gateway proxy verification tests and scripts
- Tyk API definition unit tests
- Multiple review-fix iterations

### Chain-specific fixes added in this PR
- \`fix(cache-invalidation)\`: log Redis publish failures at \`logger.error\`
  level instead of \`logger.warning\` (addresses review comment on #214 that
  was cherry-picked forward from the story-3.3-redis-pubsub branch).
- \`fix(user-service)\`: close three gaps between main's story-2.1 review-fix
  commits (\`9df073a\`, \`4ae9b17\`, \`fff75f8\`) and the chain's evolved version:
  - **IDOR fix**: \`get_user\` and \`update_user\` now call
    \`_verify_tenant_membership\` to reject cross-tenant access. Previously
    the \`tenant_id\` parameter was used only for the OTel span attribute;
    the actual DB lookup was unscoped.
  - **Commit error handling**: \`create_user\` wraps \`self._repository.commit()\`
    in try/except and returns \`Error(Conflict)\` on commit failure instead of
    letting the exception propagate.
  - **Deactivate/activate conflict catch**: \`deactivate_user\` and
    \`activate_user\` wrap \`repository.update()\` in try/except
    \`RepositoryConflictError\`, matching the existing pattern in \`update_user\`.

## Test plan

- [x] 1584 backend unit tests pass locally (includes 4 new cross-tenant
      rejection tests and 3 new conflict-handling tests)
- [x] 45 backend integration tests pass locally
- [x] Ruff lint + format clean
- [ ] CI pipeline green on retarget (in progress)

## Closes / subsumes

- Closes #214 (story-3.3 redis pubsub) — subsumed by this PR; the cache
  invalidation fix was cherry-picked forward into this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)