### PR TITLE
fix: use correct HTTP methods for Descope management API endpoints

### DIFF
--- a/backend/app/services/descope.py
+++ b/backend/app/services/descope.py
@@ -60,6 +60,24 @@ class DescopeManagementClient:
             if self._owns_client or self._http_client is None:
                 await client.aclose()
 
+    async def _get(self, path: str) -> httpx.Response:
+        """Send a GET request to the Descope Management API.
+
+        Some Descope endpoints (notably /v1/mgmt/permission/all) only
+        accept GET, unlike the majority which use POST.
+        """
+        client = self._get_client()
+        try:
+            resp = await client.get(
+                f"{self.base_url}{path}",
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return resp
+        finally:
+            if self._owns_client or self._http_client is None:
+                await client.aclose()
+
     async def create_tenant(
         self,
         name: str,
@@ -74,7 +92,7 @@ class DescopeManagementClient:
 
     async def list_tenants(self) -> list[dict]:
         """List all tenants in the Descope project."""
-        resp = await self._request("/v1/mgmt/tenant/all", {})
+        resp = await self._request("/v1/mgmt/tenant/search", {})
         return resp.json().get("tenants", [])
 
     async def load_tenant(self, tenant_id: str) -> dict:
@@ -185,8 +203,12 @@ class DescopeManagementClient:
         await self._request("/v1/mgmt/accesskey/delete", {"id": key_id})
 
     async def list_permissions(self) -> list[dict]:
-        """List all permission definitions in the Descope project."""
-        resp = await self._request("/v1/mgmt/permission/all", {})
+        """List all permission definitions in the Descope project.
+
+        Unlike tenants and roles whose ``/search`` endpoint accepts POST,
+        permissions only expose a ``/all`` endpoint that requires GET.
+        """
+        resp = await self._get("/v1/mgmt/permission/all")
         return resp.json().get("permissions", [])
 
     async def create_permission(self, name: str, description: str = "") -> None:
@@ -205,7 +227,7 @@ class DescopeManagementClient:
 
     async def list_roles(self) -> list[dict]:
         """List all role definitions in the Descope project."""
-        resp = await self._request("/v1/mgmt/role/all", {})
+        resp = await self._request("/v1/mgmt/role/search", {})
         return resp.json().get("roles") or []
 
     async def create_role(self, name: str, description: str = "", permission_names: list[str] | None = None) -> None:

--- a/backend/tests/unit/test_descope_service.py
+++ b/backend/tests/unit/test_descope_service.py
@@ -388,7 +388,7 @@ class TestDescopeManagementClient:
     async def test_list_permissions(self, mock_cls, client):
         mock_http = AsyncMock()
         mock_cls.return_value = mock_http
-        mock_http.post.return_value = MagicMock(
+        mock_http.get.return_value = MagicMock(
             status_code=200,
             raise_for_status=MagicMock(),
             json=MagicMock(return_value={"permissions": [{"name": "reports.read", "description": "View reports"}]}),
@@ -396,10 +396,9 @@ class TestDescopeManagementClient:
 
         result = await client.list_permissions()
         assert result == [{"name": "reports.read", "description": "View reports"}]
-        mock_http.post.assert_called_once_with(
+        mock_http.get.assert_called_once_with(
             "https://api.descope.com/v1/mgmt/permission/all",
             headers={"Authorization": "Bearer proj-123:mgmt-key-456"},
-            json={},
         )
 
     @pytest.mark.anyio
@@ -458,7 +457,7 @@ class TestDescopeManagementClient:
         result = await client.list_roles()
         assert result == [{"name": "admin", "description": "Admin role"}]
         mock_http.post.assert_called_once_with(
-            "https://api.descope.com/v1/mgmt/role/all",
+            "https://api.descope.com/v1/mgmt/role/search",
             headers={"Authorization": "Bearer proj-123:mgmt-key-456"},
             json={},
         )


### PR DESCRIPTION
## Summary

- `list_tenants`: `/v1/mgmt/tenant/all` → `/v1/mgmt/tenant/search` (POST) — the `/all` endpoint returns 500
- `list_roles`: `/v1/mgmt/role/all` → `/v1/mgmt/role/search` (POST) — same server-side issue
- `list_permissions`: stays on `/v1/mgmt/permission/all` but switches from POST to **GET** — the endpoint exists but only accepts GET (POST returns 500, `/search` returns 404)
- Added `_get()` helper to `DescopeManagementClient` for GET-only endpoints
- Updated unit test mock for `test_list_permissions` to use `mock_http.get` instead of `.post`

## Context

These fixes unblock the reconciliation service (`POST /api/internal/reconciliation/run`), which was failing with "Descope API unavailable" on every attempt because the management client used incorrect endpoints/methods. Without the fix, no data could be seeded from Descope into the canonical postgres store.

Verified locally: reconciliation succeeded after the fix, seeding 3 tenants, 5 roles, 18 permissions from the live Descope project.

## Test plan

- [x] 122/122 `test_descope_service.py` tests pass (including the fixed `test_list_permissions`)
- [x] 1671/1671 backend unit tests pass
- [x] make lint clean
- [x] Reconciliation runs successfully against live Descope API
- [ ] CI passes