### PR TITLE
style: increase header height and page padding for density (DS-1.3)

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -19,7 +19,7 @@ export function Header() {
   const pageLabel = routeLabels[location.pathname] ?? "Page"
 
   return (
-    <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
+    <header className="flex h-[var(--header-h)] shrink-0 items-center gap-2 border-b px-4">
       <SidebarTrigger className="-ml-1" />
       <Separator orientation="vertical" className="mr-2 h-4" />
       <span className="text-sm font-medium">{pageLabel}</span>

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -8,7 +8,7 @@ interface PageHeaderProps {
 
 export function PageHeader({ title, description, children }: PageHeaderProps) {
   return (
-    <div className="px-6 pt-6">
+    <div className="px-8 pt-8">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>

--- a/frontend/src/pages/AccessKeys.tsx
+++ b/frontend/src/pages/AccessKeys.tsx
@@ -129,7 +129,7 @@ export default function AccessKeys() {
   return (
     <>
       <PageHeader title="Access Keys" description="Create and manage API access keys" />
-      <div className="p-6 space-y-6">
+      <div className="p-8 space-y-6">
         <Card>
           <CardHeader>
             <CardTitle>Create Key</CardTitle>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -137,7 +137,7 @@ export default function Dashboard() {
   return (
     <>
       <PageHeader title={`Welcome, ${displayName}`} />
-      <div className="p-6">
+      <div className="p-8">
         {error && (
           <Alert variant="destructive" className="mb-6">
             <AlertDescription>{error}</AlertDescription>

--- a/frontend/src/pages/FGAManagement.tsx
+++ b/frontend/src/pages/FGAManagement.tsx
@@ -219,7 +219,7 @@ export default function FGAManagement() {
   return (
     <>
       <PageHeader title="FGA Management" description="Fine-Grained Authorization schema, relations, and permission checks" />
-      <div className="p-6 space-y-6">
+      <div className="p-8 space-y-6">
         {isAdmin ? (
           <>
             {/* Schema Viewer */}

--- a/frontend/src/pages/MemberManagement.tsx
+++ b/frontend/src/pages/MemberManagement.tsx
@@ -89,7 +89,7 @@ export default function MemberManagement() {
   return (
     <>
       <PageHeader title="Members" description="Invite and manage team members" />
-      <div className="p-6 space-y-6">
+      <div className="p-8 space-y-6">
         <Card>
           <CardHeader>
             <CardTitle>Invite Member</CardTitle>

--- a/frontend/src/pages/RoleManagement.tsx
+++ b/frontend/src/pages/RoleManagement.tsx
@@ -374,7 +374,7 @@ export default function RoleManagement() {
   return (
     <>
       <PageHeader title="Role Management" description="View and manage roles and permissions" />
-      <div className="p-6 space-y-6">
+      <div className="p-8 space-y-6">
         {/* Your Roles Card */}
         <Card>
           <CardHeader>

--- a/frontend/src/pages/TenantSettings.tsx
+++ b/frontend/src/pages/TenantSettings.tsx
@@ -79,7 +79,7 @@ export default function TenantSettings() {
     return (
       <>
         <PageHeader title="Tenant Settings" />
-        <div className="p-6 space-y-6">
+        <div className="p-8 space-y-6">
           <Skeleton className="h-32 w-full" />
         </div>
       </>
@@ -91,7 +91,7 @@ export default function TenantSettings() {
   return (
     <>
       <PageHeader title="Tenant Settings" description={settings.name || settings.tenant_id} />
-      <div className="p-6 space-y-6">
+      <div className="p-8 space-y-6">
         <Card>
           <CardHeader>
             <CardTitle>Current Settings</CardTitle>

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -57,7 +57,7 @@ export default function UserProfile() {
     return (
       <>
         <PageHeader title="User Profile" />
-        <div className="p-6 space-y-6">
+        <div className="p-8 space-y-6">
           <Skeleton className="h-32 w-full" />
           <Skeleton className="h-48 w-full" />
         </div>
@@ -68,7 +68,7 @@ export default function UserProfile() {
   return (
     <>
       <PageHeader title="User Profile" description={profile.email || undefined} />
-      <div className="p-6 space-y-6">
+      <div className="p-8 space-y-6">
         <Card>
           <CardHeader>
             <CardTitle>Profile</CardTitle>


### PR DESCRIPTION
## Summary
- Header height updated from static `h-12` to `h-[var(--header-h)]` (60px via CSS variable from DS-1.2)
- PageHeader padding increased from `px-6 pt-6` to `px-8 pt-8` (32px)
- All 7 page wrappers padding increased from `p-6` to `p-8` (32px): Dashboard, MemberManagement, AccessKeys, RoleManagement, FGAManagement, TenantSettings, UserProfile

Refs #212

## Review Findings Addressed
- Blind Hunter: 1 MUST FIX (false positive — `--header-h` exists from DS-1.2), 2 SHOULD FIX (pre-existing patterns), 1 NITPICK (skipped)
- Acceptance Auditor: 3/3 PASS
- 0 actionable findings — no fixes needed

## Test plan
- [x] Unit tests pass (1667 backend + 111 frontend)
- [x] Lint passes
- [x] Build succeeds
- [x] Independent review agents passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)