### PR TITLE
style: add density tokens and increase control heights (DS-1.2)

### DIFF
--- a/frontend/src/components/ui/__tests__/button.test.tsx
+++ b/frontend/src/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Button, buttonVariants } from "../button";
+
+describe("Button", () => {
+  it("renders with default variant and size", () => {
+    render(<Button>Click me</Button>);
+    const button = screen.getByRole("button", { name: "Click me" });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("data-slot", "button");
+    expect(button).toHaveAttribute("data-variant", "default");
+    expect(button).toHaveAttribute("data-size", "default");
+  });
+
+  it("applies default size class h-9", () => {
+    render(<Button>Default</Button>);
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/\bh-9\b/);
+  });
+
+  it("applies xs size class h-7", () => {
+    render(<Button size="xs">XS</Button>);
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/\bh-7\b/);
+  });
+
+  it("applies sm size class h-8", () => {
+    render(<Button size="sm">SM</Button>);
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/\bh-8\b/);
+  });
+
+  it("applies lg size class h-10", () => {
+    render(<Button size="lg">LG</Button>);
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/\bh-10\b/);
+  });
+
+  it("applies icon size class size-9", () => {
+    render(<Button size="icon">I</Button>);
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/\bsize-9\b/);
+  });
+
+  it("applies icon-xs size class size-7", () => {
+    render(<Button size="icon-xs">I</Button>);
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/\bsize-7\b/);
+  });
+
+  it("applies icon-sm size class size-8", () => {
+    render(<Button size="icon-sm">I</Button>);
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/\bsize-8\b/);
+  });
+
+  it("applies icon-lg size class size-10", () => {
+    render(<Button size="icon-lg">I</Button>);
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/\bsize-10\b/);
+  });
+
+  it("applies variant classes", () => {
+    render(<Button variant="outline">Outline</Button>);
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("data-variant", "outline");
+    expect(button.className).toContain("border-border");
+  });
+
+  it("merges custom className", () => {
+    render(<Button className="custom-class">Styled</Button>);
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("custom-class");
+  });
+
+  it("renders as child component with asChild", () => {
+    render(
+      <Button asChild>
+        <a href="/test">Link Button</a>
+      </Button>
+    );
+    const link = screen.getByRole("link", { name: "Link Button" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("data-slot", "button");
+  });
+
+  it("exports buttonVariants for external use", () => {
+    const classes = buttonVariants({ variant: "default", size: "default" });
+    expect(classes).toMatch(/\bh-9\b/);
+  });
+});

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -22,16 +22,16 @@ const buttonVariants = cva(
       },
       size: {
         default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
-        icon: "size-8",
+          "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-7 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-8 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-10 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+        icon: "size-9",
         "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+          "size-7 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
         "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
+          "size-8 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-10",
       },
     },
     defaultVariants: {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -100,6 +100,11 @@
     --chart-4: oklch(0.410 0.215 270);
     --chart-5: oklch(0.270 0.130 266);
     --radius: 0.625rem;
+    --control-h-sm: 32px;
+    --control-h:    40px;
+    --control-h-lg: 48px;
+    --header-h:     60px;
+    --page-pad:     32px;
     --sidebar: oklch(0.985 0.005 285);
     --sidebar-foreground: oklch(0.145 0 0);
     --sidebar-primary: var(--brand);


### PR DESCRIPTION
## Summary
- Add 5 density CSS custom properties to `:root` in `index.css`: `--control-h-sm` (32px), `--control-h` (40px), `--control-h-lg` (48px), `--header-h` (60px), `--page-pad` (32px)
- Increase button size variants by one Tailwind step: default `h-8→h-9`, xs `h-6→h-7`, sm `h-7→h-8`, lg `h-9→h-10` (and matching icon sizes)
- Add button component unit tests covering all 8 size variants, className merging, and asChild rendering

Refs #211

## Review Findings Addressed
- Blind Hunter: 1 MUST FIX (triaged as non-bug — CSS vars are generic control tokens for inputs/selects, button heights are button-specific per design spec), 2 SHOULD FIX (acceptable — dark mode vars are theme-agnostic sizing, class-name assertions are standard CVA test pattern), 2 NITPICK (skipped)
- Acceptance Auditor: 3/3 PASS, 0 FAIL, 0 PARTIAL

## Test plan
- [x] Unit tests pass (111 tests, 11 files)
- [x] Lint passes
- [x] Build succeeds (`npm run build`)
- [x] Independent review agents passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)