### PR TITLE
feat: Role/Permission/Tenant service layer with DI wiring

### DIFF
--- a/backend/app/dependencies/identity.py
+++ b/backend/app/dependencies/identity.py
@@ -29,13 +29,14 @@ async def get_user_service(
 ) -> UserService:
     """Build a UserService with its repository and sync adapter.
 
-    Wiring: AsyncSession -> UserRepository(session)
+    Wiring: AsyncSession -> UserRepository(session) + UserTenantRoleRepository(session)
             DescopeManagementClient -> DescopeSyncAdapter(client)
-            -> UserService(repository, adapter)
+            -> UserService(repository, adapter, assignment_repository)
     """
     repository = UserRepository(session)
+    assignment_repository = UserTenantRoleRepository(session)
     adapter = DescopeSyncAdapter(client=get_descope_client())
-    return UserService(repository=repository, adapter=adapter)
+    return UserService(repository=repository, adapter=adapter, assignment_repository=assignment_repository)
 
 
 async def get_role_service(

--- a/backend/app/repositories/assignment.py
+++ b/backend/app/repositories/assignment.py
@@ -65,6 +65,16 @@ class UserTenantRoleRepository:
         await self._session.flush()
         return result.rowcount > 0
 
+    async def delete_by_user_tenant(self, user_id: uuid.UUID, tenant_id: uuid.UUID) -> int:
+        """Delete all role assignments for a user in a tenant. Returns count of deleted rows."""
+        stmt = sa.delete(UserTenantRole).where(
+            UserTenantRole.user_id == user_id,
+            UserTenantRole.tenant_id == tenant_id,
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return result.rowcount
+
     async def commit(self) -> None:
         """Commit the current transaction."""
         await self._session.commit()

--- a/backend/app/repositories/assignment.py
+++ b/backend/app/repositories/assignment.py
@@ -54,6 +54,17 @@ class UserTenantRoleRepository:
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
 
+    async def delete(self, user_id: uuid.UUID, tenant_id: uuid.UUID, role_id: uuid.UUID) -> bool:
+        """Delete a role assignment. Returns True if deleted, False if not found."""
+        stmt = sa.delete(UserTenantRole).where(
+            UserTenantRole.user_id == user_id,
+            UserTenantRole.tenant_id == tenant_id,
+            UserTenantRole.role_id == role_id,
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return result.rowcount > 0
+
     async def commit(self) -> None:
         """Commit the current transaction."""
         await self._session.commit()

--- a/backend/app/repositories/permission.py
+++ b/backend/app/repositories/permission.py
@@ -64,6 +64,13 @@ class PermissionRepository:
             raise RepositoryConflictError(str(exc)) from exc
         return permission
 
+    async def delete(self, permission_id: uuid.UUID) -> bool:
+        """Delete a permission by ID. Returns True if deleted, False if not found."""
+        stmt = sa.delete(Permission).where(Permission.id == permission_id)
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return result.rowcount > 0
+
     async def commit(self) -> None:
         """Commit the current transaction."""
         await self._session.commit()

--- a/backend/app/repositories/role.py
+++ b/backend/app/repositories/role.py
@@ -110,6 +110,13 @@ class RoleRepository:
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
 
+    async def delete(self, role_id: uuid.UUID) -> bool:
+        """Delete a role by ID. Returns True if deleted, False if not found."""
+        stmt = sa.delete(Role).where(Role.id == role_id)
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return result.rowcount > 0
+
     async def commit(self) -> None:
         """Commit the current transaction."""
         await self._session.commit()

--- a/backend/app/repositories/user.py
+++ b/backend/app/repositories/user.py
@@ -111,6 +111,17 @@ class UserRepository:
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
 
+    async def exists_in_tenant(self, user_id: uuid.UUID, tenant_id: uuid.UUID) -> bool:
+        """Check if a user has any role assignment in the given tenant."""
+        stmt = sa.select(
+            sa.exists().where(
+                UserTenantRole.user_id == user_id,
+                UserTenantRole.tenant_id == tenant_id,
+            )
+        )
+        result = await self._session.execute(stmt)
+        return bool(result.scalar())
+
     async def commit(self) -> None:
         """Commit the current transaction."""
         await self._session.commit()

--- a/backend/app/routers/permissions.py
+++ b/backend/app/routers/permissions.py
@@ -1,6 +1,6 @@
 import uuid
 
-from expression import Error
+from expression import Error, Ok
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel, Field
 
@@ -32,6 +32,8 @@ async def list_permissions(
 ):
     """List all permission definitions. Requires owner or admin role."""
     result = await permission_service.list_permissions()
+    if result.is_ok():
+        result = Ok({"permissions": result.ok})
     return result_to_response(result, request)
 
 

--- a/backend/app/routers/permissions.py
+++ b/backend/app/routers/permissions.py
@@ -1,14 +1,15 @@
-import logging
+import uuid
 
-import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from expression import Error
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel, Field
 
+from app.dependencies.identity import get_permission_service
 from app.dependencies.rbac import require_role
+from app.errors.identity import NotFound
+from app.errors.problem_detail import result_to_response
 from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
-from app.services.descope import get_descope_client
-
-logger = logging.getLogger(__name__)
+from app.services.permission import PermissionService
 
 router = APIRouter(tags=["Permissions"])
 
@@ -25,20 +26,13 @@ class UpdatePermissionRequest(BaseModel):
 
 @router.get("/permissions")
 async def list_permissions(
+    request: Request,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    permission_service: PermissionService = Depends(get_permission_service),
 ):
     """List all permission definitions. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        permissions = await client.list_permissions()
-        return {"permissions": permissions}
-    except httpx.HTTPStatusError as exc:
-        body = exc.response.text[:500]
-        logger.warning("Descope API error listing permissions: %s %s", exc.response.status_code, body)
-        raise HTTPException(status_code=502, detail=f"Descope API {exc.response.status_code}: {body}")
-    except httpx.RequestError as exc:
-        logger.error("Network error listing permissions: %s", exc)
-        raise HTTPException(status_code=502, detail=f"Network error: {exc}")
+    result = await permission_service.list_permissions()
+    return result_to_response(result, request)
 
 
 @router.post("/permissions", status_code=201)
@@ -47,20 +41,14 @@ async def create_permission(
     request: Request,
     body: CreatePermissionRequest,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    permission_service: PermissionService = Depends(get_permission_service),
 ):
     """Create a new permission definition. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        await client.create_permission(body.name, body.description)
-        return {"name": body.name, "description": body.description}
-    except httpx.HTTPStatusError as exc:
-        logger.warning("Descope API error creating permission '%s': %s", body.name, exc.response.status_code)
-        if exc.response.status_code in (400, 409):
-            raise HTTPException(status_code=exc.response.status_code, detail="Permission already exists or invalid")
-        raise HTTPException(status_code=502, detail="Failed to create permission in Descope")
-    except httpx.RequestError as exc:
-        logger.error("Network error creating permission '%s': %s", body.name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API")
+    result = await permission_service.create_permission(
+        name=body.name,
+        description=body.description,
+    )
+    return result_to_response(result, request, status=201)
 
 
 @router.put("/permissions/{name}")
@@ -70,20 +58,23 @@ async def update_permission(
     name: str,
     body: UpdatePermissionRequest,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    permission_service: PermissionService = Depends(get_permission_service),
 ):
     """Update a permission definition. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        await client.update_permission(name, body.new_name, body.description)
-        return {"name": body.new_name, "description": body.description}
-    except httpx.HTTPStatusError as exc:
-        logger.warning("Descope API error updating permission '%s': %s", name, exc.response.status_code)
-        if exc.response.status_code in (400, 404, 409):
-            raise HTTPException(status_code=exc.response.status_code, detail="Permission not found or invalid")
-        raise HTTPException(status_code=502, detail="Failed to update permission in Descope")
-    except httpx.RequestError as exc:
-        logger.error("Network error updating permission '%s': %s", name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API")
+    # Resolve permission name to canonical ID
+    perms_result = await permission_service.list_permissions()
+    if perms_result.is_error():
+        return result_to_response(perms_result, request)
+    perm_match = next((p for p in perms_result.ok if p["name"] == name), None)
+    if perm_match is None:
+        return result_to_response(Error(NotFound(message=f"Permission '{name}' not found")), request)
+
+    result = await permission_service.update_permission(
+        permission_id=uuid.UUID(str(perm_match["id"])),
+        name=body.new_name,
+        description=body.description,
+    )
+    return result_to_response(result, request)
 
 
 @router.delete("/permissions/{name}")
@@ -92,17 +83,18 @@ async def delete_permission(
     request: Request,
     name: str,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    permission_service: PermissionService = Depends(get_permission_service),
 ):
     """Delete a permission definition. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        await client.delete_permission(name)
-        return {"status": "deleted", "name": name}
-    except httpx.HTTPStatusError as exc:
-        logger.warning("Descope API error deleting permission '%s': %s", name, exc.response.status_code)
-        if exc.response.status_code in (400, 404):
-            raise HTTPException(status_code=exc.response.status_code, detail="Permission not found or invalid")
-        raise HTTPException(status_code=502, detail="Failed to delete permission in Descope")
-    except httpx.RequestError as exc:
-        logger.error("Network error deleting permission '%s': %s", name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API")
+    # Resolve permission name to canonical ID
+    perms_result = await permission_service.list_permissions()
+    if perms_result.is_error():
+        return result_to_response(perms_result, request)
+    perm_match = next((p for p in perms_result.ok if p["name"] == name), None)
+    if perm_match is None:
+        return result_to_response(Error(NotFound(message=f"Permission '{name}' not found")), request)
+
+    result = await permission_service.delete_permission(
+        permission_id=uuid.UUID(str(perm_match["id"])),
+    )
+    return result_to_response(result, request)

--- a/backend/app/routers/roles.py
+++ b/backend/app/routers/roles.py
@@ -1,4 +1,3 @@
-import logging
 import uuid
 from typing import Annotated
 
@@ -13,8 +12,6 @@ from app.errors.identity import NotFound
 from app.errors.problem_detail import result_to_response
 from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
 from app.services.role import RoleService
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Roles"])
 
@@ -35,6 +32,14 @@ class UpdateRoleRequest(BaseModel):
     new_name: str | None = Field(default=None, min_length=1, max_length=200)
     description: str | None = Field(default=None, max_length=1000)
     permission_names: list[Annotated[str, Field(min_length=1)]] | None = Field(default=None, max_length=100)
+
+
+def _parse_uuid(value: str, field_name: str) -> uuid.UUID:
+    """Parse a string to UUID, raising 422 on invalid input."""
+    try:
+        return uuid.UUID(value)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for {field_name}: {value}")
 
 
 # --- Existing user-facing endpoints (must stay before /roles/{name}) ---
@@ -71,8 +76,8 @@ async def assign_roles(
     if "owner" in body.role_names and "owner" not in admin_roles:
         raise HTTPException(status_code=403, detail="Only owners can assign the owner role")
 
-    tenant_uuid = uuid.UUID(body.tenant_id)
-    user_uuid = uuid.UUID(body.user_id)
+    tenant_uuid = _parse_uuid(body.tenant_id, "tenant_id")
+    user_uuid = _parse_uuid(body.user_id, "user_id")
 
     # Resolve role names to canonical IDs
     roles_result = await role_service.list_roles()
@@ -113,8 +118,8 @@ async def remove_roles(
     if "owner" in body.role_names and "owner" not in admin_roles:
         raise HTTPException(status_code=403, detail="Only owners can remove the owner role")
 
-    tenant_uuid = uuid.UUID(body.tenant_id)
-    user_uuid = uuid.UUID(body.user_id)
+    tenant_uuid = _parse_uuid(body.tenant_id, "tenant_id")
+    user_uuid = _parse_uuid(body.user_id, "user_id")
 
     # Resolve role names to canonical IDs
     roles_result = await role_service.list_roles()
@@ -151,6 +156,8 @@ async def list_roles(
 ):
     """List all role definitions. Requires owner or admin role."""
     result = await role_service.list_roles()
+    if result.is_ok():
+        result = Ok({"roles": result.ok})
     return result_to_response(result, request)
 
 
@@ -166,6 +173,7 @@ async def create_role(
     result = await role_service.create_role(
         name=body.name,
         description=body.description,
+        permission_names=body.permission_names or None,
     )
     return result_to_response(result, request, status=201)
 

--- a/backend/app/routers/roles.py
+++ b/backend/app/routers/roles.py
@@ -1,14 +1,18 @@
 import logging
+import uuid
 from typing import Annotated
 
-import httpx
+from expression import Error, Ok
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from app.dependencies.identity import get_role_service
 from app.dependencies.rbac import require_role
 from app.dependencies.tenant import get_tenant_claims, get_tenant_id
+from app.errors.identity import NotFound
+from app.errors.problem_detail import result_to_response
 from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
-from app.services.descope import get_descope_client
+from app.services.role import RoleService
 
 logger = logging.getLogger(__name__)
 
@@ -59,24 +63,39 @@ async def assign_roles(
     body: RoleAssignmentRequest,
     current_tenant: str = Depends(get_tenant_id),
     admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """Assign roles to a user in a tenant. Requires owner or admin role."""
     if body.tenant_id != current_tenant:
         raise HTTPException(status_code=403, detail="Cannot manage roles for a different tenant")
     if "owner" in body.role_names and "owner" not in admin_roles:
         raise HTTPException(status_code=403, detail="Only owners can assign the owner role")
-    try:
-        client = get_descope_client()
-        login_id = await client.resolve_login_id(body.user_id)
-        await client.assign_roles(login_id, body.tenant_id, body.role_names)
-        return {"status": "roles_assigned", "user_id": body.user_id, "role_names": body.role_names}
-    except httpx.HTTPStatusError as exc:
-        body = exc.response.text[:500]
-        logger.warning("Descope API error assigning roles: %s %s", exc.response.status_code, body)
-        raise HTTPException(status_code=502, detail=f"Descope API {exc.response.status_code}: {body}") from exc
-    except httpx.RequestError as exc:
-        logger.error("Network error assigning roles: %s", exc)
-        raise HTTPException(status_code=502, detail=f"Network error: {exc}") from exc
+
+    tenant_uuid = uuid.UUID(body.tenant_id)
+    user_uuid = uuid.UUID(body.user_id)
+
+    # Resolve role names to canonical IDs
+    roles_result = await role_service.list_roles()
+    if roles_result.is_error():
+        return result_to_response(roles_result, request)
+    role_map = {r["name"]: r["id"] for r in roles_result.ok}
+
+    for role_name in body.role_names:
+        role_id = role_map.get(role_name)
+        if role_id is None:
+            return result_to_response(Error(NotFound(message=f"Role '{role_name}' not found")), request)
+        result = await role_service.assign_role_to_user(
+            user_id=user_uuid,
+            tenant_id=tenant_uuid,
+            role_id=uuid.UUID(str(role_id)),
+        )
+        if result.is_error():
+            return result_to_response(result, request)
+
+    return result_to_response(
+        Ok({"status": "roles_assigned", "user_id": body.user_id, "role_names": body.role_names}),
+        request,
+    )
 
 
 @router.post("/roles/remove")
@@ -86,24 +105,39 @@ async def remove_roles(
     body: RoleAssignmentRequest,
     current_tenant: str = Depends(get_tenant_id),
     admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """Remove roles from a user in a tenant. Requires owner or admin role."""
     if body.tenant_id != current_tenant:
         raise HTTPException(status_code=403, detail="Cannot manage roles for a different tenant")
     if "owner" in body.role_names and "owner" not in admin_roles:
         raise HTTPException(status_code=403, detail="Only owners can remove the owner role")
-    try:
-        client = get_descope_client()
-        login_id = await client.resolve_login_id(body.user_id)
-        await client.remove_roles(login_id, body.tenant_id, body.role_names)
-        return {"status": "roles_removed", "user_id": body.user_id, "role_names": body.role_names}
-    except httpx.HTTPStatusError as exc:
-        body = exc.response.text[:500]
-        logger.warning("Descope API error removing roles: %s %s", exc.response.status_code, body)
-        raise HTTPException(status_code=502, detail=f"Descope API {exc.response.status_code}: {body}") from exc
-    except httpx.RequestError as exc:
-        logger.error("Network error removing roles: %s", exc)
-        raise HTTPException(status_code=502, detail=f"Network error: {exc}") from exc
+
+    tenant_uuid = uuid.UUID(body.tenant_id)
+    user_uuid = uuid.UUID(body.user_id)
+
+    # Resolve role names to canonical IDs
+    roles_result = await role_service.list_roles()
+    if roles_result.is_error():
+        return result_to_response(roles_result, request)
+    role_map = {r["name"]: r["id"] for r in roles_result.ok}
+
+    for role_name in body.role_names:
+        role_id = role_map.get(role_name)
+        if role_id is None:
+            return result_to_response(Error(NotFound(message=f"Role '{role_name}' not found")), request)
+        result = await role_service.unassign_role_from_user(
+            user_id=user_uuid,
+            tenant_id=tenant_uuid,
+            role_id=uuid.UUID(str(role_id)),
+        )
+        if result.is_error():
+            return result_to_response(result, request)
+
+    return result_to_response(
+        Ok({"status": "roles_removed", "user_id": body.user_id, "role_names": body.role_names}),
+        request,
+    )
 
 
 # --- Role definition CRUD (admin-only) ---
@@ -111,20 +145,13 @@ async def remove_roles(
 
 @router.get("/roles")
 async def list_roles(
+    request: Request,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """List all role definitions. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        roles = await client.list_roles()
-        return {"roles": roles}
-    except httpx.HTTPStatusError as exc:
-        body = exc.response.text[:500]
-        logger.warning("Descope API error listing roles: %s %s", exc.response.status_code, body)
-        raise HTTPException(status_code=502, detail=f"Descope API {exc.response.status_code}: {body}") from exc
-    except httpx.RequestError as exc:
-        logger.error("Network error listing roles: %s", exc)
-        raise HTTPException(status_code=502, detail=f"Network error: {exc}") from exc
+    result = await role_service.list_roles()
+    return result_to_response(result, request)
 
 
 @router.post("/roles", status_code=201)
@@ -133,23 +160,14 @@ async def create_role(
     request: Request,
     body: CreateRoleRequest,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """Create a new role definition. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        await client.create_role(body.name, body.description, body.permission_names or None)
-        return {"name": body.name, "description": body.description, "permission_names": body.permission_names}
-    except httpx.HTTPStatusError as exc:
-        resp_body = exc.response.text[:500]
-        logger.warning("Descope API error creating role '%s': %s %s", body.name, exc.response.status_code, resp_body)
-        if exc.response.status_code == 400:
-            raise HTTPException(status_code=400, detail=f"Invalid role data: {resp_body}") from exc
-        if exc.response.status_code == 409:
-            raise HTTPException(status_code=409, detail="Role already exists") from exc
-        raise HTTPException(status_code=502, detail=f"Descope API {exc.response.status_code}: {resp_body}") from exc
-    except httpx.RequestError as exc:
-        logger.error("Network error creating role '%s': %s", body.name, exc)
-        raise HTTPException(status_code=502, detail=f"Network error: {exc}") from exc
+    result = await role_service.create_role(
+        name=body.name,
+        description=body.description,
+    )
+    return result_to_response(result, request, status=201)
 
 
 @router.put("/roles/{name}")
@@ -159,25 +177,24 @@ async def update_role(
     name: str,
     body: UpdateRoleRequest,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """Update a role definition. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        effective_name = body.new_name if body.new_name is not None else name
-        await client.update_role(name, effective_name, body.description, body.permission_names)
-        return {"name": effective_name, "description": body.description, "permission_names": body.permission_names}
-    except httpx.HTTPStatusError as exc:
-        logger.warning("Descope API error updating role '%s': %s", name, exc.response.status_code)
-        if exc.response.status_code == 404:
-            raise HTTPException(status_code=404, detail="Role not found") from exc
-        if exc.response.status_code == 409:
-            raise HTTPException(status_code=409, detail="Role name conflict") from exc
-        if exc.response.status_code == 400:
-            raise HTTPException(status_code=400, detail="Invalid role data") from exc
-        raise HTTPException(status_code=502, detail="Failed to update role in Descope") from exc
-    except httpx.RequestError as exc:
-        logger.error("Network error updating role '%s': %s", name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API") from exc
+    # Resolve role name to canonical ID
+    roles_result = await role_service.list_roles()
+    if roles_result.is_error():
+        return result_to_response(roles_result, request)
+    role_match = next((r for r in roles_result.ok if r["name"] == name), None)
+    if role_match is None:
+        return result_to_response(Error(NotFound(message=f"Role '{name}' not found")), request)
+
+    result = await role_service.update_role(
+        role_id=uuid.UUID(str(role_match["id"])),
+        name=body.new_name,
+        description=body.description,
+        permission_names=body.permission_names,
+    )
+    return result_to_response(result, request)
 
 
 @router.delete("/roles/{name}")
@@ -186,19 +203,16 @@ async def delete_role(
     request: Request,
     name: str,
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """Delete a role definition. Requires owner or admin role."""
-    try:
-        client = get_descope_client()
-        await client.delete_role(name)
-        return {"status": "deleted", "name": name}
-    except httpx.HTTPStatusError as exc:
-        logger.warning("Descope API error deleting role '%s': %s", name, exc.response.status_code)
-        if exc.response.status_code == 404:
-            raise HTTPException(status_code=404, detail="Role not found") from exc
-        if exc.response.status_code == 400:
-            raise HTTPException(status_code=400, detail="Invalid role data") from exc
-        raise HTTPException(status_code=502, detail="Failed to delete role in Descope") from exc
-    except httpx.RequestError as exc:
-        logger.error("Network error deleting role '%s': %s", name, exc)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API") from exc
+    # Resolve role name to canonical ID
+    roles_result = await role_service.list_roles()
+    if roles_result.is_error():
+        return result_to_response(roles_result, request)
+    role_match = next((r for r in roles_result.ok if r["name"] == name), None)
+    if role_match is None:
+        return result_to_response(Error(NotFound(message=f"Role '{name}' not found")), request)
+
+    result = await role_service.delete_role(role_id=uuid.UUID(str(role_match["id"])))
+    return result_to_response(result, request)

--- a/backend/app/routers/tenants.py
+++ b/backend/app/routers/tenants.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 
+from expression import Ok
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
@@ -56,7 +57,7 @@ async def create_tenant(
         name=body.name,
         domains=body.self_provisioning_domains,
     )
-    return result_to_response(result, request, status=201)
+    return result_to_response(result, request)
 
 
 @router.get("/tenants")
@@ -80,7 +81,13 @@ async def get_current_tenant(
     tenant_service: TenantService = Depends(get_tenant_service),
 ):
     """Get the current tenant context from the JWT `dct` claim."""
-    result = await tenant_service.get_tenant(tenant_id=uuid.UUID(tenant_id))
+    try:
+        tenant_uuid = uuid.UUID(tenant_id)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for tenant_id: {tenant_id}")
+    result = await tenant_service.get_tenant(tenant_id=tenant_uuid)
+    if result.is_ok():
+        result = Ok({"tenant_id": tenant_id, "tenant": result.ok})
     return result_to_response(result, request)
 
 

--- a/backend/app/routers/tenants.py
+++ b/backend/app/routers/tenants.py
@@ -1,17 +1,19 @@
 import logging
+import uuid
 
-import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from app.dependencies.auth import get_claims
+from app.dependencies.identity import get_tenant_service
 from app.dependencies.tenant import get_tenant_claims, get_tenant_id
+from app.errors.problem_detail import result_to_response
 from app.models.database import get_async_session
 from app.models.tenant import TenantResource
-from app.services.descope import get_descope_client
+from app.services.tenant import TenantService
 
 logger = logging.getLogger(__name__)
 
@@ -43,14 +45,18 @@ class CreateResourceRequest(BaseModel):
 
 
 @router.post("/tenants")
-async def create_tenant(body: CreateTenantRequest, claims: dict = Depends(require_admin_role)):
-    """Create a new tenant via the Descope Management API. Requires admin/owner role."""
-    client = get_descope_client()
-    result = await client.create_tenant(
+async def create_tenant(
+    request: Request,
+    body: CreateTenantRequest,
+    claims: dict = Depends(require_admin_role),
+    tenant_service: TenantService = Depends(get_tenant_service),
+):
+    """Create a new tenant via the canonical identity service. Requires admin/owner role."""
+    result = await tenant_service.create_tenant(
         name=body.name,
-        self_provisioning_domains=body.self_provisioning_domains,
+        domains=body.self_provisioning_domains,
     )
-    return result
+    return result_to_response(result, request, status=201)
 
 
 @router.get("/tenants")
@@ -69,21 +75,13 @@ async def list_user_tenants(tenant_claims: dict = Depends(get_tenant_claims)):
 
 @router.get("/tenants/current")
 async def get_current_tenant(
+    request: Request,
     tenant_id: str = Depends(get_tenant_id),
+    tenant_service: TenantService = Depends(get_tenant_service),
 ):
     """Get the current tenant context from the JWT `dct` claim."""
-    try:
-        client = get_descope_client()
-        tenant_info = await client.load_tenant(tenant_id)
-        return {"tenant_id": tenant_id, "tenant": tenant_info}
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            return {"tenant_id": tenant_id, "tenant": None}
-        logger.error("Descope API error loading tenant %s: %s", tenant_id, e)
-        raise HTTPException(status_code=502, detail="Failed to load tenant from Descope")
-    except httpx.RequestError as e:
-        logger.error("Network error loading tenant %s: %s", tenant_id, e)
-        raise HTTPException(status_code=502, detail="Failed to reach Descope API")
+    result = await tenant_service.get_tenant(tenant_id=uuid.UUID(tenant_id))
+    return result_to_response(result, request)
 
 
 @router.get("/tenants/{tenant_id}/resources")

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -67,7 +67,7 @@ async def invite_member(
 
     user_data = result.ok
 
-    # Assign requested roles to the new user
+    # Assign requested roles to the new user (best-effort: user is created regardless)
     if body.role_names:
         user_uuid = uuid.UUID(str(user_data["id"]))
         roles_result = await role_service.list_roles()
@@ -76,11 +76,13 @@ async def invite_member(
             for role_name in body.role_names:
                 role_id = role_map.get(role_name)
                 if role_id is not None:
-                    await role_service.assign_role_to_user(
+                    assign_result = await role_service.assign_role_to_user(
                         user_id=user_uuid,
                         tenant_id=tenant_uuid,
                         role_id=uuid.UUID(str(role_id)),
                     )
+                    if assign_result.is_error():
+                        break  # stop on first failure, user still created
 
     return result_to_response(
         Ok({"status": "invited", "email": body.email, "user": user_data}),

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,10 +1,14 @@
+import uuid
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, EmailStr, Field
 
+from app.dependencies.identity import get_user_service
 from app.dependencies.rbac import require_role
 from app.dependencies.tenant import get_tenant_id
+from app.errors.problem_detail import result_to_response
 from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
-from app.services.descope import get_descope_client
+from app.services.user import UserService
 
 router = APIRouter(tags=["Users"])
 
@@ -14,32 +18,16 @@ class InviteUserRequest(BaseModel):
     role_names: list[str] = Field(default_factory=lambda: ["member"])
 
 
-async def _verify_user_tenant(user_id: str, tenant_id: str) -> tuple[dict, str]:
-    """Load a user, verify tenant membership, return (user, login_id).
-
-    Descope mutation endpoints require loginId, but the frontend sends userId.
-    This resolves the loginId from the user object.
-    """
-    client = get_descope_client()
-    user = await client.load_user(user_id)
-    user_tenants = [t.get("tenantId", "") for t in user.get("userTenants", [])] if user.get("userTenants") else []
-    if tenant_id not in user_tenants:
-        raise HTTPException(status_code=403, detail="User does not belong to your tenant")
-    login_ids = user.get("loginIds", [])
-    if not login_ids:
-        raise HTTPException(status_code=400, detail="User has no login identifiers")
-    return user, login_ids[0]
-
-
 @router.get("/members")
 async def list_members(
+    request: Request,
     tenant_id: str = Depends(get_tenant_id),
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    user_service: UserService = Depends(get_user_service),
 ):
     """List all members in the current tenant."""
-    client = get_descope_client()
-    users = await client.search_tenant_users(tenant_id)
-    return {"members": users}
+    result = await user_service.search_users(tenant_id=uuid.UUID(tenant_id))
+    return result_to_response(result, request)
 
 
 @router.post("/members/invite")
@@ -49,49 +37,62 @@ async def invite_member(
     body: InviteUserRequest,
     tenant_id: str = Depends(get_tenant_id),
     caller_roles: list[str] = Depends(require_role("owner", "admin")),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Invite a user to the current tenant by email with specified roles."""
     if "owner" in body.role_names and "owner" not in caller_roles:
         raise HTTPException(status_code=403, detail="Only owners can assign the owner role")
-    client = get_descope_client()
-    user = await client.invite_user(body.email, tenant_id, body.role_names)
-    return {"status": "invited", "email": body.email, "user": user}
+    result = await user_service.create_user(
+        tenant_id=uuid.UUID(tenant_id),
+        email=body.email,
+        user_name=body.email,
+    )
+    return result_to_response(result, request, status=201)
 
 
 @router.post("/members/{user_id}/deactivate")
 async def deactivate_member(
+    request: Request,
     user_id: str,
     tenant_id: str = Depends(get_tenant_id),
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Deactivate a member. They will not be able to log in."""
-    _, login_id = await _verify_user_tenant(user_id, tenant_id)
-    client = get_descope_client()
-    await client.update_user_status(login_id, "disabled")
-    return {"status": "deactivated", "user_id": user_id}
+    result = await user_service.deactivate_user(
+        tenant_id=uuid.UUID(tenant_id),
+        user_id=uuid.UUID(user_id),
+    )
+    return result_to_response(result, request)
 
 
 @router.post("/members/{user_id}/activate")
 async def activate_member(
+    request: Request,
     user_id: str,
     tenant_id: str = Depends(get_tenant_id),
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Reactivate a previously deactivated member."""
-    _, login_id = await _verify_user_tenant(user_id, tenant_id)
-    client = get_descope_client()
-    await client.update_user_status(login_id, "enabled")
-    return {"status": "activated", "user_id": user_id}
+    result = await user_service.activate_user(
+        tenant_id=uuid.UUID(tenant_id),
+        user_id=uuid.UUID(user_id),
+    )
+    return result_to_response(result, request)
 
 
 @router.delete("/members/{user_id}")
 async def remove_member(
+    request: Request,
     user_id: str,
     tenant_id: str = Depends(get_tenant_id),
     _admin_roles: list[str] = Depends(require_role("owner", "admin")),
+    user_service: UserService = Depends(get_user_service),
 ):
     """Remove a member from the current tenant."""
-    _, login_id = await _verify_user_tenant(user_id, tenant_id)
-    client = get_descope_client()
-    await client.remove_user_from_tenant(login_id, tenant_id)
-    return {"status": "removed", "user_id": user_id}
+    result = await user_service.deactivate_user(
+        tenant_id=uuid.UUID(tenant_id),
+        user_id=uuid.UUID(user_id),
+    )
+    return result_to_response(result, request)

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,13 +1,15 @@
 import uuid
 
+from expression import Ok
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, EmailStr, Field
 
-from app.dependencies.identity import get_user_service
+from app.dependencies.identity import get_role_service, get_user_service
 from app.dependencies.rbac import require_role
 from app.dependencies.tenant import get_tenant_id
 from app.errors.problem_detail import result_to_response
 from app.middleware.rate_limit import RATE_LIMIT_AUTH, limiter
+from app.services.role import RoleService
 from app.services.user import UserService
 
 router = APIRouter(tags=["Users"])
@@ -18,6 +20,14 @@ class InviteUserRequest(BaseModel):
     role_names: list[str] = Field(default_factory=lambda: ["member"])
 
 
+def _parse_uuid(value: str, field_name: str) -> uuid.UUID:
+    """Parse a string to UUID, raising 422 on invalid input."""
+    try:
+        return uuid.UUID(value)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for {field_name}: {value}")
+
+
 @router.get("/members")
 async def list_members(
     request: Request,
@@ -26,7 +36,10 @@ async def list_members(
     user_service: UserService = Depends(get_user_service),
 ):
     """List all members in the current tenant."""
-    result = await user_service.search_users(tenant_id=uuid.UUID(tenant_id))
+    tenant_uuid = _parse_uuid(tenant_id, "tenant_id")
+    result = await user_service.search_users(tenant_id=tenant_uuid)
+    if result.is_ok():
+        result = Ok({"members": result.ok})
     return result_to_response(result, request)
 
 
@@ -38,16 +51,41 @@ async def invite_member(
     tenant_id: str = Depends(get_tenant_id),
     caller_roles: list[str] = Depends(require_role("owner", "admin")),
     user_service: UserService = Depends(get_user_service),
+    role_service: RoleService = Depends(get_role_service),
 ):
     """Invite a user to the current tenant by email with specified roles."""
     if "owner" in body.role_names and "owner" not in caller_roles:
         raise HTTPException(status_code=403, detail="Only owners can assign the owner role")
+    tenant_uuid = _parse_uuid(tenant_id, "tenant_id")
     result = await user_service.create_user(
-        tenant_id=uuid.UUID(tenant_id),
+        tenant_id=tenant_uuid,
         email=body.email,
         user_name=body.email,
     )
-    return result_to_response(result, request, status=201)
+    if result.is_error():
+        return result_to_response(result, request)
+
+    user_data = result.ok
+
+    # Assign requested roles to the new user
+    if body.role_names:
+        user_uuid = uuid.UUID(str(user_data["id"]))
+        roles_result = await role_service.list_roles()
+        if roles_result.is_ok():
+            role_map = {r["name"]: r["id"] for r in roles_result.ok}
+            for role_name in body.role_names:
+                role_id = role_map.get(role_name)
+                if role_id is not None:
+                    await role_service.assign_role_to_user(
+                        user_id=user_uuid,
+                        tenant_id=tenant_uuid,
+                        role_id=uuid.UUID(str(role_id)),
+                    )
+
+    return result_to_response(
+        Ok({"status": "invited", "email": body.email, "user": user_data}),
+        request,
+    )
 
 
 @router.post("/members/{user_id}/deactivate")
@@ -59,10 +97,14 @@ async def deactivate_member(
     user_service: UserService = Depends(get_user_service),
 ):
     """Deactivate a member. They will not be able to log in."""
+    tenant_uuid = _parse_uuid(tenant_id, "tenant_id")
+    user_uuid = _parse_uuid(user_id, "user_id")
     result = await user_service.deactivate_user(
-        tenant_id=uuid.UUID(tenant_id),
-        user_id=uuid.UUID(user_id),
+        tenant_id=tenant_uuid,
+        user_id=user_uuid,
     )
+    if result.is_ok():
+        result = Ok({"status": "deactivated", "user_id": user_id})
     return result_to_response(result, request)
 
 
@@ -75,10 +117,14 @@ async def activate_member(
     user_service: UserService = Depends(get_user_service),
 ):
     """Reactivate a previously deactivated member."""
+    tenant_uuid = _parse_uuid(tenant_id, "tenant_id")
+    user_uuid = _parse_uuid(user_id, "user_id")
     result = await user_service.activate_user(
-        tenant_id=uuid.UUID(tenant_id),
-        user_id=uuid.UUID(user_id),
+        tenant_id=tenant_uuid,
+        user_id=user_uuid,
     )
+    if result.is_ok():
+        result = Ok({"status": "activated", "user_id": user_id})
     return result_to_response(result, request)
 
 
@@ -91,8 +137,12 @@ async def remove_member(
     user_service: UserService = Depends(get_user_service),
 ):
     """Remove a member from the current tenant."""
-    result = await user_service.deactivate_user(
-        tenant_id=uuid.UUID(tenant_id),
-        user_id=uuid.UUID(user_id),
+    tenant_uuid = _parse_uuid(tenant_id, "tenant_id")
+    user_uuid = _parse_uuid(user_id, "user_id")
+    result = await user_service.remove_user_from_tenant(
+        tenant_id=tenant_uuid,
+        user_id=user_uuid,
     )
+    if result.is_ok():
+        result = Ok({"status": "removed", "user_id": user_id})
     return result_to_response(result, request)

--- a/backend/app/services/adapters/base.py
+++ b/backend/app/services/adapters/base.py
@@ -50,6 +50,16 @@ class IdentityProviderAdapter(ABC):
     ) -> Result[None, SyncError]: ...
 
     @abstractmethod
+    async def delete_role_assignment(
+        self,
+        *,
+        user_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        role_id: uuid.UUID,
+        data: dict | None = None,
+    ) -> Result[None, SyncError]: ...
+
+    @abstractmethod
     async def delete_user(self, *, user_id: uuid.UUID) -> Result[None, SyncError]: ...
 
     @abstractmethod

--- a/backend/app/services/adapters/descope.py
+++ b/backend/app/services/adapters/descope.py
@@ -193,6 +193,43 @@ class DescopeSyncAdapter(IdentityProviderAdapter):
                     )
                 )
 
+    async def delete_role_assignment(
+        self,
+        *,
+        user_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        role_id: uuid.UUID,
+        data: dict | None = None,
+    ) -> Result[None, SyncError]:
+        """Remove a role assignment in Descope via remove_roles API."""
+        with tracer.start_as_current_span("descope.delete_role_assignment") as span:
+            span.set_attribute("user.id", str(user_id))
+            span.set_attribute("tenant.id", str(tenant_id))
+            span.set_attribute("role.id", str(role_id))
+            try:
+                data = data or {}
+                role_name = data.get("role_name", str(role_id))
+                login_id = data.get("login_id", str(user_id))
+                await self._client.remove_roles(login_id, str(tenant_id), [role_name])
+                return Ok(None)
+            except Exception as exc:
+                logger.warning(
+                    "Descope delete_role_assignment failed for user %s: %s",
+                    user_id,
+                    exc,
+                )
+                return Error(
+                    SyncError(
+                        message=str(exc),
+                        operation="delete_role_assignment",
+                        context={
+                            "user_id": str(user_id),
+                            "tenant_id": str(tenant_id),
+                            "role_id": str(role_id),
+                        },
+                    )
+                )
+
     async def delete_user(self, *, user_id: uuid.UUID) -> Result[None, SyncError]:
         """Disable user in Descope (canonical delete maps to Descope disable).
 

--- a/backend/app/services/adapters/noop.py
+++ b/backend/app/services/adapters/noop.py
@@ -37,6 +37,16 @@ class NoOpSyncAdapter(IdentityProviderAdapter):
     ) -> Result[None, SyncError]:
         return Ok(None)
 
+    async def delete_role_assignment(
+        self,
+        *,
+        user_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        role_id: uuid.UUID,
+        data: dict | None = None,
+    ) -> Result[None, SyncError]:
+        return Ok(None)
+
     async def delete_user(self, *, user_id: uuid.UUID) -> Result[None, SyncError]:
         return Ok(None)
 

--- a/backend/app/services/permission.py
+++ b/backend/app/services/permission.py
@@ -93,6 +93,83 @@ class PermissionService:
                 return Error(NotFound(message=f"Permission '{permission_id}' not found"))
             return Ok(permission.model_dump())
 
+    async def list_permissions(self) -> Result[list[dict], IdentityError]:
+        """List all permissions."""
+        with tracer.start_as_current_span("PermissionService.list_permissions"):
+            permissions = await self._repository.list_all()
+            return Ok([p.model_dump() for p in permissions])
+
+    async def update_permission(
+        self,
+        *,
+        permission_id: uuid.UUID,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> Result[dict, IdentityError]:
+        """Update permission fields, then sync to IdP."""
+        with tracer.start_as_current_span("PermissionService.update_permission") as span:
+            span.set_attribute("permission.id", str(permission_id))
+
+            permission = await self._repository.get(permission_id)
+            if permission is None:
+                return Error(NotFound(message=f"Permission '{permission_id}' not found"))
+
+            if name is not None:
+                existing = await self._repository.get_by_name(name)
+                if existing is not None and existing.id != permission_id:
+                    return Error(Conflict(message=f"Permission '{name}' already exists"))
+                permission.name = name
+            if description is not None:
+                permission.description = description
+
+            try:
+                permission = await self._repository.update(permission)
+            except RepositoryConflictError:
+                await self._repository.rollback()
+                return Error(Conflict(message=f"Permission name '{name}' conflicts with existing permission"))
+
+            result_dict = permission.model_dump()
+            await self._repository.commit()
+
+            self._log_sync_failure(
+                await self._adapter.sync_permission(
+                    permission_id=permission.id,
+                    data={"name": permission.name, "description": permission.description},
+                ),
+                permission.id,
+                "update_permission",
+            )
+
+            return Ok(result_dict)
+
+    async def delete_permission(
+        self,
+        *,
+        permission_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Delete a permission from DB and sync deletion to IdP."""
+        with tracer.start_as_current_span("PermissionService.delete_permission") as span:
+            span.set_attribute("permission.id", str(permission_id))
+
+            permission = await self._repository.get(permission_id)
+            if permission is None:
+                return Error(NotFound(message=f"Permission '{permission_id}' not found"))
+
+            perm_name = permission.name
+            deleted = await self._repository.delete(permission_id)
+            if not deleted:
+                return Error(NotFound(message=f"Permission '{permission_id}' not found"))
+
+            await self._repository.commit()
+
+            self._log_sync_failure(
+                await self._adapter.delete_permission(permission_id=permission_id),
+                permission_id,
+                "delete_permission",
+            )
+
+            return Ok({"status": "deleted", "name": perm_name})
+
     @staticmethod
     def _log_sync_failure(
         result: Result[None, SyncError],

--- a/backend/app/services/role.py
+++ b/backend/app/services/role.py
@@ -54,6 +54,7 @@ class RoleService:
         name: str,
         description: str = "",
         tenant_id: uuid.UUID | None = None,
+        permission_names: list[str] | None = None,
     ) -> Result[dict, IdentityError]:
         """Create a new role: persist via repo, then sync to IdP.
 
@@ -76,15 +77,29 @@ class RoleService:
                 await self._repository.rollback()
                 return Error(Conflict(message=f"Role '{name}' already exists in this scope"))
 
+            # Map permissions to role if specified
+            resolved_permission_names: list[str] = []
+            if permission_names:
+                for perm_name in permission_names:
+                    perm = await self._permission_repository.get_by_name(perm_name)
+                    if perm is None:
+                        await self._repository.rollback()
+                        return Error(NotFound(message=f"Permission '{perm_name}' not found"))
+                    try:
+                        await self._repository.add_permission(role.id, perm.id)
+                    except RepositoryConflictError:
+                        pass  # already mapped, skip
+                    resolved_permission_names.append(perm_name)
+
             result_dict = role.model_dump()
             role_id = role.id
             await self._repository.commit()
 
+            sync_data: dict = {"name": role.name, "description": role.description}
+            if resolved_permission_names:
+                sync_data["permission_names"] = resolved_permission_names
             self._log_sync_failure(
-                await self._adapter.sync_role(
-                    role_id=role_id,
-                    data={"name": role.name, "description": role.description},
-                ),
+                await self._adapter.sync_role(role_id=role_id, data=sync_data),
                 role_id,
                 "create_role",
             )
@@ -307,11 +322,14 @@ class RoleService:
         tenant_id: uuid.UUID,
         role_id: uuid.UUID,
     ) -> Result[dict, IdentityError]:
-        """Remove a role assignment from a user within a tenant."""
+        """Remove a role assignment from a user within a tenant, then sync to IdP."""
         with tracer.start_as_current_span("RoleService.unassign_role_from_user") as span:
             span.set_attribute("user.id", str(user_id))
             span.set_attribute("tenant.id", str(tenant_id))
             span.set_attribute("role.id", str(role_id))
+
+            role = await self._repository.get(role_id)
+            role_name = role.name if role else str(role_id)
 
             deleted = await self._assignment_repository.delete(user_id, tenant_id, role_id)
             if not deleted:
@@ -319,6 +337,17 @@ class RoleService:
                 return Error(NotFound(message=msg))
 
             await self._assignment_repository.commit()
+
+            self._log_sync_failure(
+                await self._adapter.delete_role_assignment(
+                    user_id=user_id,
+                    tenant_id=tenant_id,
+                    role_id=role_id,
+                    data={"role_name": role_name},
+                ),
+                role_id,
+                "unassign_role_from_user",
+            )
 
             return Ok(
                 {

--- a/backend/app/services/role.py
+++ b/backend/app/services/role.py
@@ -215,6 +215,120 @@ class RoleService:
 
             return Ok(result_dict)
 
+    async def list_roles(
+        self,
+        *,
+        tenant_id: uuid.UUID | None = None,
+    ) -> Result[list[dict], IdentityError]:
+        """List roles filtered by tenant scope."""
+        with tracer.start_as_current_span("RoleService.list_roles") as span:
+            if tenant_id is not None:
+                span.set_attribute("tenant.id", str(tenant_id))
+
+            roles = await self._repository.list_by_tenant(tenant_id)
+            return Ok([r.model_dump() for r in roles])
+
+    async def update_role(
+        self,
+        *,
+        role_id: uuid.UUID,
+        name: str | None = None,
+        description: str | None = None,
+        permission_names: list[str] | None = None,
+    ) -> Result[dict, IdentityError]:
+        """Update role fields, then sync to IdP."""
+        with tracer.start_as_current_span("RoleService.update_role") as span:
+            span.set_attribute("role.id", str(role_id))
+
+            role = await self._repository.get(role_id)
+            if role is None:
+                return Error(NotFound(message=f"Role '{role_id}' not found"))
+
+            if name is not None:
+                existing = await self._repository.get_by_name(name, role.tenant_id)
+                if existing is not None and existing.id != role_id:
+                    return Error(Conflict(message=f"Role '{name}' already exists in this scope"))
+                role.name = name
+            if description is not None:
+                role.description = description
+
+            try:
+                role = await self._repository.update(role)
+            except RepositoryConflictError:
+                await self._repository.rollback()
+                return Error(Conflict(message=f"Role name '{name}' conflicts with existing role"))
+
+            result_dict = role.model_dump()
+            sync_data: dict = {"name": role.name, "description": role.description}
+            if permission_names is not None:
+                sync_data["permission_names"] = permission_names
+            await self._repository.commit()
+
+            self._log_sync_failure(
+                await self._adapter.sync_role(role_id=role.id, data=sync_data),
+                role.id,
+                "update_role",
+            )
+
+            return Ok(result_dict)
+
+    async def delete_role(
+        self,
+        *,
+        role_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Delete a role from DB and sync deletion to IdP."""
+        with tracer.start_as_current_span("RoleService.delete_role") as span:
+            span.set_attribute("role.id", str(role_id))
+
+            role = await self._repository.get(role_id)
+            if role is None:
+                return Error(NotFound(message=f"Role '{role_id}' not found"))
+
+            role_name = role.name
+            deleted = await self._repository.delete(role_id)
+            if not deleted:
+                return Error(NotFound(message=f"Role '{role_id}' not found"))
+
+            await self._repository.commit()
+
+            self._log_sync_failure(
+                await self._adapter.delete_role(role_id=role_id),
+                role_id,
+                "delete_role",
+            )
+
+            return Ok({"status": "deleted", "name": role_name})
+
+    async def unassign_role_from_user(
+        self,
+        *,
+        user_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        role_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Remove a role assignment from a user within a tenant."""
+        with tracer.start_as_current_span("RoleService.unassign_role_from_user") as span:
+            span.set_attribute("user.id", str(user_id))
+            span.set_attribute("tenant.id", str(tenant_id))
+            span.set_attribute("role.id", str(role_id))
+
+            deleted = await self._assignment_repository.delete(user_id, tenant_id, role_id)
+            if not deleted:
+                msg = f"Role assignment not found for user '{user_id}' in tenant '{tenant_id}'"
+                return Error(NotFound(message=msg))
+
+            await self._assignment_repository.commit()
+
+            return Ok(
+                {
+                    "status": "removed",
+                    "user_id": str(user_id),
+                    "tenant_id": str(tenant_id),
+                    "role_id": str(role_id),
+                }
+            )
+
     @staticmethod
     def _log_sync_failure(
         result: Result[None, SyncError],

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -179,6 +179,39 @@ class UserService:
 
             return Ok(result_dict)
 
+    async def activate_user(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Set user status to active and sync to IdP.
+
+        Mirrors deactivate_user for reactivation.
+        """
+        with tracer.start_as_current_span("UserService.activate_user") as span:
+            span.set_attribute("tenant.id", str(tenant_id))
+            span.set_attribute("user.id", str(user_id))
+
+            user = await self._repository.get(user_id)
+            if user is None:
+                return Error(NotFound(message=f"User '{user_id}' not found"))
+
+            user.status = UserStatus.active
+            user = await self._repository.update(user)
+
+            result_dict = user.model_dump()
+            sync_data = {"email": user.email, "status": user.status.value}
+            await self._repository.commit()
+
+            self._log_sync_failure(
+                await self._adapter.sync_user(user_id=user.id, data=sync_data),
+                user.id,
+                "activate",
+            )
+
+            return Ok(result_dict)
+
     async def search_users(
         self,
         *,

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -13,8 +13,9 @@ import uuid
 from expression import Error, Ok, Result
 from opentelemetry import trace
 
-from app.errors.identity import Conflict, IdentityError, NotFound
+from app.errors.identity import Conflict, Forbidden, IdentityError, NotFound
 from app.models.identity.user import User, UserStatus
+from app.repositories.assignment import UserTenantRoleRepository
 from app.repositories.user import RepositoryConflictError, UserRepository
 from app.services.adapters.base import IdentityProviderAdapter, SyncError
 
@@ -34,9 +35,11 @@ class UserService:
         *,
         repository: UserRepository,
         adapter: IdentityProviderAdapter,
+        assignment_repository: UserTenantRoleRepository | None = None,
     ) -> None:
         self._repository = repository
         self._adapter = adapter
+        self._assignment_repository = assignment_repository
 
     async def create_user(
         self,
@@ -146,6 +149,12 @@ class UserService:
 
             return Ok(result_dict)
 
+    async def _verify_tenant_membership(self, user_id: uuid.UUID, tenant_id: uuid.UUID) -> IdentityError | None:
+        """Verify user has a role assignment in the given tenant. Returns error if not."""
+        if not await self._repository.exists_in_tenant(user_id, tenant_id):
+            return Forbidden(message="User does not belong to your tenant")
+        return None
+
     async def deactivate_user(
         self,
         *,
@@ -163,6 +172,10 @@ class UserService:
             user = await self._repository.get(user_id)
             if user is None:
                 return Error(NotFound(message=f"User '{user_id}' not found"))
+
+            membership_err = await self._verify_tenant_membership(user_id, tenant_id)
+            if membership_err is not None:
+                return Error(membership_err)
 
             user.status = UserStatus.inactive
             user = await self._repository.update(user)
@@ -197,6 +210,10 @@ class UserService:
             if user is None:
                 return Error(NotFound(message=f"User '{user_id}' not found"))
 
+            membership_err = await self._verify_tenant_membership(user_id, tenant_id)
+            if membership_err is not None:
+                return Error(membership_err)
+
             user.status = UserStatus.active
             user = await self._repository.update(user)
 
@@ -211,6 +228,37 @@ class UserService:
             )
 
             return Ok(result_dict)
+
+    async def remove_user_from_tenant(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> Result[dict, IdentityError]:
+        """Remove a user's membership from a tenant by deleting all role assignments."""
+        with tracer.start_as_current_span("UserService.remove_user_from_tenant") as span:
+            span.set_attribute("tenant.id", str(tenant_id))
+            span.set_attribute("user.id", str(user_id))
+
+            user = await self._repository.get(user_id)
+            if user is None:
+                return Error(NotFound(message=f"User '{user_id}' not found"))
+
+            membership_err = await self._verify_tenant_membership(user_id, tenant_id)
+            if membership_err is not None:
+                return Error(membership_err)
+
+            if self._assignment_repository is None:
+                return Error(NotFound(message="Assignment repository not configured"))
+
+            deleted_count = await self._assignment_repository.delete_by_user_tenant(user_id, tenant_id)
+            if deleted_count == 0:
+                msg = f"No role assignments found for user '{user_id}' in tenant '{tenant_id}'"
+                return Error(NotFound(message=msg))
+
+            await self._assignment_repository.commit()
+
+            return Ok({"status": "removed", "user_id": str(user_id)})
 
     async def search_users(
         self,

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -258,6 +258,16 @@ class UserService:
 
             await self._assignment_repository.commit()
 
+            # Best-effort sync: notify IdP of membership removal
+            self._log_sync_failure(
+                await self._adapter.sync_user(
+                    user_id=user_id,
+                    data={"email": user.email, "status": user.status.value},
+                ),
+                user_id,
+                "remove_user_from_tenant",
+            )
+
             return Ok({"status": "removed", "user_id": str(user_id)})
 
     async def search_users(

--- a/backend/tests/unit/test_identity_adapter.py
+++ b/backend/tests/unit/test_identity_adapter.py
@@ -41,6 +41,15 @@ class TestNoOpSyncAdapterMethods:
         )
         assert result == Ok(None)
 
+    async def test_delete_role_assignment(self):
+        adapter = NoOpSyncAdapter()
+        result = await adapter.delete_role_assignment(
+            user_id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            role_id=uuid.uuid4(),
+        )
+        assert result == Ok(None)
+
     async def test_delete_user(self):
         adapter = NoOpSyncAdapter()
         result = await adapter.delete_user(user_id=uuid.uuid4())
@@ -73,6 +82,7 @@ class TestNoOpSyncAdapterMethods:
             await adapter.sync_permission(permission_id=uid, data=data),
             await adapter.sync_tenant(tenant_id=uid, data=data),
             await adapter.sync_role_assignment(user_id=uid, tenant_id=uid, role_id=uid),
+            await adapter.delete_role_assignment(user_id=uid, tenant_id=uid, role_id=uid),
             await adapter.delete_user(user_id=uid),
             await adapter.delete_role(role_id=uid),
             await adapter.delete_permission(permission_id=uid),

--- a/backend/tests/unit/test_permission_service.py
+++ b/backend/tests/unit/test_permission_service.py
@@ -131,3 +131,123 @@ class TestGetPermission:
 
         assert result.is_error()
         assert isinstance(result.error, NotFound)
+
+
+@pytest.mark.anyio
+class TestListPermissions:
+    """Story 2.3: list_permissions delegates to repository."""
+
+    async def test_list_permissions_returns_list(self):
+        service, repo, _adapter = _build_service()
+        perms = [_make_permission(name="read"), _make_permission(name="write")]
+        repo.list_all.return_value = perms
+
+        result = await service.list_permissions()
+
+        assert result.is_ok()
+        assert len(result.ok) == 2
+        repo.list_all.assert_awaited_once()
+
+    async def test_list_permissions_empty(self):
+        service, repo, _adapter = _build_service()
+        repo.list_all.return_value = []
+
+        result = await service.list_permissions()
+
+        assert result.is_ok()
+        assert result.ok == []
+
+
+@pytest.mark.anyio
+class TestUpdatePermission:
+    """Story 2.3: update_permission updates fields, commits, syncs."""
+
+    async def test_update_permission_success(self):
+        service, repo, adapter = _build_service()
+        perm = _make_permission(name="reports.read")
+        repo.get.return_value = perm
+        repo.get_by_name.return_value = None
+        repo.update.return_value = perm
+        adapter.sync_permission.return_value = Ok(None)
+
+        result = await service.update_permission(permission_id=perm.id, name="reports.view", description="View reports")
+
+        assert result.is_ok()
+        repo.update.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+        adapter.sync_permission.assert_awaited_once()
+
+    async def test_update_permission_not_found(self):
+        service, repo, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.update_permission(permission_id=uuid.uuid4(), name="new")
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_update_permission_name_conflict(self):
+        service, repo, _adapter = _build_service()
+        perm = _make_permission(name="reports.read")
+        existing = _make_permission(name="reports.write")
+        repo.get.return_value = perm
+        repo.get_by_name.return_value = existing
+
+        result = await service.update_permission(permission_id=perm.id, name="reports.write")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_update_permission_integrity_error(self):
+        service, repo, _adapter = _build_service()
+        perm = _make_permission()
+        repo.get.return_value = perm
+        repo.get_by_name.return_value = None
+        repo.update.side_effect = RepositoryConflictError("duplicate key")
+
+        result = await service.update_permission(permission_id=perm.id, name="new")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+
+@pytest.mark.anyio
+class TestDeletePermission:
+    """Story 2.3: delete_permission removes from DB, commits, syncs deletion."""
+
+    async def test_delete_permission_success(self):
+        service, repo, adapter = _build_service()
+        perm = _make_permission(name="reports.read")
+        repo.get.return_value = perm
+        repo.delete.return_value = True
+        adapter.delete_permission.return_value = Ok(None)
+
+        result = await service.delete_permission(permission_id=perm.id)
+
+        assert result.is_ok()
+        assert result.ok["status"] == "deleted"
+        assert result.ok["name"] == "reports.read"
+        repo.commit.assert_awaited_once()
+        adapter.delete_permission.assert_awaited_once()
+
+    async def test_delete_permission_not_found(self):
+        service, repo, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.delete_permission(permission_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_delete_permission_sync_failure_still_ok(self):
+        service, repo, adapter = _build_service()
+        perm = _make_permission()
+        repo.get.return_value = perm
+        repo.delete.return_value = True
+        adapter.delete_permission.return_value = Error(SyncError(message="down", operation="delete_permission"))
+
+        with patch("app.services.permission.logger") as mock_logger:
+            result = await service.delete_permission(permission_id=perm.id)
+
+        assert result.is_ok()
+        mock_logger.warning.assert_called_once()

--- a/backend/tests/unit/test_permissions_router.py
+++ b/backend/tests/unit/test_permissions_router.py
@@ -1,12 +1,20 @@
-"""Unit tests for the permissions router."""
+"""Unit tests for the permissions router.
 
+Story 2.3: tests rewired endpoints that use PermissionService via DI
+instead of get_descope_client().
+"""
+
+import uuid
 from unittest.mock import AsyncMock, patch
 
-import httpx
 import pytest
+from expression import Error, Ok
 from httpx import ASGITransport, AsyncClient
 
+from app.dependencies.identity import get_permission_service
+from app.errors.identity import Conflict
 from app.main import app
+from app.services.permission import PermissionService
 
 
 @pytest.fixture
@@ -21,33 +29,49 @@ def _set_env(monkeypatch):
 
 
 @pytest.fixture
+def mock_permission_service():
+    return AsyncMock(spec=PermissionService)
+
+
+@pytest.fixture(autouse=True)
+def _override_permission_service(mock_permission_service):
+    app.dependency_overrides[get_permission_service] = lambda: mock_permission_service
+    yield
+    app.dependency_overrides.pop(get_permission_service, None)
+
+
+@pytest.fixture
 async def client():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
 
 
+TENANT_ID = "51c5957b-684a-453f-8ab1-8f239999c4d8"
+
 ADMIN_CLAIMS = {
     "sub": "user123",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {"roles": ["admin"], "permissions": ["settings.manage"]},
+        TENANT_ID: {"roles": ["admin"], "permissions": ["settings.manage"]},
     },
 }
 
 VIEWER_CLAIMS = {
     "sub": "user456",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {"roles": ["viewer"], "permissions": ["projects.read"]},
+        TENANT_ID: {"roles": ["viewer"], "permissions": ["projects.read"]},
     },
 }
 
 AUTH_HEADER = {"Authorization": "Bearer valid.token"}
 
+PERM_ID = str(uuid.uuid4())
+
 SAMPLE_PERMISSIONS = [
-    {"name": "reports.read", "description": "View reports"},
-    {"name": "reports.write", "description": "Edit reports"},
+    {"id": str(uuid.uuid4()), "name": "reports.read", "description": "View reports"},
+    {"id": str(uuid.uuid4()), "name": "reports.write", "description": "Edit reports"},
 ]
 
 
@@ -92,32 +116,36 @@ async def test_delete_permission_rejects_viewer(mock_validate, client):
     assert response.status_code == 403
 
 
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_permissions_rejected_without_tenant(mock_validate, client):
+    mock_validate.return_value = {"sub": "user789", "tenants": {}}
+    response = await client.get("/api/permissions", headers=AUTH_HEADER)
+    assert response.status_code == 403
+
+
 # --- Happy path ---
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_permissions(mock_validate, mock_factory, client):
+async def test_list_permissions(mock_validate, mock_permission_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.list_permissions.return_value = SAMPLE_PERMISSIONS
-    mock_factory.return_value = mock_client
+    mock_permission_service.list_permissions.return_value = Ok(SAMPLE_PERMISSIONS)
 
     response = await client.get("/api/permissions", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
-    assert data["permissions"] == SAMPLE_PERMISSIONS
-    mock_client.list_permissions.assert_called_once()
+    assert len(data) == 2
+    mock_permission_service.list_permissions.assert_awaited_once()
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_permission(mock_validate, mock_factory, client):
+async def test_create_permission(mock_validate, mock_permission_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    perm_dict = {"id": PERM_ID, "name": "reports.read", "description": "View reports"}
+    mock_permission_service.create_permission.return_value = Ok(perm_dict)
 
     response = await client.post(
         "/api/permissions",
@@ -128,16 +156,15 @@ async def test_create_permission(mock_validate, mock_factory, client):
     data = response.json()
     assert data["name"] == "reports.read"
     assert data["description"] == "View reports"
-    mock_client.create_permission.assert_called_once_with("reports.read", "View reports")
+    mock_permission_service.create_permission.assert_awaited_once_with(name="reports.read", description="View reports")
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_permission_default_description(mock_validate, mock_factory, client):
+async def test_create_permission_default_description(mock_validate, mock_permission_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    perm_dict = {"id": PERM_ID, "name": "reports.read", "description": ""}
+    mock_permission_service.create_permission.return_value = Ok(perm_dict)
 
     response = await client.post(
         "/api/permissions",
@@ -145,16 +172,18 @@ async def test_create_permission_default_description(mock_validate, mock_factory
         json={"name": "reports.read"},
     )
     assert response.status_code == 201
-    mock_client.create_permission.assert_called_once_with("reports.read", "")
+    mock_permission_service.create_permission.assert_awaited_once_with(name="reports.read", description="")
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_permission(mock_validate, mock_factory, client):
+async def test_update_permission(mock_validate, mock_permission_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    perm_id = str(uuid.uuid4())
+    mock_permission_service.list_permissions.return_value = Ok([{"id": perm_id, "name": "reports.read"}])
+    mock_permission_service.update_permission.return_value = Ok(
+        {"id": perm_id, "name": "reports.view", "description": "View reports"}
+    )
 
     response = await client.put(
         "/api/permissions/reports.read",
@@ -164,165 +193,67 @@ async def test_update_permission(mock_validate, mock_factory, client):
     assert response.status_code == 200
     data = response.json()
     assert data["name"] == "reports.view"
-    assert data["description"] == "View reports"
-    mock_client.update_permission.assert_called_once_with("reports.read", "reports.view", "View reports")
+    mock_permission_service.update_permission.assert_awaited_once()
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_permission(mock_validate, mock_factory, client):
+async def test_delete_permission(mock_validate, mock_permission_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    perm_id = str(uuid.uuid4())
+    mock_permission_service.list_permissions.return_value = Ok([{"id": perm_id, "name": "reports.read"}])
+    mock_permission_service.delete_permission.return_value = Ok({"status": "deleted", "name": "reports.read"})
 
     response = await client.delete("/api/permissions/reports.read", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "deleted"
     assert data["name"] == "reports.read"
-    mock_client.delete_permission.assert_called_once_with("reports.read")
 
 
 # --- Error handling ---
 
 
-def _make_http_status_error(status_code: int = 500) -> httpx.HTTPStatusError:
-    request = httpx.Request("POST", "https://api.descope.com/v1/mgmt/permission/create")
-    response = httpx.Response(status_code, request=request, text="error detail")
-    return httpx.HTTPStatusError(f"{status_code} Server Error", request=request, response=response)
-
-
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_permission_duplicate_returns_client_error(mock_validate, mock_factory, client):
-    """Descope returns 4xx for duplicate permission names — forwarded to caller."""
+async def test_create_permission_duplicate_returns_conflict(mock_validate, mock_permission_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_permission.side_effect = _make_http_status_error(400)
-    mock_factory.return_value = mock_client
+    mock_permission_service.create_permission.return_value = Error(
+        Conflict(message="Permission 'existing.perm' already exists")
+    )
 
     response = await client.post(
         "/api/permissions",
         headers=AUTH_HEADER,
         json={"name": "existing.perm"},
     )
-    assert response.status_code == 400
+    assert response.status_code == 409
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_permissions_descope_server_error(mock_validate, mock_factory, client):
-    """Descope 5xx → 502."""
+async def test_update_permission_not_found(mock_validate, mock_permission_service, client):
+    """Permission name not in list → 404."""
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.list_permissions.side_effect = _make_http_status_error(500)
-    mock_factory.return_value = mock_client
-
-    response = await client.get("/api/permissions", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_permission_network_error(mock_validate, mock_factory, client):
-    """Network error → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_permission.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/permissions",
-        headers=AUTH_HEADER,
-        json={"name": "test.perm"},
-    )
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_permission_descope_error(mock_validate, mock_factory, client):
-    """Descope 5xx on update → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.update_permission.side_effect = _make_http_status_error(500)
-    mock_factory.return_value = mock_client
+    mock_permission_service.list_permissions.return_value = Ok([])
 
     response = await client.put(
-        "/api/permissions/test.perm",
+        "/api/permissions/nonexistent",
         headers=AUTH_HEADER,
-        json={"new_name": "test.perm2"},
+        json={"new_name": "new-name"},
     )
-    assert response.status_code == 502
+    assert response.status_code == 404
 
 
 @pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_permission_descope_error(mock_validate, mock_factory, client):
-    """Descope 5xx on delete → 502."""
+async def test_delete_permission_not_found(mock_validate, mock_permission_service, client):
+    """Permission name not in list → 404."""
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.delete_permission.side_effect = _make_http_status_error(500)
-    mock_factory.return_value = mock_client
+    mock_permission_service.list_permissions.return_value = Ok([])
 
-    response = await client.delete("/api/permissions/test.perm", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_permission_network_error(mock_validate, mock_factory, client):
-    """Network error on delete → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.delete_permission.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.delete("/api/permissions/test.perm", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_permission_network_error(mock_validate, mock_factory, client):
-    """Network error on update → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.update_permission.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.put(
-        "/api/permissions/test.perm",
-        headers=AUTH_HEADER,
-        json={"new_name": "test.perm2"},
-    )
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.permissions.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_permission_descope_401_becomes_502(mock_validate, mock_factory, client):
-    """Descope 401 (e.g. expired mgmt key) should not be forwarded — returns 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_permission.side_effect = _make_http_status_error(401)
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/permissions",
-        headers=AUTH_HEADER,
-        json={"name": "test.perm"},
-    )
-    assert response.status_code == 502
+    response = await client.delete("/api/permissions/nonexistent", headers=AUTH_HEADER)
+    assert response.status_code == 404
 
 
 # --- Input validation ---
@@ -350,14 +281,3 @@ async def test_update_permission_empty_new_name_rejected(mock_validate, client):
         json={"new_name": ""},
     )
     assert response.status_code == 422
-
-
-# --- No tenant context ---
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_permissions_rejected_without_tenant(mock_validate, client):
-    mock_validate.return_value = {"sub": "user789", "tenants": {}}
-    response = await client.get("/api/permissions", headers=AUTH_HEADER)
-    assert response.status_code == 403

--- a/backend/tests/unit/test_permissions_router.py
+++ b/backend/tests/unit/test_permissions_router.py
@@ -136,7 +136,8 @@ async def test_list_permissions(mock_validate, mock_permission_service, client):
     response = await client.get("/api/permissions", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 2
+    assert "permissions" in data
+    assert len(data["permissions"]) == 2
     mock_permission_service.list_permissions.assert_awaited_once()
 
 

--- a/backend/tests/unit/test_role_service.py
+++ b/backend/tests/unit/test_role_service.py
@@ -525,22 +525,42 @@ class TestUnassignRoleFromUser:
     """Story 2.3: unassign_role_from_user removes assignment record."""
 
     async def test_unassign_success(self):
-        service, _repo, _perm, assign_repo, _adapter = _build_service()
+        service, repo, _perm, assign_repo, adapter = _build_service()
         user_id = uuid.uuid4()
-        role_id = uuid.uuid4()
+        role = _make_role()
+        repo.get.return_value = role
         assign_repo.delete.return_value = True
+        adapter.delete_role_assignment.return_value = Ok(None)
 
-        result = await service.unassign_role_from_user(user_id=user_id, tenant_id=TENANT_ID, role_id=role_id)
+        result = await service.unassign_role_from_user(user_id=user_id, tenant_id=TENANT_ID, role_id=role.id)
 
         assert result.is_ok()
         assert result.ok["status"] == "removed"
         assign_repo.commit.assert_awaited_once()
+        adapter.delete_role_assignment.assert_awaited_once()
 
     async def test_unassign_not_found(self):
-        service, _repo, _perm, assign_repo, _adapter = _build_service()
+        service, repo, _perm, assign_repo, _adapter = _build_service()
+        repo.get.return_value = None
         assign_repo.delete.return_value = False
 
         result = await service.unassign_role_from_user(user_id=uuid.uuid4(), tenant_id=TENANT_ID, role_id=uuid.uuid4())
 
         assert result.is_error()
         assert isinstance(result.error, NotFound)
+
+    async def test_unassign_sync_failure_still_returns_ok(self):
+        service, repo, _perm, assign_repo, adapter = _build_service()
+        role = _make_role()
+        repo.get.return_value = role
+        assign_repo.delete.return_value = True
+        adapter.delete_role_assignment.return_value = Error(
+            SyncError(message="Descope down", operation="delete_role_assignment")
+        )
+
+        with patch("app.services.role.logger") as mock_logger:
+            result = await service.unassign_role_from_user(user_id=uuid.uuid4(), tenant_id=TENANT_ID, role_id=role.id)
+
+        assert result.is_ok()
+        assign_repo.commit.assert_awaited_once()
+        mock_logger.warning.assert_called_once()

--- a/backend/tests/unit/test_role_service.py
+++ b/backend/tests/unit/test_role_service.py
@@ -377,3 +377,170 @@ class TestAssignRoleToUser:
 
         assert result.is_ok()
         assert result.ok["assigned_by"] == str(assigner_id)
+
+
+@pytest.mark.anyio
+class TestListRoles:
+    """Story 2.3: list_roles delegates to repository."""
+
+    async def test_list_roles_returns_list(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        roles = [_make_role(name="admin"), _make_role(name="viewer")]
+        repo.list_by_tenant.return_value = roles
+
+        result = await service.list_roles()
+
+        assert result.is_ok()
+        assert len(result.ok) == 2
+        repo.list_by_tenant.assert_awaited_once_with(None)
+
+    async def test_list_roles_with_tenant(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        repo.list_by_tenant.return_value = []
+
+        result = await service.list_roles(tenant_id=TENANT_ID)
+
+        assert result.is_ok()
+        repo.list_by_tenant.assert_awaited_once_with(TENANT_ID)
+
+    async def test_list_roles_empty(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        repo.list_by_tenant.return_value = []
+
+        result = await service.list_roles()
+
+        assert result.is_ok()
+        assert result.ok == []
+
+
+@pytest.mark.anyio
+class TestUpdateRole:
+    """Story 2.3: update_role updates fields, commits, syncs."""
+
+    async def test_update_role_success(self):
+        service, repo, _perm, _assign, adapter = _build_service()
+        role = _make_role(name="editor")
+        repo.get.return_value = role
+        repo.get_by_name.return_value = None
+        repo.update.return_value = role
+        adapter.sync_role.return_value = Ok(None)
+
+        result = await service.update_role(role_id=role.id, name="senior-editor", description="Senior")
+
+        assert result.is_ok()
+        repo.update.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+        adapter.sync_role.assert_awaited_once()
+
+    async def test_update_role_not_found(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.update_role(role_id=uuid.uuid4(), name="new-name")
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_update_role_name_conflict(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        role = _make_role(name="editor")
+        existing = _make_role(name="admin")
+        repo.get.return_value = role
+        repo.get_by_name.return_value = existing
+
+        result = await service.update_role(role_id=role.id, name="admin")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+    async def test_update_role_same_name_no_conflict(self):
+        service, repo, _perm, _assign, adapter = _build_service()
+        role = _make_role(name="editor")
+        repo.get.return_value = role
+        repo.get_by_name.return_value = role  # same role
+        repo.update.return_value = role
+        adapter.sync_role.return_value = Ok(None)
+
+        result = await service.update_role(role_id=role.id, name="editor")
+
+        assert result.is_ok()
+
+    async def test_update_role_integrity_error(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        role = _make_role()
+        repo.get.return_value = role
+        repo.get_by_name.return_value = None
+        repo.update.side_effect = RepositoryConflictError("duplicate key")
+
+        result = await service.update_role(role_id=role.id, name="new-name")
+
+        assert result.is_error()
+        assert isinstance(result.error, Conflict)
+
+
+@pytest.mark.anyio
+class TestDeleteRole:
+    """Story 2.3: delete_role removes from DB, commits, syncs deletion."""
+
+    async def test_delete_role_success(self):
+        service, repo, _perm, _assign, adapter = _build_service()
+        role = _make_role(name="editor")
+        repo.get.return_value = role
+        repo.delete.return_value = True
+        adapter.delete_role.return_value = Ok(None)
+
+        result = await service.delete_role(role_id=role.id)
+
+        assert result.is_ok()
+        assert result.ok["status"] == "deleted"
+        assert result.ok["name"] == "editor"
+        repo.commit.assert_awaited_once()
+        adapter.delete_role.assert_awaited_once()
+
+    async def test_delete_role_not_found(self):
+        service, repo, _perm, _assign, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.delete_role(role_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_delete_role_sync_failure_still_ok(self):
+        service, repo, _perm, _assign, adapter = _build_service()
+        role = _make_role()
+        repo.get.return_value = role
+        repo.delete.return_value = True
+        adapter.delete_role.return_value = Error(SyncError(message="down", operation="delete_role"))
+
+        with patch("app.services.role.logger") as mock_logger:
+            result = await service.delete_role(role_id=role.id)
+
+        assert result.is_ok()
+        mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.anyio
+class TestUnassignRoleFromUser:
+    """Story 2.3: unassign_role_from_user removes assignment record."""
+
+    async def test_unassign_success(self):
+        service, _repo, _perm, assign_repo, _adapter = _build_service()
+        user_id = uuid.uuid4()
+        role_id = uuid.uuid4()
+        assign_repo.delete.return_value = True
+
+        result = await service.unassign_role_from_user(user_id=user_id, tenant_id=TENANT_ID, role_id=role_id)
+
+        assert result.is_ok()
+        assert result.ok["status"] == "removed"
+        assign_repo.commit.assert_awaited_once()
+
+    async def test_unassign_not_found(self):
+        service, _repo, _perm, assign_repo, _adapter = _build_service()
+        assign_repo.delete.return_value = False
+
+        result = await service.unassign_role_from_user(user_id=uuid.uuid4(), tenant_id=TENANT_ID, role_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)

--- a/backend/tests/unit/test_roles_router.py
+++ b/backend/tests/unit/test_roles_router.py
@@ -1,12 +1,20 @@
-"""Unit tests for the roles router endpoints."""
+"""Unit tests for the roles router endpoints.
 
+Story 2.3: tests rewired endpoints that use RoleService via DI
+instead of get_descope_client().
+"""
+
+import uuid
 from unittest.mock import AsyncMock, patch
 
-import httpx
 import pytest
+from expression import Error, Ok
 from httpx import ASGITransport, AsyncClient
 
+from app.dependencies.identity import get_role_service
+from app.errors.identity import Conflict
 from app.main import app
+from app.services.role import RoleService
 
 
 @pytest.fixture
@@ -21,17 +29,31 @@ def _set_env(monkeypatch):
 
 
 @pytest.fixture
+def mock_role_service():
+    return AsyncMock(spec=RoleService)
+
+
+@pytest.fixture(autouse=True)
+def _override_role_service(mock_role_service):
+    app.dependency_overrides[get_role_service] = lambda: mock_role_service
+    yield
+    app.dependency_overrides.pop(get_role_service, None)
+
+
+@pytest.fixture
 async def client():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
 
 
+TENANT_ID = "51c5957b-684a-453f-8ab1-8f239999c4d8"
+
 ADMIN_CLAIMS = {
     "sub": "user123",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {
+        TENANT_ID: {
             "roles": ["admin"],
             "permissions": ["projects.create", "projects.read", "members.invite", "members.update_role"],
         },
@@ -40,9 +62,9 @@ ADMIN_CLAIMS = {
 
 VIEWER_CLAIMS = {
     "sub": "user456",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {
+        TENANT_ID: {
             "roles": ["viewer"],
             "permissions": ["projects.read", "documents.read"],
         },
@@ -51,9 +73,9 @@ VIEWER_CLAIMS = {
 
 OWNER_CLAIMS = {
     "sub": "owner1",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {
+        TENANT_ID: {
             "roles": ["owner"],
             "permissions": ["projects.create", "members.update_role", "billing.manage"],
         },
@@ -64,6 +86,18 @@ NO_TENANT_CLAIMS = {
     "sub": "user789",
     "tenants": {},
 }
+
+AUTH_HEADER = {"Authorization": "Bearer valid.token"}
+
+ROLE_ID = str(uuid.uuid4())
+
+SAMPLE_ROLES = [
+    {"id": str(uuid.uuid4()), "name": "editor", "description": "Can edit", "tenant_id": None},
+    {"id": str(uuid.uuid4()), "name": "viewer", "description": "Read only", "tenant_id": None},
+]
+
+
+# --- /roles/me (claims-based, no service) ---
 
 
 @pytest.mark.anyio
@@ -76,10 +110,10 @@ async def test_roles_me_rejects_unauthenticated(client):
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_roles_me_returns_current_roles(mock_validate, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.get("/api/roles/me", headers={"Authorization": "Bearer valid.token"})
+    response = await client.get("/api/roles/me", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
-    assert data["tenant_id"] == "tenant-abc"
+    assert data["tenant_id"] == TENANT_ID
     assert "admin" in data["roles"]
     assert "projects.create" in data["permissions"]
 
@@ -88,80 +122,15 @@ async def test_roles_me_returns_current_roles(mock_validate, client):
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_roles_me_returns_403_without_tenant(mock_validate, client):
     mock_validate.return_value = NO_TENANT_CLAIMS
-    response = await client.get("/api/roles/me", headers={"Authorization": "Bearer valid.token"})
-    assert response.status_code == 403
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_assign_roles_as_admin(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.resolve_login_id.return_value = "target-user@example.com"
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["member"]},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "roles_assigned"
-    mock_client.resolve_login_id.assert_called_once_with("target-user")
-    mock_client.assign_roles.assert_called_once_with("target-user@example.com", "tenant-abc", ["member"])
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_assign_roles_rejected_for_viewer(mock_validate, client):
-    mock_validate.return_value = VIEWER_CLAIMS
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["admin"]},
-    )
-    assert response.status_code == 403
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_remove_roles_as_admin(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.resolve_login_id.return_value = "target-user@example.com"
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/roles/remove",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["member"]},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "roles_removed"
-    mock_client.resolve_login_id.assert_called_once_with("target-user")
-    mock_client.remove_roles.assert_called_once_with("target-user@example.com", "tenant-abc", ["member"])
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_remove_roles_rejected_for_viewer(mock_validate, client):
-    mock_validate.return_value = VIEWER_CLAIMS
-    response = await client.post(
-        "/api/roles/remove",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["admin"]},
-    )
+    response = await client.get("/api/roles/me", headers=AUTH_HEADER)
     assert response.status_code == 403
 
 
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_roles_me_viewer(mock_validate, client):
-    """Viewer should see their own roles and permissions."""
     mock_validate.return_value = VIEWER_CLAIMS
-    response = await client.get("/api/roles/me", headers={"Authorization": "Bearer valid.token"})
+    response = await client.get("/api/roles/me", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
     assert "viewer" in data["roles"]
@@ -170,105 +139,14 @@ async def test_roles_me_viewer(mock_validate, client):
 
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_assign_roles_rejected_without_tenant(mock_validate, client):
-    """Role assignment should fail when user has no tenant context."""
-    mock_validate.return_value = NO_TENANT_CLAIMS
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["member"]},
-    )
-    assert response.status_code == 403
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_assign_roles_rejected_cross_tenant(mock_validate, client):
-    """Admin in tenant-abc cannot assign roles in tenant-other."""
+async def test_roles_me_not_captured_by_name_param(mock_validate, client):
+    """Ensure /roles/me is NOT interpreted as /roles/{name} with name='me'."""
     mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-other", "role_names": ["member"]},
-    )
-    assert response.status_code == 403
-    assert "different tenant" in response.json()["detail"]
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_admin_cannot_assign_owner_role(mock_validate, client):
-    """Admin should not be able to escalate to owner."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["owner"]},
-    )
-    assert response.status_code == 403
-    assert "owner" in response.json()["detail"].lower()
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_owner_can_assign_owner_role(mock_validate, mock_factory, client):
-    """Owner should be able to assign the owner role."""
-    mock_validate.return_value = OWNER_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.resolve_login_id.return_value = "target-user@example.com"
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": ["owner"]},
-    )
+    response = await client.get("/api/roles/me", headers=AUTH_HEADER)
     assert response.status_code == 200
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_assign_empty_role_names_rejected(mock_validate, client):
-    """Empty role_names list should be rejected by validation."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.post(
-        "/api/roles/assign",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-abc", "role_names": []},
-    )
-    assert response.status_code == 422
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_remove_roles_rejected_cross_tenant(mock_validate, client):
-    """Admin cannot remove roles in a different tenant."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.post(
-        "/api/roles/remove",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"user_id": "target-user", "tenant_id": "tenant-other", "role_names": ["member"]},
-    )
-    assert response.status_code == 403
-
-
-# =============================================================================
-# Role Definition CRUD Tests
-# =============================================================================
-
-AUTH_HEADER = {"Authorization": "Bearer valid.token"}
-
-SAMPLE_ROLES = [
-    {"name": "editor", "description": "Can edit", "permissionNames": ["docs.write"]},
-    {"name": "viewer", "description": "Read only", "permissionNames": ["docs.read"]},
-]
-
-
-def _make_http_status_error(status_code: int = 500) -> httpx.HTTPStatusError:
-    request = httpx.Request("POST", "https://api.descope.com/v1/mgmt/role/create")
-    response = httpx.Response(status_code, request=request, text="error detail")
-    return httpx.HTTPStatusError(f"{status_code} Server Error", request=request, response=response)
+    data = response.json()
+    assert "tenant_id" in data
+    assert "roles" in data
 
 
 # --- Auth enforcement for CRUD endpoints ---
@@ -312,53 +190,143 @@ async def test_delete_role_rejects_viewer(mock_validate, client):
     assert response.status_code == 403
 
 
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_list_roles_rejected_without_tenant(mock_validate, client):
+    mock_validate.return_value = NO_TENANT_CLAIMS
+    response = await client.get("/api/roles", headers=AUTH_HEADER)
+    assert response.status_code == 403
+
+
+# --- Role assign/remove auth ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_assign_roles_rejected_for_viewer(mock_validate, client):
+    mock_validate.return_value = VIEWER_CLAIMS
+    response = await client.post(
+        "/api/roles/assign",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["admin"]},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_remove_roles_rejected_for_viewer(mock_validate, client):
+    mock_validate.return_value = VIEWER_CLAIMS
+    response = await client.post(
+        "/api/roles/remove",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["admin"]},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_assign_roles_rejected_without_tenant(mock_validate, client):
+    mock_validate.return_value = NO_TENANT_CLAIMS
+    response = await client.post(
+        "/api/roles/assign",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["member"]},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_assign_roles_rejected_cross_tenant(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/roles/assign",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": "tenant-other", "role_names": ["member"]},
+    )
+    assert response.status_code == 403
+    assert "different tenant" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_admin_cannot_assign_owner_role(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/roles/assign",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["owner"]},
+    )
+    assert response.status_code == 403
+    assert "owner" in response.json()["detail"].lower()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_assign_empty_role_names_rejected(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/roles/assign",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": []},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_remove_roles_rejected_cross_tenant(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/roles/remove",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": "tenant-other", "role_names": ["member"]},
+    )
+    assert response.status_code == 403
+
+
 # --- Happy path ---
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_roles(mock_validate, mock_factory, client):
+async def test_list_roles(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.list_roles.return_value = SAMPLE_ROLES
-    mock_factory.return_value = mock_client
+    mock_role_service.list_roles.return_value = Ok(SAMPLE_ROLES)
 
     response = await client.get("/api/roles", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
-    assert data["roles"] == SAMPLE_ROLES
-    mock_client.list_roles.assert_called_once()
+    assert len(data) == 2
+    mock_role_service.list_roles.assert_awaited_once()
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role(mock_validate, mock_factory, client):
+async def test_create_role(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    role_dict = {"id": ROLE_ID, "name": "editor", "description": "Can edit", "tenant_id": None}
+    mock_role_service.create_role.return_value = Ok(role_dict)
 
     response = await client.post(
         "/api/roles",
         headers=AUTH_HEADER,
-        json={"name": "editor", "description": "Can edit", "permission_names": ["docs.write"]},
+        json={"name": "editor", "description": "Can edit"},
     )
     assert response.status_code == 201
     data = response.json()
     assert data["name"] == "editor"
-    assert data["description"] == "Can edit"
-    assert data["permission_names"] == ["docs.write"]
-    mock_client.create_role.assert_called_once_with("editor", "Can edit", ["docs.write"])
+    mock_role_service.create_role.assert_awaited_once_with(name="editor", description="Can edit")
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role_default_fields(mock_validate, mock_factory, client):
+async def test_create_role_default_fields(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    role_dict = {"id": ROLE_ID, "name": "viewer", "description": "", "tenant_id": None}
+    mock_role_service.create_role.return_value = Ok(role_dict)
 
     response = await client.post(
         "/api/roles",
@@ -366,224 +334,126 @@ async def test_create_role_default_fields(mock_validate, mock_factory, client):
         json={"name": "viewer"},
     )
     assert response.status_code == 201
-    data = response.json()
-    assert data["description"] == ""
-    assert data["permission_names"] == []
-    mock_client.create_role.assert_called_once_with("viewer", "", None)
+    mock_role_service.create_role.assert_awaited_once_with(name="viewer", description="")
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role(mock_validate, mock_factory, client):
+async def test_update_role(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "editor"}])
+    mock_role_service.update_role.return_value = Ok(
+        {"id": role_id, "name": "senior-editor", "description": "Senior editor", "tenant_id": None}
+    )
 
     response = await client.put(
         "/api/roles/editor",
         headers=AUTH_HEADER,
-        json={
-            "new_name": "senior-editor",
-            "description": "Senior editor",
-            "permission_names": ["docs.write", "docs.admin"],
-        },
+        json={"new_name": "senior-editor", "description": "Senior editor"},
     )
     assert response.status_code == 200
     data = response.json()
     assert data["name"] == "senior-editor"
-    assert data["description"] == "Senior editor"
-    assert data["permission_names"] == ["docs.write", "docs.admin"]
-    mock_client.update_role.assert_called_once_with(
-        "editor", "senior-editor", "Senior editor", ["docs.write", "docs.admin"]
-    )
+    mock_role_service.update_role.assert_awaited_once()
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_role(mock_validate, mock_factory, client):
+async def test_delete_role(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "editor"}])
+    mock_role_service.delete_role.return_value = Ok({"status": "deleted", "name": "editor"})
 
     response = await client.delete("/api/roles/editor", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "deleted"
     assert data["name"] == "editor"
-    mock_client.delete_role.assert_called_once_with("editor")
-
-
-# --- Partial update ---
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role_partial_description_only(mock_validate, mock_factory, client):
-    """Omitting new_name and permission_names should not wipe them."""
+async def test_assign_roles_as_admin(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
-
-    response = await client.put(
-        "/api/roles/editor",
-        headers=AUTH_HEADER,
-        json={"description": "Updated desc"},
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "member"}])
+    mock_role_service.assign_role_to_user.return_value = Ok(
+        {"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_id": role_id}
     )
-    assert response.status_code == 200
-    data = response.json()
-    assert data["name"] == "editor"  # defaults to path param
-    assert data["description"] == "Updated desc"
-    assert data["permission_names"] is None  # not sent → unchanged
-    mock_client.update_role.assert_called_once_with("editor", "editor", "Updated desc", None)
 
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role_empty_body(mock_validate, mock_factory, client):
-    """Empty body is a no-op: name defaults to path param, others are None."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_factory.return_value = mock_client
-
-    response = await client.put(
-        "/api/roles/editor",
-        headers=AUTH_HEADER,
-        json={},
-    )
-    assert response.status_code == 200
-    data = response.json()
-    assert data["name"] == "editor"
-    mock_client.update_role.assert_called_once_with("editor", "editor", None, None)
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role_empty_permission_name_rejected(mock_validate, client):
-    """Empty strings in permission_names list should be rejected."""
-    mock_validate.return_value = ADMIN_CLAIMS
     response = await client.post(
-        "/api/roles",
+        "/api/roles/assign",
         headers=AUTH_HEADER,
-        json={"name": "test-role", "permission_names": ["", "docs.read"]},
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["member"]},
     )
-    assert response.status_code == 422
+    assert response.status_code == 200
+    assert response.json()["status"] == "roles_assigned"
+    mock_role_service.assign_role_to_user.assert_awaited_once()
 
 
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role_empty_permission_name_rejected(mock_validate, client):
-    """Empty strings in permission_names list should be rejected on update."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.put(
-        "/api/roles/editor",
-        headers=AUTH_HEADER,
-        json={"permission_names": ["", "docs.read"]},
+async def test_owner_can_assign_owner_role(mock_validate, mock_role_service, client):
+    mock_validate.return_value = OWNER_CLAIMS
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "owner"}])
+    mock_role_service.assign_role_to_user.return_value = Ok(
+        {"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_id": role_id}
     )
-    assert response.status_code == 422
+
+    response = await client.post(
+        "/api/roles/assign",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["owner"]},
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_remove_roles_as_admin(mock_validate, mock_role_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "member"}])
+    user_id = "dd98f159-658f-47f3-9ed2-99e85686b04c"
+    mock_role_service.unassign_role_from_user.return_value = Ok(
+        {"status": "removed", "user_id": user_id, "tenant_id": TENANT_ID, "role_id": role_id}
+    )
+
+    response = await client.post(
+        "/api/roles/remove",
+        headers=AUTH_HEADER,
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["member"]},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "roles_removed"
 
 
 # --- Error handling ---
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role_duplicate_returns_client_error(mock_validate, mock_factory, client):
-    """Descope returns 400/409 for duplicate role names — forwarded to caller."""
+async def test_create_role_duplicate_returns_conflict(mock_validate, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_role.side_effect = _make_http_status_error(409)
-    mock_factory.return_value = mock_client
+    mock_role_service.create_role.return_value = Error(Conflict(message="Role 'editor' already exists in this scope"))
 
     response = await client.post(
         "/api/roles",
         headers=AUTH_HEADER,
-        json={"name": "existing-role"},
+        json={"name": "editor"},
     )
     assert response.status_code == 409
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role_bad_request_forwarded(mock_validate, mock_factory, client):
-    """Descope 400 on create → forwarded."""
+async def test_update_role_not_found(mock_validate, mock_role_service, client):
+    """Role name not found in list → 404."""
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_role.side_effect = _make_http_status_error(400)
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/roles",
-        headers=AUTH_HEADER,
-        json={"name": "bad-role"},
-    )
-    assert response.status_code == 400
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_roles_descope_server_error(mock_validate, mock_factory, client):
-    """Descope 5xx → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.list_roles.side_effect = _make_http_status_error(500)
-    mock_factory.return_value = mock_client
-
-    response = await client.get("/api/roles", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role_network_error(mock_validate, mock_factory, client):
-    """Network error → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_role.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/roles",
-        headers=AUTH_HEADER,
-        json={"name": "test-role"},
-    )
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role_descope_error(mock_validate, mock_factory, client):
-    """Descope 5xx on update → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.update_role.side_effect = _make_http_status_error(500)
-    mock_factory.return_value = mock_client
-
-    response = await client.put(
-        "/api/roles/editor",
-        headers=AUTH_HEADER,
-        json={"new_name": "senior-editor"},
-    )
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role_not_found(mock_validate, mock_factory, client):
-    """Descope 404 on update → forwarded."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.update_role.side_effect = _make_http_status_error(404)
-    mock_factory.return_value = mock_client
+    mock_role_service.list_roles.return_value = Ok([])
 
     response = await client.put(
         "/api/roles/nonexistent",
@@ -594,95 +464,29 @@ async def test_update_role_not_found(mock_validate, mock_factory, client):
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_role_descope_error(mock_validate, mock_factory, client):
-    """Descope 5xx on delete → 502."""
+async def test_delete_role_not_found(mock_validate, mock_role_service, client):
+    """Role name not found in list → 404."""
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.delete_role.side_effect = _make_http_status_error(500)
-    mock_factory.return_value = mock_client
-
-    response = await client.delete("/api/roles/editor", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_role_not_found(mock_validate, mock_factory, client):
-    """Descope 404 on delete → forwarded."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.delete_role.side_effect = _make_http_status_error(404)
-    mock_factory.return_value = mock_client
+    mock_role_service.list_roles.return_value = Ok([])
 
     response = await client.delete("/api/roles/nonexistent", headers=AUTH_HEADER)
     assert response.status_code == 404
 
 
 @pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_delete_role_network_error(mock_validate, mock_factory, client):
-    """Network error on delete → 502."""
+async def test_assign_role_not_found(mock_validate, mock_role_service, client):
+    """Role name not in list → 404."""
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.delete_role.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.delete("/api/roles/editor", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_update_role_network_error(mock_validate, mock_factory, client):
-    """Network error on update → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.update_role.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.put(
-        "/api/roles/editor",
-        headers=AUTH_HEADER,
-        json={"new_name": "senior-editor"},
-    )
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_roles_network_error(mock_validate, mock_factory, client):
-    """Network error on list → 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.list_roles.side_effect = httpx.RequestError("Connection refused")
-    mock_factory.return_value = mock_client
-
-    response = await client.get("/api/roles", headers=AUTH_HEADER)
-    assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.roles.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_role_descope_401_becomes_502(mock_validate, mock_factory, client):
-    """Descope 401 (e.g. expired mgmt key) should not be forwarded — returns 502."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.create_role.side_effect = _make_http_status_error(401)
-    mock_factory.return_value = mock_client
+    mock_role_service.list_roles.return_value = Ok([])
 
     response = await client.post(
-        "/api/roles",
+        "/api/roles/assign",
         headers=AUTH_HEADER,
-        json={"name": "test-role"},
+        json={"user_id": "dd98f159-658f-47f3-9ed2-99e85686b04c", "tenant_id": TENANT_ID, "role_names": ["nonexistent"]},
     )
-    assert response.status_code == 502
+    assert response.status_code == 404
 
 
 # --- Input validation ---
@@ -712,28 +516,25 @@ async def test_update_role_empty_new_name_rejected(mock_validate, client):
     assert response.status_code == 422
 
 
-# --- No tenant context ---
-
-
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_roles_rejected_without_tenant(mock_validate, client):
-    mock_validate.return_value = NO_TENANT_CLAIMS
-    response = await client.get("/api/roles", headers=AUTH_HEADER)
-    assert response.status_code == 403
-
-
-# --- Route ordering: /roles/me still works ---
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_roles_me_not_captured_by_name_param(mock_validate, client):
-    """Ensure /roles/me is NOT interpreted as /roles/{name} with name='me'."""
+async def test_create_role_empty_permission_name_rejected(mock_validate, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.get("/api/roles/me", headers=AUTH_HEADER)
-    assert response.status_code == 200
-    data = response.json()
-    # /roles/me returns tenant_id, roles, permissions — not a role definition
-    assert "tenant_id" in data
-    assert "roles" in data
+    response = await client.post(
+        "/api/roles",
+        headers=AUTH_HEADER,
+        json={"name": "test-role", "permission_names": ["", "docs.read"]},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_update_role_empty_permission_name_rejected(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.put(
+        "/api/roles/editor",
+        headers=AUTH_HEADER,
+        json={"permission_names": ["", "docs.read"]},
+    )
+    assert response.status_code == 422

--- a/backend/tests/unit/test_roles_router.py
+++ b/backend/tests/unit/test_roles_router.py
@@ -299,7 +299,8 @@ async def test_list_roles(mock_validate, mock_role_service, client):
     response = await client.get("/api/roles", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 2
+    assert "roles" in data
+    assert len(data["roles"]) == 2
     mock_role_service.list_roles.assert_awaited_once()
 
 
@@ -318,7 +319,7 @@ async def test_create_role(mock_validate, mock_role_service, client):
     assert response.status_code == 201
     data = response.json()
     assert data["name"] == "editor"
-    mock_role_service.create_role.assert_awaited_once_with(name="editor", description="Can edit")
+    mock_role_service.create_role.assert_awaited_once_with(name="editor", description="Can edit", permission_names=None)
 
 
 @pytest.mark.anyio
@@ -334,7 +335,7 @@ async def test_create_role_default_fields(mock_validate, mock_role_service, clie
         json={"name": "viewer"},
     )
     assert response.status_code == 201
-    mock_role_service.create_role.assert_awaited_once_with(name="viewer", description="")
+    mock_role_service.create_role.assert_awaited_once_with(name="viewer", description="", permission_names=None)
 
 
 @pytest.mark.anyio

--- a/backend/tests/unit/test_tenant_router.py
+++ b/backend/tests/unit/test_tenant_router.py
@@ -1,16 +1,23 @@
-"""Unit tests for the tenant router endpoints."""
+"""Unit tests for the tenant router endpoints.
+
+Story 2.3: create_tenant and get_current_tenant now use TenantService via DI.
+list_user_tenants stays claims-based. tenant resources stay direct SQLAlchemy.
+"""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
 import pytest
+from expression import Error, Ok
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
+from app.dependencies.identity import get_tenant_service
+from app.errors.identity import NotFound
 from app.main import app
 from app.models.database import get_async_session
+from app.services.tenant import TenantService
 
 
 @pytest.fixture
@@ -24,8 +31,13 @@ def _set_env(monkeypatch):
     monkeypatch.setenv("DESCOPE_MANAGEMENT_KEY", "test-management-key")
 
 
+@pytest.fixture
+def mock_tenant_service():
+    return AsyncMock(spec=TenantService)
+
+
 @pytest.fixture(autouse=True)
-async def _test_db():
+async def _test_db(mock_tenant_service):
     """Use an in-memory async SQLite database for each test."""
     engine = create_async_engine("sqlite+aiosqlite://", echo=False)
     async with engine.begin() as conn:
@@ -38,8 +50,10 @@ async def _test_db():
             yield session
 
     app.dependency_overrides[get_async_session] = override_get_async_session
+    app.dependency_overrides[get_tenant_service] = lambda: mock_tenant_service
     yield
     app.dependency_overrides.pop(get_async_session, None)
+    app.dependency_overrides.pop(get_tenant_service, None)
     async with engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.drop_all)
     await engine.dispose()
@@ -52,32 +66,40 @@ async def client():
         yield c
 
 
+TENANT_UUID = "51c5957b-684a-453f-8ab1-8f239999c4d8"
+TENANT_UUID_2 = "dd98f159-658f-47f3-9ed2-99e85686b04c"
+
 MOCK_CLAIMS_ADMIN = {
     "sub": "user123",
-    "dct": "tenant-abc",
+    "dct": TENANT_UUID,
     "roles": ["admin"],
     "tenants": {
-        "tenant-abc": {"roles": ["admin"], "permissions": ["read", "write"]},
-        "tenant-xyz": {"roles": ["viewer"], "permissions": ["read"]},
+        TENANT_UUID: {"roles": ["admin"], "permissions": ["read", "write"]},
+        TENANT_UUID_2: {"roles": ["viewer"], "permissions": ["read"]},
     },
 }
 
 MOCK_CLAIMS_WITH_TENANT = {
     "sub": "user123",
-    "dct": "tenant-abc",
+    "dct": TENANT_UUID,
     "tenants": {
-        "tenant-abc": {"roles": ["admin"], "permissions": ["read", "write"]},
-        "tenant-xyz": {"roles": ["viewer"], "permissions": ["read"]},
+        TENANT_UUID: {"roles": ["admin"], "permissions": ["read", "write"]},
+        TENANT_UUID_2: {"roles": ["viewer"], "permissions": ["read"]},
     },
 }
 
 MOCK_CLAIMS_NO_TENANT = {
     "sub": "user123",
     "tenants": {
-        "tenant-abc": {"roles": ["admin"], "permissions": ["read"]},
-        "tenant-xyz": {"roles": ["viewer"], "permissions": ["read"]},
+        TENANT_UUID: {"roles": ["admin"], "permissions": ["read"]},
+        TENANT_UUID_2: {"roles": ["viewer"], "permissions": ["read"]},
     },
 }
+
+AUTH_HEADER = {"Authorization": "Bearer valid.token"}
+
+
+# --- Claims-based endpoints (unchanged) ---
 
 
 @pytest.mark.anyio
@@ -89,9 +111,8 @@ async def test_list_tenants_rejects_unauthenticated(client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_list_user_tenants_empty(mock_validate, client):
-    """User with no tenants claim should get an empty list."""
     mock_validate.return_value = {"sub": "user123"}
-    response = await client.get("/api/tenants", headers={"Authorization": "Bearer valid.token"})
+    response = await client.get("/api/tenants", headers=AUTH_HEADER)
     assert response.status_code == 200
     assert response.json()["tenants"] == []
 
@@ -100,123 +121,48 @@ async def test_list_user_tenants_empty(mock_validate, client):
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_list_user_tenants(mock_validate, client):
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
-    response = await client.get("/api/tenants", headers={"Authorization": "Bearer valid.token"})
+    response = await client.get("/api/tenants", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
     assert len(data["tenants"]) == 2
     ids = {t["id"] for t in data["tenants"]}
-    assert "tenant-abc" in ids
-    assert "tenant-xyz" in ids
+    assert TENANT_UUID in ids
+    assert TENANT_UUID_2 in ids
+
+
+# --- create_tenant (via TenantService) ---
 
 
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_get_current_tenant(mock_validate, client):
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
-    with patch("app.routers.tenants.get_descope_client") as mock_factory:
-        mock_client = AsyncMock()
-        mock_client.load_tenant.return_value = {"id": "tenant-abc", "name": "Acme Corp"}
-        mock_factory.return_value = mock_client
-
-        response = await client.get("/api/tenants/current", headers={"Authorization": "Bearer valid.token"})
-        assert response.status_code == 200
-        data = response.json()
-        assert data["tenant_id"] == "tenant-abc"
-        assert data["tenant"]["name"] == "Acme Corp"
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_get_current_tenant_returns_403_without_dct(mock_validate, client):
-    mock_validate.return_value = MOCK_CLAIMS_NO_TENANT
-    response = await client.get("/api/tenants/current", headers={"Authorization": "Bearer valid.token"})
-    assert response.status_code == 403
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_get_current_tenant_returns_null_on_404(mock_validate, client):
-    """When Descope API returns 404 for tenant, return tenant_id with null tenant."""
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
-    with patch("app.routers.tenants.get_descope_client") as mock_factory:
-        mock_client = AsyncMock()
-        req = httpx.Request("POST", "http://test")
-        response_404 = httpx.Response(404, request=req)
-        mock_client.load_tenant.side_effect = httpx.HTTPStatusError("Not Found", request=req, response=response_404)
-        mock_factory.return_value = mock_client
-
-        response = await client.get("/api/tenants/current", headers={"Authorization": "Bearer valid.token"})
-        assert response.status_code == 200
-        data = response.json()
-        assert data["tenant_id"] == "tenant-abc"
-        assert data["tenant"] is None
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_get_current_tenant_returns_502_on_api_error(mock_validate, client):
-    """When Descope API returns a non-404 error, return 502."""
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
-    with patch("app.routers.tenants.get_descope_client") as mock_factory:
-        mock_client = AsyncMock()
-        req = httpx.Request("POST", "http://test")
-        response_500 = httpx.Response(500, request=req)
-        mock_client.load_tenant.side_effect = httpx.HTTPStatusError("Server Error", request=req, response=response_500)
-        mock_factory.return_value = mock_client
-
-        response = await client.get("/api/tenants/current", headers={"Authorization": "Bearer valid.token"})
-        assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_get_current_tenant_returns_502_on_network_error(mock_validate, client):
-    """When a network error occurs, return 502."""
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
-    with patch("app.routers.tenants.get_descope_client") as mock_factory:
-        mock_client = AsyncMock()
-        mock_client.load_tenant.side_effect = httpx.RequestError("Connection refused")
-        mock_factory.return_value = mock_client
-
-        response = await client.get("/api/tenants/current", headers={"Authorization": "Bearer valid.token"})
-        assert response.status_code == 502
-
-
-@pytest.mark.anyio
-@patch("app.routers.tenants.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_tenant(mock_validate, mock_factory, client):
+async def test_create_tenant(mock_validate, mock_tenant_service, client):
     mock_validate.return_value = MOCK_CLAIMS_ADMIN
-    mock_client = AsyncMock()
-    mock_client.create_tenant.return_value = {"id": "new-tenant-id"}
-    mock_factory.return_value = mock_client
+    tenant_dict = {"id": "new-tenant-id", "name": "New Org", "domains": []}
+    mock_tenant_service.create_tenant.return_value = Ok(tenant_dict)
 
     response = await client.post(
         "/api/tenants",
-        headers={"Authorization": "Bearer valid.token"},
+        headers=AUTH_HEADER,
         json={"name": "New Org"},
     )
-    assert response.status_code == 200
-    assert response.json()["id"] == "new-tenant-id"
+    assert response.status_code == 201
+    mock_tenant_service.create_tenant.assert_awaited_once_with(name="New Org", domains=None)
 
 
 @pytest.mark.anyio
-@patch("app.routers.tenants.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_create_tenant_with_domains(mock_validate, mock_factory, client):
-    """Create tenant with self-provisioning domains."""
+async def test_create_tenant_with_domains(mock_validate, mock_tenant_service, client):
     mock_validate.return_value = MOCK_CLAIMS_ADMIN
-    mock_client = AsyncMock()
-    mock_client.create_tenant.return_value = {"id": "domain-tenant"}
-    mock_factory.return_value = mock_client
+    tenant_dict = {"id": "domain-tenant", "name": "Domain Corp", "domains": ["domain.com"]}
+    mock_tenant_service.create_tenant.return_value = Ok(tenant_dict)
 
     response = await client.post(
         "/api/tenants",
-        headers={"Authorization": "Bearer valid.token"},
+        headers=AUTH_HEADER,
         json={"name": "Domain Corp", "self_provisioning_domains": ["domain.com"]},
     )
-    assert response.status_code == 200
-    mock_client.create_tenant.assert_called_once_with(name="Domain Corp", self_provisioning_domains=["domain.com"])
+    assert response.status_code == 201
+    mock_tenant_service.create_tenant.assert_awaited_once_with(name="Domain Corp", domains=["domain.com"])
 
 
 @pytest.mark.anyio
@@ -228,11 +174,10 @@ async def test_create_tenant_rejects_unauthenticated(client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_create_tenant_rejects_non_admin(mock_validate, client):
-    """User without admin/owner role cannot create tenants."""
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT  # no top-level roles
     response = await client.post(
         "/api/tenants",
-        headers={"Authorization": "Bearer valid.token"},
+        headers=AUTH_HEADER,
         json={"name": "Sneaky Org"},
     )
     assert response.status_code == 403
@@ -241,14 +186,51 @@ async def test_create_tenant_rejects_non_admin(mock_validate, client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_create_tenant_rejects_empty_name(mock_validate, client):
-    """Empty tenant name should be rejected by validation."""
     mock_validate.return_value = MOCK_CLAIMS_ADMIN
     response = await client.post(
         "/api/tenants",
-        headers={"Authorization": "Bearer valid.token"},
+        headers=AUTH_HEADER,
         json={"name": ""},
     )
     assert response.status_code == 422
+
+
+# --- get_current_tenant (via TenantService) ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_get_current_tenant(mock_validate, mock_tenant_service, client):
+    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
+    tenant_dict = {"id": TENANT_UUID, "name": "Acme Corp", "domains": []}
+    mock_tenant_service.get_tenant.return_value = Ok(tenant_dict)
+
+    response = await client.get("/api/tenants/current", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Acme Corp"
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_get_current_tenant_returns_403_without_dct(mock_validate, client):
+    mock_validate.return_value = MOCK_CLAIMS_NO_TENANT
+    response = await client.get("/api/tenants/current", headers=AUTH_HEADER)
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_get_current_tenant_not_found(mock_validate, mock_tenant_service, client):
+    """Tenant not found in canonical DB → 404."""
+    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
+    mock_tenant_service.get_tenant.return_value = Error(NotFound(message="Tenant 'tenant-abc' not found"))
+
+    response = await client.get("/api/tenants/current", headers=AUTH_HEADER)
+    assert response.status_code == 404
+
+
+# --- Tenant resources (direct SQLAlchemy, unchanged) ---
 
 
 @pytest.mark.anyio
@@ -256,8 +238,8 @@ async def test_create_tenant_rejects_empty_name(mock_validate, client):
 async def test_list_tenant_resources_empty(mock_validate, client):
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
     response = await client.get(
-        "/api/tenants/tenant-abc/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources",
+        headers=AUTH_HEADER,
     )
     assert response.status_code == 200
     assert response.json()["resources"] == []
@@ -268,21 +250,19 @@ async def test_list_tenant_resources_empty(mock_validate, client):
 async def test_create_and_list_tenant_resources(mock_validate, client):
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
 
-    # Create a resource
     create_resp = await client.post(
-        "/api/tenants/tenant-abc/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources",
+        headers=AUTH_HEADER,
         json={"name": "Test Resource", "description": "A test"},
     )
     assert create_resp.status_code == 200
     resource = create_resp.json()
     assert resource["name"] == "Test Resource"
-    assert resource["tenant_id"] == "tenant-abc"
+    assert resource["tenant_id"] == TENANT_UUID
 
-    # List resources
     list_resp = await client.get(
-        "/api/tenants/tenant-abc/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources",
+        headers=AUTH_HEADER,
     )
     assert list_resp.status_code == 200
     resources = list_resp.json()["resources"]
@@ -293,11 +273,10 @@ async def test_create_and_list_tenant_resources(mock_validate, client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_cannot_access_non_member_tenant_resources(mock_validate, client):
-    """User who is not a member of a tenant cannot access its resources."""
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT  # member of tenant-abc and tenant-xyz
+    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
     response = await client.get(
-        "/api/tenants/tenant-other/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        "/api/tenants/8a70c45c-dc5e-48ed-a8ea-34b0b35058a4/resources",
+        headers=AUTH_HEADER,
     )
     assert response.status_code == 403
 
@@ -305,11 +284,10 @@ async def test_cannot_access_non_member_tenant_resources(mock_validate, client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_cannot_create_resource_in_non_member_tenant(mock_validate, client):
-    """User who is not a member of a tenant cannot create resources in it."""
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT  # member of tenant-abc and tenant-xyz
+    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
     response = await client.post(
-        "/api/tenants/tenant-other/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        "/api/tenants/8a70c45c-dc5e-48ed-a8ea-34b0b35058a4/resources",
+        headers=AUTH_HEADER,
         json={"name": "Sneaky Resource"},
     )
     assert response.status_code == 403
@@ -318,11 +296,10 @@ async def test_cannot_create_resource_in_non_member_tenant(mock_validate, client
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_can_access_member_tenant_resources_without_dct(mock_validate, client):
-    """User can access resources for a tenant they are a member of, even if dct points elsewhere."""
-    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT  # dct=tenant-abc, member of tenant-xyz too
+    mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
     response = await client.get(
-        "/api/tenants/tenant-xyz/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID_2}/resources",
+        headers=AUTH_HEADER,
     )
     assert response.status_code == 200
 
@@ -330,11 +307,10 @@ async def test_can_access_member_tenant_resources_without_dct(mock_validate, cli
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_create_resource_rejects_empty_name(mock_validate, client):
-    """Empty resource name should be rejected by validation."""
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
     response = await client.post(
-        "/api/tenants/tenant-abc/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources",
+        headers=AUTH_HEADER,
         json={"name": ""},
     )
     assert response.status_code == 422
@@ -343,11 +319,10 @@ async def test_create_resource_rejects_empty_name(mock_validate, client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_list_resources_with_pagination(mock_validate, client):
-    """Pagination params are accepted."""
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
     response = await client.get(
-        "/api/tenants/tenant-abc/resources?limit=10&offset=0",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources?limit=10&offset=0",
+        headers=AUTH_HEADER,
     )
     assert response.status_code == 200
 
@@ -355,7 +330,6 @@ async def test_list_resources_with_pagination(mock_validate, client):
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_create_resource_integrity_error_returns_409(mock_validate, client):
-    """IntegrityError (e.g. duplicate name) returns 409 Conflict."""
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
 
     async def _integrity_error_session():
@@ -371,8 +345,8 @@ async def test_create_resource_integrity_error_returns_409(mock_validate, client
     app.dependency_overrides[get_async_session] = _integrity_error_session
 
     response = await client.post(
-        "/api/tenants/tenant-abc/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources",
+        headers=AUTH_HEADER,
         json={"name": "Duplicate Resource"},
     )
     assert response.status_code == 409
@@ -382,7 +356,6 @@ async def test_create_resource_integrity_error_returns_409(mock_validate, client
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_create_resource_db_error_returns_500(mock_validate, client):
-    """Generic DB error returns 500."""
     mock_validate.return_value = MOCK_CLAIMS_WITH_TENANT
 
     async def _db_error_session():
@@ -396,8 +369,8 @@ async def test_create_resource_db_error_returns_500(mock_validate, client):
     app.dependency_overrides[get_async_session] = _db_error_session
 
     response = await client.post(
-        "/api/tenants/tenant-abc/resources",
-        headers={"Authorization": "Bearer valid.token"},
+        f"/api/tenants/{TENANT_UUID}/resources",
+        headers=AUTH_HEADER,
         json={"name": "Some Resource"},
     )
     assert response.status_code == 500

--- a/backend/tests/unit/test_tenant_router.py
+++ b/backend/tests/unit/test_tenant_router.py
@@ -145,7 +145,7 @@ async def test_create_tenant(mock_validate, mock_tenant_service, client):
         headers=AUTH_HEADER,
         json={"name": "New Org"},
     )
-    assert response.status_code == 201
+    assert response.status_code == 200
     mock_tenant_service.create_tenant.assert_awaited_once_with(name="New Org", domains=None)
 
 
@@ -161,7 +161,7 @@ async def test_create_tenant_with_domains(mock_validate, mock_tenant_service, cl
         headers=AUTH_HEADER,
         json={"name": "Domain Corp", "self_provisioning_domains": ["domain.com"]},
     )
-    assert response.status_code == 201
+    assert response.status_code == 200
     mock_tenant_service.create_tenant.assert_awaited_once_with(name="Domain Corp", domains=["domain.com"])
 
 
@@ -208,7 +208,8 @@ async def test_get_current_tenant(mock_validate, mock_tenant_service, client):
     response = await client.get("/api/tenants/current", headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
-    assert data["name"] == "Acme Corp"
+    assert data["tenant_id"] == TENANT_UUID
+    assert data["tenant"]["name"] == "Acme Corp"
 
 
 @pytest.mark.anyio

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -286,6 +286,47 @@ class TestDeactivateUser:
 
 
 @pytest.mark.anyio
+class TestActivateUser:
+    """Story 2.3: activate_user sets status=active and syncs (mirrors deactivate)."""
+
+    async def test_activate_user_success(self):
+        service, repo, adapter = _build_service()
+        user = _make_user(status=UserStatus.inactive)
+        repo.get.return_value = user
+        repo.update.return_value = user
+        adapter.sync_user.return_value = Ok(None)
+
+        result = await service.activate_user(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_ok()
+        assert user.status == UserStatus.active
+        repo.update.assert_awaited_once()
+        repo.commit.assert_awaited_once()
+
+    async def test_activate_user_not_found(self):
+        service, repo, _adapter = _build_service()
+        repo.get.return_value = None
+
+        result = await service.activate_user(tenant_id=TENANT_ID, user_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_activate_sync_failure_still_returns_ok(self):
+        service, repo, adapter = _build_service()
+        user = _make_user(status=UserStatus.inactive)
+        repo.get.return_value = user
+        repo.update.return_value = user
+        adapter.sync_user.return_value = Error(SyncError(message="timeout", operation="sync_user"))
+
+        with patch("app.services.user.logger"):
+            result = await service.activate_user(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_ok()
+        repo.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
 class TestSearchUsers:
     """AC-2.1.3: search_users delegates to repository with tenant scoping."""
 

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -401,11 +401,12 @@ class TestRemoveUserFromTenant:
     """Story 2.3: remove_user_from_tenant deletes all role assignments for user+tenant."""
 
     async def test_remove_user_from_tenant_success(self):
-        service, repo, _adapter, assign_repo = _build_service()
+        service, repo, adapter, assign_repo = _build_service()
         user = _make_user()
         repo.get.return_value = user
         repo.exists_in_tenant.return_value = True
         assign_repo.delete_by_user_tenant.return_value = 2
+        adapter.sync_user.return_value = Ok(None)
 
         result = await service.remove_user_from_tenant(tenant_id=TENANT_ID, user_id=user.id)
 
@@ -413,6 +414,7 @@ class TestRemoveUserFromTenant:
         assert result.ok["status"] == "removed"
         assign_repo.delete_by_user_tenant.assert_awaited_once_with(user.id, TENANT_ID)
         assign_repo.commit.assert_awaited_once()
+        adapter.sync_user.assert_awaited_once()
 
     async def test_remove_user_not_found(self):
         service, repo, _adapter, _assign_repo = _build_service()

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -14,8 +14,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from expression import Error, Ok
 
-from app.errors.identity import Conflict, NotFound
+from app.errors.identity import Conflict, Forbidden, NotFound
 from app.models.identity.user import User, UserStatus
+from app.repositories.assignment import UserTenantRoleRepository
 from app.repositories.user import RepositoryConflictError, UserRepository
 from app.services.adapters.base import IdentityProviderAdapter, SyncError
 from app.services.user import UserService
@@ -40,14 +41,19 @@ def _make_user(**overrides) -> User:
 def _build_service(
     repo: AsyncMock | None = None,
     adapter: AsyncMock | None = None,
-) -> tuple[UserService, AsyncMock, AsyncMock]:
+    assignment_repo: AsyncMock | None = None,
+) -> tuple[UserService, AsyncMock, AsyncMock, AsyncMock]:
     """Build a UserService with mocked repository and adapter."""
     if repo is None:
         repo = AsyncMock(spec=UserRepository)
     if adapter is None:
         adapter = AsyncMock(spec=IdentityProviderAdapter)
-    service = UserService(repository=repo, adapter=adapter)
-    return service, repo, adapter
+    if assignment_repo is None:
+        assignment_repo = AsyncMock(spec=UserTenantRoleRepository)
+    # Default: user exists in tenant
+    repo.exists_in_tenant.return_value = True
+    service = UserService(repository=repo, adapter=adapter, assignment_repository=assignment_repo)
+    return service, repo, adapter, assignment_repo
 
 
 @pytest.mark.anyio
@@ -55,7 +61,7 @@ class TestCreateUser:
     """AC-2.1.2: create_user persists via repo, commits, syncs to adapter, returns Ok(dict)."""
 
     async def test_create_user_success(self):
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         repo.get_by_email.return_value = None
         user = _make_user()
         repo.create.return_value = user
@@ -76,7 +82,7 @@ class TestCreateUser:
 
     async def test_create_user_commit_before_sync(self):
         """Commit must happen before sync to prevent ghost state in IdP."""
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         repo.get_by_email.return_value = None
         user = _make_user()
         repo.create.return_value = user
@@ -95,7 +101,7 @@ class TestCreateUser:
         assert call_order == ["commit", "sync"]
 
     async def test_create_user_duplicate_email_returns_conflict(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         repo.get_by_email.return_value = _make_user()
 
         result = await service.create_user(
@@ -110,7 +116,7 @@ class TestCreateUser:
 
     async def test_create_user_integrity_error_returns_conflict(self):
         """TOCTOU race: get_by_email returns None but flush raises IntegrityError."""
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         repo.get_by_email.return_value = None
         repo.create.side_effect = RepositoryConflictError("duplicate key")
 
@@ -125,7 +131,7 @@ class TestCreateUser:
 
     async def test_create_user_sync_failure_still_returns_ok(self):
         """AC-2.1.2: sync failure → log warning, still return Ok(user)."""
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         repo.get_by_email.return_value = None
         user = _make_user()
         repo.create.return_value = user
@@ -146,7 +152,7 @@ class TestCreateUser:
 @pytest.mark.anyio
 class TestGetUser:
     async def test_get_user_found(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         user = _make_user()
         repo.get.return_value = user
 
@@ -156,7 +162,7 @@ class TestGetUser:
         assert result.ok["email"] == user.email
 
     async def test_get_user_not_found(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         repo.get.return_value = None
 
         result = await service.get_user(tenant_id=TENANT_ID, user_id=uuid.uuid4())
@@ -168,7 +174,7 @@ class TestGetUser:
 @pytest.mark.anyio
 class TestUpdateUser:
     async def test_update_user_success(self):
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         user = _make_user()
         repo.get.return_value = user
         repo.get_by_email.return_value = None
@@ -187,7 +193,7 @@ class TestUpdateUser:
         repo.commit.assert_awaited_once()
 
     async def test_update_user_not_found(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         repo.get.return_value = None
 
         result = await service.update_user(tenant_id=TENANT_ID, user_id=uuid.uuid4(), email="x@y.com")
@@ -196,7 +202,7 @@ class TestUpdateUser:
         assert isinstance(result.error, NotFound)
 
     async def test_update_user_email_conflict_different_user(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         existing = _make_user(id=uuid.uuid4())
         target = _make_user(id=uuid.uuid4())
         repo.get.return_value = target
@@ -214,7 +220,7 @@ class TestUpdateUser:
 
     async def test_update_user_same_email_no_conflict(self):
         """Updating to the same email the user already has should not conflict."""
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         user = _make_user()
         repo.get.return_value = user
         repo.get_by_email.return_value = user  # same user
@@ -227,7 +233,7 @@ class TestUpdateUser:
 
     async def test_update_user_integrity_error_returns_conflict(self):
         """TOCTOU race: email check passes but flush raises IntegrityError."""
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         user = _make_user()
         repo.get.return_value = user
         repo.get_by_email.return_value = None
@@ -249,7 +255,7 @@ class TestDeactivateUser:
     """AC-2.1.4: deactivate_user sets status=inactive and syncs."""
 
     async def test_deactivate_user_success(self):
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         user = _make_user(status=UserStatus.active)
         repo.get.return_value = user
         repo.update.return_value = user
@@ -263,7 +269,7 @@ class TestDeactivateUser:
         repo.commit.assert_awaited_once()
 
     async def test_deactivate_user_not_found(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         repo.get.return_value = None
 
         result = await service.deactivate_user(tenant_id=TENANT_ID, user_id=uuid.uuid4())
@@ -272,7 +278,7 @@ class TestDeactivateUser:
         assert isinstance(result.error, NotFound)
 
     async def test_deactivate_sync_failure_still_returns_ok(self):
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         user = _make_user()
         repo.get.return_value = user
         repo.update.return_value = user
@@ -290,7 +296,7 @@ class TestActivateUser:
     """Story 2.3: activate_user sets status=active and syncs (mirrors deactivate)."""
 
     async def test_activate_user_success(self):
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         user = _make_user(status=UserStatus.inactive)
         repo.get.return_value = user
         repo.update.return_value = user
@@ -304,7 +310,7 @@ class TestActivateUser:
         repo.commit.assert_awaited_once()
 
     async def test_activate_user_not_found(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         repo.get.return_value = None
 
         result = await service.activate_user(tenant_id=TENANT_ID, user_id=uuid.uuid4())
@@ -313,7 +319,7 @@ class TestActivateUser:
         assert isinstance(result.error, NotFound)
 
     async def test_activate_sync_failure_still_returns_ok(self):
-        service, repo, adapter = _build_service()
+        service, repo, adapter, _assign_repo = _build_service()
         user = _make_user(status=UserStatus.inactive)
         repo.get.return_value = user
         repo.update.return_value = user
@@ -331,7 +337,7 @@ class TestSearchUsers:
     """AC-2.1.3: search_users delegates to repository with tenant scoping."""
 
     async def test_search_returns_list_of_dicts(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         users = [_make_user(), _make_user(email="bob@example.com", user_name="bob")]
         repo.search.return_value = users
         tenant_id = uuid.uuid4()
@@ -343,7 +349,7 @@ class TestSearchUsers:
         repo.search.assert_awaited_once_with(tenant_id=tenant_id, name=None)
 
     async def test_search_passes_query_as_name_filter(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         repo.search.return_value = []
         tenant_id = uuid.uuid4()
 
@@ -352,10 +358,78 @@ class TestSearchUsers:
         repo.search.assert_awaited_once_with(tenant_id=tenant_id, name="alice")
 
     async def test_search_empty_query_passes_none(self):
-        service, repo, _adapter = _build_service()
+        service, repo, _adapter, _assign_repo = _build_service()
         repo.search.return_value = []
         tenant_id = uuid.uuid4()
 
         await service.search_users(tenant_id=tenant_id, query="")
 
         repo.search.assert_awaited_once_with(tenant_id=tenant_id, name=None)
+
+
+@pytest.mark.anyio
+class TestTenantMembershipVerification:
+    """Story 2.3: deactivate/activate verify user belongs to caller's tenant."""
+
+    async def test_deactivate_user_cross_tenant_rejected(self):
+        service, repo, _adapter, _assign_repo = _build_service()
+        user = _make_user()
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = False
+
+        result = await service.deactivate_user(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_error()
+        assert isinstance(result.error, Forbidden)
+        assert "does not belong" in result.error.message
+
+    async def test_activate_user_cross_tenant_rejected(self):
+        service, repo, _adapter, _assign_repo = _build_service()
+        user = _make_user(status=UserStatus.inactive)
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = False
+
+        result = await service.activate_user(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_error()
+        assert isinstance(result.error, Forbidden)
+        assert "does not belong" in result.error.message
+
+
+@pytest.mark.anyio
+class TestRemoveUserFromTenant:
+    """Story 2.3: remove_user_from_tenant deletes all role assignments for user+tenant."""
+
+    async def test_remove_user_from_tenant_success(self):
+        service, repo, _adapter, assign_repo = _build_service()
+        user = _make_user()
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = True
+        assign_repo.delete_by_user_tenant.return_value = 2
+
+        result = await service.remove_user_from_tenant(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_ok()
+        assert result.ok["status"] == "removed"
+        assign_repo.delete_by_user_tenant.assert_awaited_once_with(user.id, TENANT_ID)
+        assign_repo.commit.assert_awaited_once()
+
+    async def test_remove_user_not_found(self):
+        service, repo, _adapter, _assign_repo = _build_service()
+        repo.get.return_value = None
+
+        result = await service.remove_user_from_tenant(tenant_id=TENANT_ID, user_id=uuid.uuid4())
+
+        assert result.is_error()
+        assert isinstance(result.error, NotFound)
+
+    async def test_remove_user_cross_tenant_rejected(self):
+        service, repo, _adapter, _assign_repo = _build_service()
+        user = _make_user()
+        repo.get.return_value = user
+        repo.exists_in_tenant.return_value = False
+
+        result = await service.remove_user_from_tenant(tenant_id=TENANT_ID, user_id=user.id)
+
+        assert result.is_error()
+        assert isinstance(result.error, Forbidden)

--- a/backend/tests/unit/test_users_router.py
+++ b/backend/tests/unit/test_users_router.py
@@ -1,11 +1,20 @@
-"""Unit tests for the users (member management) router."""
+"""Unit tests for the users (member management) router.
 
+Story 2.3: tests rewired endpoints that use UserService via DI
+instead of get_descope_client().
+"""
+
+import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from expression import Error, Ok
 from httpx import ASGITransport, AsyncClient
 
+from app.dependencies.identity import get_user_service
+from app.errors.identity import Conflict, NotFound
 from app.main import app
+from app.services.user import UserService
 
 
 @pytest.fixture
@@ -20,27 +29,63 @@ def _set_env(monkeypatch):
 
 
 @pytest.fixture
+def mock_user_service():
+    return AsyncMock(spec=UserService)
+
+
+@pytest.fixture(autouse=True)
+def _override_user_service(mock_user_service):
+    app.dependency_overrides[get_user_service] = lambda: mock_user_service
+    yield
+    app.dependency_overrides.pop(get_user_service, None)
+
+
+@pytest.fixture
 async def client():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
 
 
+TENANT_ID = "51c5957b-684a-453f-8ab1-8f239999c4d8"
+
 ADMIN_CLAIMS = {
     "sub": "user123",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {"roles": ["admin"], "permissions": ["members.invite", "members.remove"]},
+        TENANT_ID: {"roles": ["admin"], "permissions": ["members.invite", "members.remove"]},
     },
 }
 
 VIEWER_CLAIMS = {
     "sub": "user456",
-    "dct": "tenant-abc",
+    "dct": TENANT_ID,
     "tenants": {
-        "tenant-abc": {"roles": ["viewer"], "permissions": ["projects.read"]},
+        TENANT_ID: {"roles": ["viewer"], "permissions": ["projects.read"]},
     },
 }
+
+OWNER_CLAIMS = {
+    "sub": "owner1",
+    "dct": TENANT_ID,
+    "tenants": {
+        TENANT_ID: {"roles": ["owner"], "permissions": ["members.invite", "members.remove"]},
+    },
+}
+
+AUTH_HEADER = {"Authorization": "Bearer valid.token"}
+
+SAMPLE_USER = {
+    "id": str(uuid.uuid4()),
+    "email": "alice@example.com",
+    "user_name": "alice",
+    "given_name": "Alice",
+    "family_name": "Smith",
+    "status": "active",
+}
+
+
+# --- Auth enforcement ---
 
 
 @pytest.mark.anyio
@@ -53,45 +98,8 @@ async def test_list_members_rejects_unauthenticated(client):
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
 async def test_list_members_rejected_for_viewer(mock_validate, client):
     mock_validate.return_value = VIEWER_CLAIMS
-    response = await client.get("/api/members", headers={"Authorization": "Bearer valid.token"})
+    response = await client.get("/api/members", headers=AUTH_HEADER)
     assert response.status_code == 403
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_list_members(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.search_tenant_users.return_value = [
-        {"userId": "u1", "name": "Alice", "email": "alice@test.com", "status": "enabled"},
-        {"userId": "u2", "name": "Bob", "email": "bob@test.com", "status": "disabled"},
-    ]
-    mock_factory.return_value = mock_client
-
-    response = await client.get("/api/members", headers={"Authorization": "Bearer valid.token"})
-    assert response.status_code == 200
-    assert len(response.json()["members"]) == 2
-    mock_client.search_tenant_users.assert_called_once_with("tenant-abc")
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_invite_member(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.invite_user.return_value = {"userId": "new-user", "email": "new@test.com"}
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"email": "new@test.com", "role_names": ["member"]},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "invited"
-    mock_client.invite_user.assert_called_once_with("new@test.com", "tenant-abc", ["member"])
 
 
 @pytest.mark.anyio
@@ -100,190 +108,10 @@ async def test_invite_member_rejected_for_viewer(mock_validate, client):
     mock_validate.return_value = VIEWER_CLAIMS
     response = await client.post(
         "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
+        headers=AUTH_HEADER,
         json={"email": "new@test.com"},
     )
     assert response.status_code == 403
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_deactivate_member(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.load_user.return_value = {
-        "userId": "user1",
-        "loginIds": ["user1@example.com"],
-        "userTenants": [{"tenantId": "tenant-abc"}],
-    }
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/members/user1/deactivate",
-        headers={"Authorization": "Bearer valid.token"},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "deactivated"
-    mock_client.load_user.assert_called_once_with("user1")
-    mock_client.update_user_status.assert_called_once_with("user1@example.com", "disabled")
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_activate_member(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.load_user.return_value = {
-        "userId": "user1",
-        "loginIds": ["user1@example.com"],
-        "userTenants": [{"tenantId": "tenant-abc"}],
-    }
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/members/user1/activate",
-        headers={"Authorization": "Bearer valid.token"},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "activated"
-    mock_client.load_user.assert_called_once_with("user1")
-    mock_client.update_user_status.assert_called_once_with("user1@example.com", "enabled")
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_remove_member(mock_validate, mock_factory, client):
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.load_user.return_value = {
-        "userId": "user1",
-        "loginIds": ["user1@example.com"],
-        "userTenants": [{"tenantId": "tenant-abc"}],
-    }
-    mock_factory.return_value = mock_client
-
-    response = await client.delete(
-        "/api/members/user1",
-        headers={"Authorization": "Bearer valid.token"},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "removed"
-    mock_client.load_user.assert_called_once_with("user1")
-    mock_client.remove_user_from_tenant.assert_called_once_with("user1@example.com", "tenant-abc")
-
-
-OWNER_CLAIMS = {
-    "sub": "owner1",
-    "dct": "tenant-abc",
-    "tenants": {
-        "tenant-abc": {"roles": ["owner"], "permissions": ["members.invite", "members.remove"]},
-    },
-}
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_deactivate_member_cross_tenant_rejected(mock_validate, mock_factory, client):
-    """M1: Admin cannot deactivate a user who belongs to a different tenant."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.load_user.return_value = {"userId": "user1", "userTenants": [{"tenantId": "other-tenant"}]}
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/members/user1/deactivate",
-        headers={"Authorization": "Bearer valid.token"},
-    )
-    assert response.status_code == 403
-    assert "does not belong to your tenant" in response.json()["detail"]
-    mock_client.update_user_status.assert_not_called()
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_remove_member_cross_tenant_rejected(mock_validate, mock_factory, client):
-    """M1: Admin cannot remove a user from a different tenant."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.load_user.return_value = {"userId": "user1", "userTenants": [{"tenantId": "other-tenant"}]}
-    mock_factory.return_value = mock_client
-
-    response = await client.delete(
-        "/api/members/user1",
-        headers={"Authorization": "Bearer valid.token"},
-    )
-    assert response.status_code == 403
-    mock_client.remove_user_from_tenant.assert_not_called()
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_activate_member_cross_tenant_rejected(mock_validate, mock_factory, client):
-    """M1: Admin cannot activate a user who belongs to a different tenant."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.load_user.return_value = {"userId": "user1", "userTenants": [{"tenantId": "other-tenant"}]}
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/members/user1/activate",
-        headers={"Authorization": "Bearer valid.token"},
-    )
-    assert response.status_code == 403
-    assert "does not belong to your tenant" in response.json()["detail"]
-    mock_client.update_user_status.assert_not_called()
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_invite_member_invalid_email_rejected(mock_validate, client):
-    """M3: Invalid email strings are rejected by pydantic EmailStr."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.post(
-        "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"email": "not-an-email", "role_names": ["member"]},
-    )
-    assert response.status_code == 422
-
-
-@pytest.mark.anyio
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_admin_cannot_assign_owner_role(mock_validate, client):
-    """M4: Admin cannot invite a user with the owner role."""
-    mock_validate.return_value = ADMIN_CLAIMS
-    response = await client.post(
-        "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"email": "new@test.com", "role_names": ["owner"]},
-    )
-    assert response.status_code == 403
-    assert "Only owners can assign the owner role" in response.json()["detail"]
-
-
-@pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
-@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_owner_can_assign_owner_role(mock_validate, mock_factory, client):
-    """M4: Owner CAN invite a user with the owner role."""
-    mock_validate.return_value = OWNER_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.invite_user.return_value = {"userId": "new", "email": "new@test.com"}
-    mock_factory.return_value = mock_client
-
-    response = await client.post(
-        "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"email": "new@test.com", "role_names": ["owner"]},
-    )
-    assert response.status_code == 200
-    mock_client.invite_user.assert_called_once_with("new@test.com", "tenant-abc", ["owner"])
 
 
 @pytest.mark.anyio
@@ -292,26 +120,176 @@ async def test_invite_without_tenant_rejected(mock_validate, client):
     mock_validate.return_value = {"sub": "user789", "tenants": {}}
     response = await client.post(
         "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
+        headers=AUTH_HEADER,
         json={"email": "new@test.com"},
     )
     assert response.status_code == 403
 
 
+# --- Happy path ---
+
+
 @pytest.mark.anyio
-@patch("app.routers.users.get_descope_client")
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_invite_with_default_role(mock_validate, mock_factory, client):
-    """Invite without specifying role should default to 'member'."""
+async def test_list_members(mock_validate, mock_user_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
-    mock_client = AsyncMock()
-    mock_client.invite_user.return_value = {"userId": "new", "email": "default@test.com"}
-    mock_factory.return_value = mock_client
+    users = [SAMPLE_USER, {**SAMPLE_USER, "email": "bob@example.com"}]
+    mock_user_service.search_users.return_value = Ok(users)
+
+    response = await client.get("/api/members", headers=AUTH_HEADER)
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+    mock_user_service.search_users.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_invite_member(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_user_service.create_user.return_value = Ok(SAMPLE_USER)
 
     response = await client.post(
         "/api/members/invite",
-        headers={"Authorization": "Bearer valid.token"},
-        json={"email": "default@test.com"},
+        headers=AUTH_HEADER,
+        json={"email": "new@test.com", "role_names": ["member"]},
+    )
+    assert response.status_code == 201
+    mock_user_service.create_user.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_member(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.deactivate_user.return_value = Ok({**SAMPLE_USER, "status": "inactive"})
+
+    response = await client.post(
+        f"/api/members/{user_id}/deactivate",
+        headers=AUTH_HEADER,
     )
     assert response.status_code == 200
-    mock_client.invite_user.assert_called_once_with("default@test.com", "tenant-abc", ["member"])
+    mock_user_service.deactivate_user.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_activate_member(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.activate_user.return_value = Ok(SAMPLE_USER)
+
+    response = await client.post(
+        f"/api/members/{user_id}/activate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 200
+    mock_user_service.activate_user.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_remove_member(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.deactivate_user.return_value = Ok({**SAMPLE_USER, "status": "inactive"})
+
+    response = await client.delete(
+        f"/api/members/{user_id}",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 200
+    mock_user_service.deactivate_user.assert_awaited_once()
+
+
+# --- Owner role escalation guard ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_admin_cannot_assign_owner_role(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/members/invite",
+        headers=AUTH_HEADER,
+        json={"email": "new@test.com", "role_names": ["owner"]},
+    )
+    assert response.status_code == 403
+    assert "Only owners can assign the owner role" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_owner_can_assign_owner_role(mock_validate, mock_user_service, client):
+    mock_validate.return_value = OWNER_CLAIMS
+    mock_user_service.create_user.return_value = Ok(SAMPLE_USER)
+
+    response = await client.post(
+        "/api/members/invite",
+        headers=AUTH_HEADER,
+        json={"email": "new@test.com", "role_names": ["owner"]},
+    )
+    assert response.status_code == 201
+
+
+# --- Error handling (service returns Error) ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_invite_member_conflict(mock_validate, mock_user_service, client):
+    """Duplicate email → 409 via result_to_response."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    mock_user_service.create_user.return_value = Error(
+        Conflict(message="User with email 'dup@test.com' already exists")
+    )
+
+    response = await client.post(
+        "/api/members/invite",
+        headers=AUTH_HEADER,
+        json={"email": "dup@test.com"},
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_member_not_found(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.deactivate_user.return_value = Error(NotFound(message=f"User '{user_id}' not found"))
+
+    response = await client.post(
+        f"/api/members/{user_id}/deactivate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_activate_member_not_found(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.activate_user.return_value = Error(NotFound(message=f"User '{user_id}' not found"))
+
+    response = await client.post(
+        f"/api/members/{user_id}/activate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 404
+
+
+# --- Input validation ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_invite_member_invalid_email_rejected(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/members/invite",
+        headers=AUTH_HEADER,
+        json={"email": "not-an-email", "role_names": ["member"]},
+    )
+    assert response.status_code == 422

--- a/backend/tests/unit/test_users_router.py
+++ b/backend/tests/unit/test_users_router.py
@@ -11,9 +11,10 @@ import pytest
 from expression import Error, Ok
 from httpx import ASGITransport, AsyncClient
 
-from app.dependencies.identity import get_user_service
-from app.errors.identity import Conflict, NotFound
+from app.dependencies.identity import get_role_service, get_user_service
+from app.errors.identity import Conflict, Forbidden, NotFound
 from app.main import app
+from app.services.role import RoleService
 from app.services.user import UserService
 
 
@@ -33,11 +34,18 @@ def mock_user_service():
     return AsyncMock(spec=UserService)
 
 
+@pytest.fixture
+def mock_role_service():
+    return AsyncMock(spec=RoleService)
+
+
 @pytest.fixture(autouse=True)
-def _override_user_service(mock_user_service):
+def _override_services(mock_user_service, mock_role_service):
     app.dependency_overrides[get_user_service] = lambda: mock_user_service
+    app.dependency_overrides[get_role_service] = lambda: mock_role_service
     yield
     app.dependency_overrides.pop(get_user_service, None)
+    app.dependency_overrides.pop(get_role_service, None)
 
 
 @pytest.fixture
@@ -138,23 +146,33 @@ async def test_list_members(mock_validate, mock_user_service, client):
 
     response = await client.get("/api/members", headers=AUTH_HEADER)
     assert response.status_code == 200
-    assert len(response.json()) == 2
+    data = response.json()
+    assert "members" in data
+    assert len(data["members"]) == 2
     mock_user_service.search_users.assert_awaited_once()
 
 
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_invite_member(mock_validate, mock_user_service, client):
+async def test_invite_member(mock_validate, mock_user_service, mock_role_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
     mock_user_service.create_user.return_value = Ok(SAMPLE_USER)
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "member"}])
+    mock_role_service.assign_role_to_user.return_value = Ok({})
 
     response = await client.post(
         "/api/members/invite",
         headers=AUTH_HEADER,
         json={"email": "new@test.com", "role_names": ["member"]},
     )
-    assert response.status_code == 201
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "invited"
+    assert data["email"] == "new@test.com"
+    assert "user" in data
     mock_user_service.create_user.assert_awaited_once()
+    mock_role_service.assign_role_to_user.assert_awaited_once()
 
 
 @pytest.mark.anyio
@@ -169,6 +187,9 @@ async def test_deactivate_member(mock_validate, mock_user_service, client):
         headers=AUTH_HEADER,
     )
     assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "deactivated"
+    assert data["user_id"] == user_id
     mock_user_service.deactivate_user.assert_awaited_once()
 
 
@@ -184,6 +205,9 @@ async def test_activate_member(mock_validate, mock_user_service, client):
         headers=AUTH_HEADER,
     )
     assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "activated"
+    assert data["user_id"] == user_id
     mock_user_service.activate_user.assert_awaited_once()
 
 
@@ -192,14 +216,17 @@ async def test_activate_member(mock_validate, mock_user_service, client):
 async def test_remove_member(mock_validate, mock_user_service, client):
     mock_validate.return_value = ADMIN_CLAIMS
     user_id = str(uuid.uuid4())
-    mock_user_service.deactivate_user.return_value = Ok({**SAMPLE_USER, "status": "inactive"})
+    mock_user_service.remove_user_from_tenant.return_value = Ok({"status": "removed", "user_id": user_id})
 
     response = await client.delete(
         f"/api/members/{user_id}",
         headers=AUTH_HEADER,
     )
     assert response.status_code == 200
-    mock_user_service.deactivate_user.assert_awaited_once()
+    data = response.json()
+    assert data["status"] == "removed"
+    assert data["user_id"] == user_id
+    mock_user_service.remove_user_from_tenant.assert_awaited_once()
 
 
 # --- Owner role escalation guard ---
@@ -220,16 +247,67 @@ async def test_admin_cannot_assign_owner_role(mock_validate, client):
 
 @pytest.mark.anyio
 @patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
-async def test_owner_can_assign_owner_role(mock_validate, mock_user_service, client):
+async def test_owner_can_assign_owner_role(mock_validate, mock_user_service, mock_role_service, client):
     mock_validate.return_value = OWNER_CLAIMS
     mock_user_service.create_user.return_value = Ok(SAMPLE_USER)
+    role_id = str(uuid.uuid4())
+    mock_role_service.list_roles.return_value = Ok([{"id": role_id, "name": "owner"}])
+    mock_role_service.assign_role_to_user.return_value = Ok({})
 
     response = await client.post(
         "/api/members/invite",
         headers=AUTH_HEADER,
         json={"email": "new@test.com", "role_names": ["owner"]},
     )
-    assert response.status_code == 201
+    assert response.status_code == 200
+
+
+# --- Cross-tenant verification ---
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_member_cross_tenant_rejected(mock_validate, mock_user_service, client):
+    """Service returns Forbidden if user is not in caller's tenant."""
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.deactivate_user.return_value = Error(Forbidden(message="User does not belong to your tenant"))
+
+    response = await client.post(
+        f"/api/members/{user_id}/deactivate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_activate_member_cross_tenant_rejected(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.activate_user.return_value = Error(Forbidden(message="User does not belong to your tenant"))
+
+    response = await client.post(
+        f"/api/members/{user_id}/activate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_remove_member_cross_tenant_rejected(mock_validate, mock_user_service, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    user_id = str(uuid.uuid4())
+    mock_user_service.remove_user_from_tenant.return_value = Error(
+        Forbidden(message="User does not belong to your tenant")
+    )
+
+    response = await client.delete(
+        f"/api/members/{user_id}",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 403
 
 
 # --- Error handling (service returns Error) ---
@@ -291,5 +369,38 @@ async def test_invite_member_invalid_email_rejected(mock_validate, client):
         "/api/members/invite",
         headers=AUTH_HEADER,
         json={"email": "not-an-email", "role_names": ["member"]},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_deactivate_invalid_uuid_returns_422(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/members/not-a-uuid/deactivate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_activate_invalid_uuid_returns_422(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.post(
+        "/api/members/not-a-uuid/activate",
+        headers=AUTH_HEADER,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+@patch("app.middleware.auth.validate_token", new_callable=AsyncMock)
+async def test_remove_invalid_uuid_returns_422(mock_validate, client):
+    mock_validate.return_value = ADMIN_CLAIMS
+    response = await client.delete(
+        "/api/members/not-a-uuid",
+        headers=AUTH_HEADER,
     )
     assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Implement Role, Permission, and Tenant repositories with full CRUD operations
- Add RoleService, PermissionService, and TenantService with adapter sync and OTel instrumentation
- Rewire identity routers (users, roles, permissions, tenants) to inject domain services via DI instead of direct Descope client access
- Add assignment repository for role-user mappings with duplicate detection
- Comprehensive unit tests for all new services and updated router tests

Refs #145

## Review Findings Addressed
- 2 review-fix iterations addressing security, contract preservation, IdP sync, shared-session rollback, role name sync, and post-commit query issues
- All P0/P1 findings resolved

## Test plan
- [x] Unit tests pass (1003 tests)
- [x] Lint passes (ruff check + format)
- [x] Independent review agents passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)