### PR TITLE
ci: split dependabot groups by update-type (closes #236)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,58 @@
 version: 2
+
+# Groups are split by update-type so dependabot creates separate PRs for
+# safe (patch), usually-safe (minor), and risky (major) bumps. This was
+# split out of one wildcard group after #236, where 8 major-version bumps
+# (typescript 5→6, vite 6→8, eslint 9→10, etc.) were silently mixed in
+# with 9 patch/minor bumps in a single PR — too dangerous to merge as a
+# blob, too tedious to split by hand. Now patches/minors flow through
+# normally and majors get their own focused PR with no surprises.
+
 updates:
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
     groups:
-      python-deps:
+      python-deps-patch:
         patterns: ["*"]
-    open-pull-requests-limit: 5
+        update-types: ["patch"]
+      python-deps-minor:
+        patterns: ["*"]
+        update-types: ["minor"]
+      python-deps-major:
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
     groups:
-      npm-deps:
+      npm-deps-patch:
         patterns: ["*"]
-    open-pull-requests-limit: 5
+        update-types: ["patch"]
+      npm-deps-minor:
+        patterns: ["*"]
+        update-types: ["minor"]
+      npm-deps-major:
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
     groups:
-      actions:
+      actions-patch:
         patterns: ["*"]
+        update-types: ["patch"]
+      actions-minor:
+        patterns: ["*"]
+        update-types: ["minor"]
+      actions-major:
+        patterns: ["*"]
+        update-types: ["major"]


### PR DESCRIPTION
## Summary

Split each dependabot ecosystem's wildcard group into three update-type groups (`patch`, `minor`, `major`) so future runs produce focused PRs instead of mega-blobs that mix safe and risky bumps.

## Why

#236 surfaced the workflow problem: the `npm-deps` group bundled **8 major-version bumps** (typescript 5→6, vite 6→8, eslint 9→10, @vitejs/plugin-react 4→6, eslint-plugin-react-hooks 5→7, @eslint/js 9→10, @types/testing-library__jest-dom 5→6, globals 15→17) with 9 patch/minor bumps in a single PR. The grouped bump was:
- Too risky to merge unattended — every major needs its own regression review
- Too tedious to split by hand — closing the dependabot PR loses all 17 lock-file updates

## Effect

Going forward each ecosystem produces up to 3 dependabot PRs per cycle:
- `*-patch` — safe; routine merge after CI green
- `*-minor` — usually safe; quick review then merge
- `*-major` — needs focused review of breaking changes in isolation

Branch protection on `main` is now strict (11 required checks including the runtime profile-integration-tests job from #239), so the patch/minor PRs can land confidently — broken bumps will be caught by CI before they touch `main`.

## Closes

- #236 (the bundled mega-PR — too dangerous to merge as-is, will be regenerated as 3 separate PRs on the next dependabot cycle)

## Test plan

- [x] YAML validates
- [ ] CI passes