### PR TITLE
docs: add deployment mode documentation (factory, compose, tyk)

### DIFF
--- a/backend/app/middleware/factory.py
+++ b/backend/app/middleware/factory.py
@@ -1,10 +1,94 @@
 """Middleware factory — sole location for deployment-mode-conditional logic.
 
-Evaluates DEPLOYMENT_MODE once at import time (never per-request).
+DEPLOYMENT_MODE is evaluated **once** at module import time (never per
+request). The mode determines which middleware get registered, and the
+factory is the only place where that branching happens — every other
+middleware module is mode-agnostic.
 
-v2 upgrade path: replace os.getenv("DEPLOYMENT_MODE") with
-OpenFeature client.get_string_value("deployment_mode", "standalone")
-for hot-toggle and per-feature flag support.
+## Deployment modes
+
+Two modes are supported:
+
+### standalone (default — `docker compose up`)
+
+The backend is the **primary** enforcement layer. The browser (or any
+client) talks to the backend directly through nginx's `/api/` proxy on
+the same origin. Middleware stack (outermost → innermost):
+
+  1. ProxyHeadersMiddleware     — trusts X-Forwarded-* from 127.0.0.1
+  2. SecurityHeadersMiddleware  — adds CSP, X-Frame-Options, etc.
+  3. SlowAPIMiddleware          — per-route rate limiting
+  4. TokenValidationMiddleware  — validates Descope JWT signature via
+                                  JWKS, enforces exp/iss/aud, populates
+                                  request.state.claims
+  5. CORSMiddleware             — same-origin in dev, env-driven in prod
+
+`require_role` / `require_permission` dependencies in routers consume
+`request.state.claims` (set by TokenValidation) to enforce per-tenant
+authorization.
+
+### gateway (`make dev-gateway` — flips DEPLOYMENT_MODE via override)
+
+Tyk is the **primary** enforcement layer. Browser → Tyk:8080 → backend.
+Tyk validates the JWT signature, expiry, issuer, and audience against
+Descope's JWKS, then forwards the original `Authorization` header to
+the backend. The backend's middleware stack drops TokenValidation and
+SlowAPI (Tyk handles them) and adds GatewayClaimsMiddleware:
+
+  1. ProxyHeadersMiddleware     — trusts X-Forwarded-* from 127.0.0.1
+  2. SecurityHeadersMiddleware  — adds CSP, X-Frame-Options, etc.
+  3. GatewayClaimsMiddleware    — base64-decodes the pre-validated JWT
+                                  to populate request.state.claims;
+                                  ALSO enforces exp/iss/aud as defense
+                                  in depth (issue #240)
+  4. CORSMiddleware             — same-origin in dev, env-driven in prod
+
+`require_role` / `require_permission` work identically in both modes
+because they only read `request.state.claims` — they don't care which
+middleware populated it.
+
+### Auth / authz boundary
+
+  - **Authentication** (who is this?): Tyk in gateway mode,
+    TokenValidationMiddleware in standalone mode. Both verify the JWT
+    signature, expiry, issuer, and audience against Descope.
+  - **Authorization** (what can they do?): always FastAPI. Tyk does NOT
+    decode tenant claims — it just forwards the validated JWT. The
+    backend's RBAC dependencies decode `dct` (current tenant) and
+    `tenants[*].roles/permissions` from request.state.claims.
+
+The `Authorization` header is intentionally NOT stripped at the Tyk
+layer (`strip_auth_data: false` in tyk/apps/saas-backend.json) so the
+backend can decode tenant claims after Tyk validates the signature.
+
+### Defense in depth (issue #240)
+
+Issue #240 documented a four-day window where `tyk/entrypoint.sh` was
+silently broken and Tyk wasn't actually validating tokens, while the
+backend was running in gateway mode (= signature verification skipped)
+and trusting forwarded headers. To prevent a recurrence:
+
+  - GatewayClaimsMiddleware enforces exp/iss/aud independently of Tyk,
+    so a missing or misconfigured Tyk will not result in forged or
+    expired tokens being trusted.
+  - scripts/test-integration-{standalone,gateway}.sh assert
+    `docker compose exec backend printenv DEPLOYMENT_MODE` matches
+    expectations at runtime, gating CI on the mode actually flowing
+    through the override.
+  - test_standalone_regression.py and the standalone integration script
+    prove that forged X-Tyk-Request-ID headers cannot bypass auth in
+    standalone mode.
+
+These checks are NOT a substitute for signature verification by Tyk in
+gateway mode — they catch the "Tyk silently not in front" failure mode,
+not the "Tyk in front but compromised" mode.
+
+## v2 upgrade path
+
+Replace `os.getenv("DEPLOYMENT_MODE")` with
+`OpenFeature client.get_string_value("deployment_mode", "standalone")`
+for hot-toggle and per-feature flag support without restarting the
+backend container.
 """
 
 import logging

