### PR TITLE
style: add typography scale tokens and semantic base styles (DS-1.4)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
+        "@fontsource-variable/geist-mono": "^5.2.7",
         "@tailwindcss/vite": "^4.2.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1060,6 +1061,15 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.8.tgz",
       "integrity": "sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/geist-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist-mono/-/geist-mono-5.2.7.tgz",
+      "integrity": "sha512-ZKlZ5sjtalb2TwXKs400mAGDlt/+2ENLNySPx0wTz3bP3mWARCsUW+rpxzZc7e05d2qGch70pItt3K4qttbIYA==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.8",
+    "@fontsource-variable/geist-mono": "^5.2.7",
     "@tailwindcss/vite": "^4.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,12 +2,14 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/geist";
+@import "@fontsource-variable/geist-mono";
 
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
     --font-heading: var(--font-sans);
     --font-sans: 'Geist Variable', sans-serif;
+    --font-mono: 'Geist Mono Variable', ui-monospace, 'SF Mono', Menlo, monospace;
     --color-ink-foreground: var(--ink-foreground);
     --color-ink: var(--ink);
     --color-brand-soft-foreground: var(--brand-soft-foreground);
@@ -105,6 +107,13 @@
     --control-h-lg: 48px;
     --header-h:     60px;
     --page-pad:     32px;
+    --text-xs:   0.8125rem;
+    --text-sm:   0.9375rem;
+    --text-base: 1rem;
+    --text-lg:   1.125rem;
+    --text-xl:   1.375rem;
+    --text-2xl:  1.75rem;
+    --text-3xl:  2.25rem;
     --sidebar: oklch(0.985 0.005 285);
     --sidebar-foreground: oklch(0.145 0 0);
     --sidebar-primary: var(--brand);
@@ -164,8 +173,19 @@
     }
   body {
     @apply bg-background text-foreground;
+    font-size: var(--text-sm);
+    line-height: 1.55;
     }
   html {
     @apply font-sans;
     }
+  h1, .h1 { font-family: var(--font-heading); font-size: var(--text-2xl); font-weight: 600; letter-spacing: -0.02em; line-height: 1.2; margin: 0; }
+  h2, .h2 { font-family: var(--font-heading); font-size: var(--text-xl); font-weight: 600; letter-spacing: -0.01em; line-height: 1.25; margin: 0; }
+  h3, .h3 { font-family: var(--font-heading); font-size: var(--text-lg); font-weight: 500; line-height: 1.35; margin: 0; }
+  h4, .h4 { font-family: var(--font-heading); font-size: var(--text-base); font-weight: 500; line-height: 1.4; margin: 0; }
+  p { font-size: var(--text-sm); line-height: 1.55; }
+  small, .small { font-size: var(--text-xs); color: var(--muted-foreground); }
+  code, .mono { font-family: var(--font-mono); font-size: 0.88em; }
+  .label { font-size: var(--text-sm); font-weight: 500; line-height: 1; }
+  .muted { color: var(--muted-foreground); }
 }


### PR DESCRIPTION
## Summary
- Added 7 typography scale CSS variables (`--text-xs` through `--text-3xl`) to `:root`
- Added `--font-mono` (Geist Mono Variable) to `@theme inline` block
- Installed `@fontsource-variable/geist-mono` package
- Added semantic base styles in `@layer base`: h1-h4, body, p, small, code, `.label`, `.muted`
- Set body font-size to `var(--text-sm)` (15px) with line-height 1.55

Refs #213

## Review Findings Addressed
- Blind Hunter: 0 MUST FIX, 3 SHOULD FIX (all intentional per design spec), 2 NITPICK (skipped)
- Acceptance Auditor: 2/2 PASS (typography scale vars + semantic base styles)

## Test plan
- [x] Unit tests pass (111 tests, 11 files)
- [x] Backend tests pass (1667 tests)
- [x] Build succeeds (Geist Mono font assets bundled)
- [x] Lint passes
- [x] Independent review agents passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)