### PR TITLE
feat: wire DEPLOYMENT_MODE into docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test-integration-standalone: ## run standalone profile integration tests (manage
 	./scripts/test-integration-standalone.sh
 
 test-integration-gateway: ## run gateway profile integration tests (manages compose lifecycle, requires env vars)
-	./scripts/test-integration-gateway.sh
+	COMPOSE_GATEWAY_OVERRIDE="-f docker-compose.yml -f docker-compose.gateway.yml" ./scripts/test-integration-gateway.sh
 
-dev-gateway: ## start full stack with gateway profile
-	docker compose --profile gateway up --build
+dev-gateway: ## start full stack with gateway profile (DEPLOYMENT_MODE=gateway via override)
+	docker compose -f docker-compose.yml -f docker-compose.gateway.yml --profile gateway up --build

--- a/backend/tests/unit/test_docker_compose_gateway.py
+++ b/backend/tests/unit/test_docker_compose_gateway.py
@@ -204,6 +204,40 @@ class TestDefaultComposeMinimumFunctional:
         assert len(default_services) == 3
 
 
+class TestDeploymentModeWiring:
+    """Story 3.2: DEPLOYMENT_MODE is wired through docker compose.
+
+    The base file sets standalone; the gateway override flips it to gateway.
+    Both `make dev-gateway` and `make test-integration-gateway` use the
+    multi-file invocation so backend lands in gateway mode whenever Tyk is
+    in front of it.
+    """
+
+    def test_base_compose_sets_standalone_default(self):
+        compose = _load_compose()
+        env = compose["services"]["backend"]["environment"]
+        assert any("DEPLOYMENT_MODE=standalone" in str(e) for e in env), (
+            "backend service must declare DEPLOYMENT_MODE=standalone in the base compose file"
+        )
+
+    def test_gateway_override_file_exists(self):
+        override = REPO_ROOT / "docker-compose.gateway.yml"
+        assert override.exists(), "docker-compose.gateway.yml override file must exist"
+
+    def test_gateway_override_flips_deployment_mode(self):
+        override = yaml.safe_load((REPO_ROOT / "docker-compose.gateway.yml").read_text())
+        env = override["services"]["backend"]["environment"]
+        assert any("DEPLOYMENT_MODE=gateway" in str(e) for e in env), (
+            "docker-compose.gateway.yml must override DEPLOYMENT_MODE=gateway"
+        )
+
+    def test_makefile_dev_gateway_uses_override(self):
+        makefile = (REPO_ROOT / "Makefile").read_text()
+        assert "docker-compose.gateway.yml" in makefile, (
+            "Makefile must reference docker-compose.gateway.yml so dev-gateway flips DEPLOYMENT_MODE"
+        )
+
+
 class TestInfraProfile:
     """Story 4.1: redis + aspire-dashboard are opt-in via --profile infra."""
 

--- a/docker-compose.gateway.yml
+++ b/docker-compose.gateway.yml
@@ -1,0 +1,19 @@
+# Gateway-mode override (story 3.2).
+#
+# Layered on top of docker-compose.yml to flip the backend into gateway
+# mode (DEPLOYMENT_MODE=gateway), which causes the middleware factory to
+# replace TokenValidationMiddleware with GatewayClaimsMiddleware (story
+# 2.4) and skip SlowAPIMiddleware. Tyk is the primary enforcement layer
+# in this mode; GatewayClaimsMiddleware enforces exp/iss/aud as defense
+# in depth (issue #240).
+#
+# Activation: prefer `make dev-gateway` and `make test-integration-gateway`
+# which wrap the multi-file invocation. Direct CLI form:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.gateway.yml \
+#     --profile gateway up --build
+
+services:
+  backend:
+    environment:
+      - DEPLOYMENT_MODE=gateway

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,13 @@ services:
       - REDIS_URL=redis://:${REDIS_PASSWORD:-changeme}@redis:6379/0
       - DESCOPE_PROJECT_ID=${DESCOPE_PROJECT_ID:-}
       - DESCOPE_MANAGEMENT_KEY=${DESCOPE_MANAGEMENT_KEY:-}
+      # DEPLOYMENT_MODE selects whether the backend runs its own JWT
+      # validation + rate limiting (standalone) or trusts Tyk to have
+      # done it (gateway). Default is standalone; gateway mode is
+      # opt-in via the docker-compose.gateway.yml override (story 3.2)
+      # which `make dev-gateway` and `make test-integration-gateway`
+      # both wrap automatically.
+      - DEPLOYMENT_MODE=standalone
     healthcheck:
       test:
         - CMD

--- a/scripts/test-integration-gateway.sh
+++ b/scripts/test-integration-gateway.sh
@@ -33,10 +33,10 @@ cleanup() {
     header "Teardown"
     if [ "$exit_code" -ne 0 ] || [ "${FAIL:-0}" -gt 0 ]; then
         echo "Test run failed — dumping container logs before teardown:"
-        docker compose --profile gateway logs --tail=200 2>&1 || true
+        docker compose ${COMPOSE_GATEWAY_OVERRIDE:-} --profile gateway logs --tail=200 2>&1 || true
     fi
     echo "Stopping gateway profile..."
-    docker compose --profile gateway down -v --timeout 10 2>&1 || true
+    docker compose ${COMPOSE_GATEWAY_OVERRIDE:-} --profile gateway down -v --timeout 10 2>&1 || true
     echo "Teardown complete."
 }
 trap cleanup EXIT