--- a/backend/tests/unit/test_docker_compose_gateway.py
+++ b/backend/tests/unit/test_docker_compose_gateway.py
@@ -238,6 +238,71 @@ class TestDeploymentModeWiring:
         )
 
 
+class TestTykReadme:
+    """Story 3.3: tyk/README.md must describe the post-#229 init-sidecar
+    setup, not the deleted entrypoint.sh."""
+
+    def test_readme_exists(self):
+        readme = TYK_DIR / "README.md"
+        assert readme.exists(), "tyk/README.md must exist (story 3.3 deployment-mode docs)"
+
+    def test_readme_describes_init_sidecar(self):
+        text = (TYK_DIR / "README.md").read_text()
+        assert "tyk-init" in text, (
+            "tyk/README.md must describe the tyk-init sidecar (the post-#229 substitution mechanism)"
+        )
+
+    def test_readme_does_not_describe_deleted_entrypoint_script_as_current(self):
+        text = (TYK_DIR / "README.md").read_text()
+        # The old approach used a tyk/entrypoint.sh shell script that
+        # could not exec inside the scratch tyk image. #229 deleted it.
+        # Allow historical references inside the section that explains
+        # the substitution history, but the file must not be listed as
+        # part of the current layout.
+        layout_section = text.split("## How env-var substitution works")[0]
+        assert "entrypoint.sh" not in layout_section, (
+            "tyk/README.md layout section must not list entrypoint.sh — it was deleted in #229"
+        )
+
+    def test_readme_documents_target_url_at_backend_root(self):
+        text = (TYK_DIR / "README.md").read_text()
+        assert "http://backend:8000/" in text, (
+            "tyk/README.md must document target_url=http://backend:8000/ "
+            "(the post-#229 fix for the duplicated /api/ prefix)"
+        )
+
+
+class TestFactoryDocstring:
+    """Story 3.3: factory.py module docstring must honestly describe both
+    deployment modes — including the gateway-mode middleware stack that
+    actually exists post-#230, and the defense-in-depth checks added in
+    response to #240."""
+
+    def test_module_docstring_describes_both_modes(self):
+        from app.middleware import factory
+
+        doc = factory.__doc__ or ""
+        assert "standalone" in doc.lower(), "module docstring must describe standalone mode"
+        assert "gateway" in doc.lower(), "module docstring must describe gateway mode"
+
+    def test_module_docstring_documents_gatewayclaims_middleware(self):
+        from app.middleware import factory
+
+        doc = factory.__doc__ or ""
+        assert "GatewayClaimsMiddleware" in doc, (
+            "module docstring must document GatewayClaimsMiddleware now that it exists (added by #230)"
+        )
+
+    def test_module_docstring_documents_240_defense_in_depth(self):
+        from app.middleware import factory
+
+        doc = factory.__doc__ or ""
+        assert "#240" in doc or "240" in doc, (
+            "module docstring must reference issue #240 — the operational lesson the defense-in-depth "
+            "checks were built to catch"
+        )
+
+
 class TestFrontendApiBaseUrlBuildArg:
     """Story 4.2: VITE_API_BASE_URL is wired through compose -> Dockerfile.
 

--- a/tyk/README.md
+++ b/tyk/README.md
@@ -1,0 +1,152 @@
+# Tyk Gateway Configuration
+
+This directory holds the file-based Tyk configuration the gateway profile
+mounts into the `tyk-gateway` container. Tyk runs in [file-based mode]
+(`use_db_app_configs: false`), so editing files here and running
+`make dev-gateway` (or `docker compose --profile gateway up --build`) is
+the canonical way to change gateway behavior.
+
+[file-based mode]: https://tyk.io/docs/tyk-self-managed/install/install-tyk-gateway/configure-tyk-gateway/
+
+## Layout
+
+```
+tyk/
+├── README.md           ← this file
+├── tyk.conf            ← gateway-level config (listen port, Redis, policies, app_path)
+├── apps/               ← API definition templates (read by tyk-init sidecar)
+│   └── saas-backend.json
+├── policies/           ← shared OpenID/key policies
+│   └── policies.json
+└── middleware/         ← Tyk JS plugins (currently empty placeholder)
+```
+
+The base directory layout is mounted into the container at boot:
+
+| Host path             | Container path                            | Mode | Notes                                                   |
+| --------------------- | ----------------------------------------- | ---- | ------------------------------------------------------- |
+| `tyk/tyk.conf`        | `/opt/tyk-gateway/tyk.conf`               | rw   | Gateway config — substituted at startup, edit freely    |
+| `tyk/apps/`           | (mounted into `tyk-init`'s `/in`, not gateway) | ro   | API definition **templates** (with `${VAR}` placeholders) |
+| `tyk-apps` (volume)   | `/opt/tyk-gateway/apps`                   | ro   | Substituted API definitions (written by `tyk-init`)     |
+| `tyk/middleware/`     | `/opt/tyk-gateway/middleware`             | rw   | JS plugin directory                                     |
+| `tyk/policies/`       | `/opt/tyk-gateway/policies`               | rw   | Policy JSON                                             |
+
+## How env-var substitution works (`tyk-init` sidecar)
+
+The `tykio/tyk-gateway:v5.3` image is **scratch-based** — it ships only
+the `tyk` binary and has no shell. That means a shebang script (the
+old `tyk/entrypoint.sh` approach) cannot run inside the container at
+all; it crashes with `exec: no such file or directory` because the
+kernel can't find `/bin/sh`. This was discovered in [issue #240]
+during the CI wire-up of the profile integration tests, after the
+broken setup had been silently sitting in `main` for four days.
+
+[issue #240]: https://github.com/jamescrowley321/identity-stack/issues/240
+
+The fix is the **`tyk-init` init sidecar** defined in
+`docker-compose.yml`:
+
+```yaml
+tyk-init:
+  image: alpine:3.20
+  environment:
+    - DESCOPE_PROJECT_ID=${DESCOPE_PROJECT_ID:?...}
+  volumes:
+    - ./tyk/apps:/in:ro          # template source
+    - tyk-apps:/out              # substituted output
+  entrypoint:
+    - /bin/sh
+    - -eu
+    - -c
+    - |
+      # validate DESCOPE_PROJECT_ID
+      # rm -f /out/*.json
+      # for f in /in/*.json; do sed substitute → /out/$(basename $f)
+  profiles: [gateway, full]
+
+tyk-gateway:
+  image: tykio/tyk-gateway:v5.3
+  volumes:
+    - ./tyk/tyk.conf:/opt/tyk-gateway/tyk.conf
+    - tyk-apps:/opt/tyk-gateway/apps:ro    # mounts substituted output
+    - ./tyk/middleware:/opt/tyk-gateway/middleware
+    - ./tyk/policies:/opt/tyk-gateway/policies
+  depends_on:
+    tyk-init: { condition: service_completed_successfully }
+    tyk-redis: { condition: service_started }
+    backend:   { condition: service_started }
+```
+
+`tyk-gateway` uses its image default entrypoint (`/opt/tyk-gateway/tyk`)
+and waits on `tyk-init` to exit successfully via
+`service_completed_successfully`. The `tyk-apps` named volume is the
+shared substitution output directory, mounted read-only into the
+gateway. Adding a new template:
+
+  1. Drop `your-api.json` into `tyk/apps/`.
+  2. Use `${DESCOPE_PROJECT_ID}` (or any other env var) anywhere you
+     want compose-time substitution.
+  3. `make dev-gateway` (or `docker compose --profile gateway up --build`)
+     — `tyk-init` will sed-substitute it on next boot.
+
+## API definition: `tyk/apps/saas-backend.json`
+
+Defines the proxy from Tyk's `/api/` to the backend. Key fields:
+
+| Field                  | Value                          | Why                                                            |
+| ---------------------- | ------------------------------ | -------------------------------------------------------------- |
+| `listen_path`          | `/api/`                        | Tyk listens for requests under this prefix                     |
+| `target_url`           | `http://backend:8000/`         | Backend root — Tyk forwards the full incoming path verbatim    |
+| `strip_listen_path`    | `false`                        | Keep the `/api/` prefix when forwarding (it's part of FastAPI's routes)|
+| `preserve_host_header` | `true`                         | Backend sees the original `Host` header                        |
+| `strip_auth_data`      | `false`                        | Authorization header is forwarded so FastAPI can read tenant claims |
+| `use_openid`           | `true`                         | Validate JWTs against Descope's OpenID Connect discovery       |
+| `openid_options.providers` | dual issuer                | Descope emits two issuer formats (OIDC and session/access-key) |
+| `extended_paths.ignored` | `/api/health` GET            | Health endpoint bypasses JWT validation for readiness probes   |
+| `extended_paths.rate_limit` | `/api/validate-id-token` 10/min POST | Stricter rate limit on a token-handling route        |
+
+The `target_url` is the **backend root**, not `http://backend:8000/api/`.
+With `strip_listen_path: false`, Tyk appends the full incoming path
+(`/api/<x>`) to the target URL. If the target included `/api/`, the
+backend would see `/api/api/<x>` and 404. The unit test
+`test_api_definition_required_keys` pins this to prevent the
+duplicated-prefix regression that was uncovered alongside #240.
+
+## tyk.conf
+
+| Key                  | Value                                               | Notes                                                            |
+| -------------------- | --------------------------------------------------- | ---------------------------------------------------------------- |
+| `listen_port`        | `8080`                                              | Compose maps to host `127.0.0.1:8080`                            |
+| `secret`             | `REPLACE_AT_RUNTIME`                                | Sentinel — overridden by `TYK_GW_SECRET` env var (no hardcoded secrets) |
+| `app_path`           | `/opt/tyk-gateway/apps`                             | Tyk reads API definitions from here — populated by `tyk-init`    |
+| `use_db_app_configs` | `false`                                             | File-based mode, no Tyk Dashboard required                       |
+| `storage`            | Redis (`tyk-redis:6379`)                            | Separate Redis instance from the app's `redis` service           |
+
+## Operating procedures
+
+| Command                                | Effect                                                          |
+| -------------------------------------- | --------------------------------------------------------------- |
+| `make dev-gateway`                     | Spin up gateway profile + backend in `DEPLOYMENT_MODE=gateway`  |
+| `make test-integration-gateway`        | Lifecycle-managed end-to-end test (CI gate)                     |
+| `docker compose logs tyk-init`         | Inspect substitution output (template count + filenames)        |
+| `docker compose logs tyk-gateway`      | Inspect Tyk's startup, API loading, and request logs            |
+
+## Troubleshooting
+
+**`tyk-init` exits 1 with `FATAL: DESCOPE_PROJECT_ID contains invalid characters`**
+
+The substitution script enforces `[A-Za-z0-9_-]` on the project id to
+prevent shell-injection-style placeholder values. Set `DESCOPE_PROJECT_ID`
+in `.env` (or your CI env) to a real project id.
+
+**`tyk-gateway` healthcheck fails / 404 from `/api/health`**
+
+Confirm `tyk-init` exited cleanly and the `tyk-apps` volume contains
+the substituted JSON: `docker run --rm -v identity-stack_tyk-apps:/data alpine:3.20 ls -la /data/`.
+If the volume is empty, the init sidecar didn't run — check
+`docker compose logs tyk-init`.
+
+If the volume is populated but the gateway returns 404 on `/api/<x>`
+that the backend should serve, verify `target_url` is `http://backend:8000/`
+(NOT `http://backend:8000/api/`) — the duplicated-prefix bug is
+specifically what `test_api_definition_required_keys` guards against.


### PR DESCRIPTION
## Summary

- Expanded `backend/app/middleware/factory.py` module docstring with comprehensive deployment mode documentation covering two modes, middleware stacks per mode, auth/authz boundary, and v2 upgrade path (AC-1)
- Added 16-line comment block at top of `docker-compose.yml` with profile usage examples for standalone, gateway, and full stack modes (AC-3)
- Created `tyk/README.md` with file layout, API definition structure, dual-issuer OpenID Connect config, and auth/authz boundary documentation (AC-4)
- `tyk/apps/saas-backend.json` already had `x-description` field documenting auth boundary — no changes needed (AC-2)
- AC-5 (composite) satisfied by AC-1 + AC-2 + AC-4 together

Refs #173

## Review Findings Addressed

- **5 reviewers**: Blind Hunter, Edge Case Hunter, Acceptance Auditor, Sentinel, Viper
- **1 P1 fix applied**: Clarified gateway comment in docker-compose.yml — override file now presented as required with warning about silent misconfiguration
- **4 P1 dismissed**: All Viper MEDIUM/LOW findings are pre-existing infrastructure concerns not introduced by this docs-only story
- **0 P0 findings**
- **Acceptance Auditor**: 5/5 ACs PASS

## Test plan
- [x] Unit tests pass (1584 backend, 86 frontend)
- [x] Lint passes (ruff check + format)
- [x] Independent review agents passed (5 reviewers)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)