### PR TITLE
fix(ux): tenant names in Dashboard + access key list refresh (#267 #268 #269)

### DIFF
--- a/frontend/src/pages/AccessKeys.tsx
+++ b/frontend/src/pages/AccessKeys.tsx
@@ -66,7 +66,10 @@ export default function AccessKeys() {
         setName("");
         setCopied(false);
         toast.success("Access key created");
-        loadKeys();
+        // Brief delay before refresh — the Descope search index needs a
+        // moment to include the newly created key, otherwise loadKeys()
+        // returns stale results and the list appears not to update.
+        setTimeout(loadKeys, 1500);
       } else {
         const err = await res.json();
         toast.error(err.detail || "Failed to create key");

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -35,6 +35,7 @@ export default function Dashboard() {
   const [resources, setResources] = useState<TenantResource[]>([]);
   const [newResourceName, setNewResourceName] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [tenantName, setTenantName] = useState<string | null>(null);
 
   const idToken = auth.user?.id_token;
 
@@ -44,6 +45,18 @@ export default function Dashboard() {
       .then((data) => setHealth(data.status))
       .catch(() => setHealth("unreachable"));
   }, []);
+
+  // Fetch tenant name for display (avoids showing raw Descope IDs)
+  useEffect(() => {
+    if (!auth.user?.access_token || !currentTenantId) return;
+    apiFetch("/api/tenants")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        const match = data?.tenants?.find((t: { id: string }) => t.id === currentTenantId);
+        if (match?.name) setTenantName(match.name);
+      })
+      .catch(() => {});
+  }, [auth.user?.access_token, currentTenantId, apiFetch]);
 
   useEffect(() => {
     if (!auth.user?.access_token) return;
@@ -153,7 +166,7 @@ export default function Dashboard() {
                 {currentTenantId && (
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-muted-foreground">Tenant:</span>
-                    <Badge variant="outline">{currentTenantId}</Badge>
+                    <Badge variant="outline">{tenantName || currentTenantId}</Badge>
                   </div>
                 )}
                 {roles.length > 0 && (
@@ -169,7 +182,7 @@ export default function Dashboard() {
                 {tenants.length > 0 && (
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-muted-foreground">Memberships:</span>
-                    <span className="text-sm">{tenants.map((t) => t.id).join(", ")}</span>
+                    <span className="text-sm">{tenantName || tenants.map((t) => t.id).join(", ")}</span>
                   </div>
                 )}
               </CardContent>
@@ -181,7 +194,7 @@ export default function Dashboard() {
               <Card>
                 <CardHeader>
                   <CardTitle>Tenant Resources</CardTitle>
-                  <CardDescription>Scoped to {currentTenantId}</CardDescription>
+                  <CardDescription>Scoped to {tenantName || currentTenantId}</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <RequirePermission permission="documents.write">


### PR DESCRIPTION
## Summary

Two UX polish fixes + orphaned key cleanup from Playwright testing:

1. **#267 — Dashboard raw tenant ID**: Overview, Resources, and Memberships all showed `T3BW3...` instead of the tenant name. Now fetches name from `/api/tenants`.
2. **#268 — Access Keys list stale after create**: `loadKeys()` fired immediately after create but Descope search index hadn't propagated yet. Added 1.5s delay.
3. **#269 — Orphaned keys**: 5 keys with empty `keyTenants` deleted via management API (manual cleanup, no code change).

## Test plan
- [ ] CI passes
- Dashboard Overview/Resources/Memberships show tenant name
- Access Keys list refreshes ~1.5s after creating a key

Closes #267, #268, #269.