@@ -57,20 +57,31 @@ echo "All required env vars present."
 
 # ── Startup ──
 header "Starting gateway profile"
-if ! docker compose --profile gateway up -d --build --wait --wait-timeout "$MAX_WAIT"; then
+if ! docker compose ${COMPOSE_GATEWAY_OVERRIDE:-} --profile gateway up -d --build --wait --wait-timeout "$MAX_WAIT"; then
     echo "ERROR: Compose up failed. Container logs:"
-    docker compose --profile gateway logs --tail=50 || true
+    docker compose ${COMPOSE_GATEWAY_OVERRIDE:-} --profile gateway logs --tail=50 || true
     exit 1
 fi
 echo "Compose up complete."
+
+# ── AC: Backend DEPLOYMENT_MODE is gateway (story 3.2 wiring) ──
+header "AC: Backend DEPLOYMENT_MODE is gateway"
+set +e
+ACTUAL_MODE=$(docker compose ${COMPOSE_GATEWAY_OVERRIDE:-} --profile gateway exec -T backend printenv DEPLOYMENT_MODE 2>/dev/null | tr -d '\r\n')
+set -e
+if [ "$ACTUAL_MODE" = "gateway" ]; then
+    pass "Backend container has DEPLOYMENT_MODE=gateway"
+else
+    fail "Backend container has DEPLOYMENT_MODE='${ACTUAL_MODE}', expected 'gateway' — override file not loaded?"
+fi
 
 # ── AC5: Container count ──
 header "AC5: Gateway container count"
 # Count all containers compose started (including successfully-exited init
 # sidecars like tyk-init, which use service_completed_successfully and are
 # therefore not in "running" state once they finish their substitution work).
-EXPECTED_COUNT=$(docker compose --profile gateway config --services | wc -l | tr -d ' ')
-ACTUAL_COUNT=$(docker compose --profile gateway ps --all -q | wc -l | tr -d ' ')
+EXPECTED_COUNT=$(docker compose ${COMPOSE_GATEWAY_OVERRIDE:-} --profile gateway config --services | wc -l | tr -d ' ')
+ACTUAL_COUNT=$(docker compose ${COMPOSE_GATEWAY_OVERRIDE:-} --profile gateway ps --all -q | wc -l | tr -d ' ')
 if [ "$ACTUAL_COUNT" -eq "$EXPECTED_COUNT" ]; then
     pass "Container count (${ACTUAL_COUNT}) matches expected (${EXPECTED_COUNT})"
 else

--- a/scripts/test-integration-standalone.sh
+++ b/scripts/test-integration-standalone.sh
@@ -64,6 +64,17 @@ if ! docker compose up -d --build --wait --wait-timeout "$MAX_WAIT"; then
 fi
 echo "Compose up complete."
 
+# ── AC: Backend DEPLOYMENT_MODE is standalone (story 3.2 wiring) ──
+header "AC: Backend DEPLOYMENT_MODE is standalone"
+set +e
+ACTUAL_MODE=$(docker compose exec -T backend printenv DEPLOYMENT_MODE 2>/dev/null | tr -d '\r\n')
+set -e
+if [ "$ACTUAL_MODE" = "standalone" ]; then
+    pass "Backend container has DEPLOYMENT_MODE=standalone"
+else
+    fail "Backend container has DEPLOYMENT_MODE='${ACTUAL_MODE}', expected 'standalone'"
+fi
+
 # ── AC4: Container count ──
 header "AC4: Standalone container count"
 EXPECTED_COUNT=$(docker compose config --services | wc -l | tr -d ' ')


### PR DESCRIPTION
## Summary
- Added `DEPLOYMENT_MODE=standalone` to `docker-compose.yml` backend service environment block (AC-1, AC-3)
- Created `docker-compose.gateway.yml` override file setting `DEPLOYMENT_MODE=gateway` for backend service (AC-2, AC-4)
- Updated `Makefile` `dev-gateway` target to include `-f docker-compose.gateway.yml` override (AC-4)
- Updated stale gateway launch instructions in test files to reference `make dev-gateway`

Refs #172

## Review Findings Addressed
- 5 reviewers spawned (Blind Hunter, Edge Case Hunter, Acceptance Auditor, Sentinel, Viper)
- 0 MUST FIX / 0 BLOCK / 0 CRITICAL / 0 HIGH findings
- 2 SHOULD FIX dismissed (silent behavior change — no actual change since factory default is standalone; fragile invocation — by design per ADR-GW-6)
- 2 Edge Case stale instruction fixes applied (commit d99ec10)
- 2 Viper MEDIUM dismissed (backend port exposure and rate limiting — outside story scope)
- Acceptance Auditor: all 5 ACs PASS

## Test plan
- [x] Unit tests pass (1584)
- [x] Frontend tests pass (86)
- [x] Lint passes
- [x] Independent review agents passed (5/5)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)