### PR TITLE
feat: add success and warning badge variants (DS-2.1)

### DIFF
--- a/frontend/src/components/ui/__tests__/badge.test.tsx
+++ b/frontend/src/components/ui/__tests__/badge.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Badge, badgeVariants } from "../badge";
+
+describe("Badge", () => {
+  it("renders with default variant", () => {
+    render(<Badge>Status</Badge>);
+    const badge = screen.getByText("Status");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("data-slot", "badge");
+    expect(badge).toHaveAttribute("data-variant", "default");
+  });
+
+  it("renders success variant with green tones", () => {
+    render(<Badge variant="success">Synced</Badge>);
+    const badge = screen.getByText("Synced");
+    expect(badge).toHaveAttribute("data-variant", "success");
+    expect(badge.className).toContain("text-success");
+    expect(badge.className).toContain("bg-success/20");
+  });
+
+  it("renders warning variant with amber tones", () => {
+    render(<Badge variant="warning">Pending</Badge>);
+    const badge = screen.getByText("Pending");
+    expect(badge).toHaveAttribute("data-variant", "warning");
+    expect(badge.className).toContain("text-warning");
+    expect(badge.className).toContain("bg-warning/25");
+  });
+
+  it("renders destructive variant", () => {
+    render(<Badge variant="destructive">Error</Badge>);
+    const badge = screen.getByText("Error");
+    expect(badge).toHaveAttribute("data-variant", "destructive");
+    expect(badge.className).toContain("text-destructive");
+  });
+
+  it("merges custom className", () => {
+    render(<Badge className="custom-class">Styled</Badge>);
+    const badge = screen.getByText("Styled");
+    expect(badge.className).toContain("custom-class");
+  });
+
+  it("renders as child component with asChild", () => {
+    render(
+      <Badge asChild>
+        <a href="/test">Link Badge</a>
+      </Badge>
+    );
+    const link = screen.getByRole("link", { name: "Link Badge" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("data-slot", "badge");
+  });
+
+  it("exports badgeVariants for external use", () => {
+    const classes = badgeVariants({ variant: "success" });
+    expect(classes).toContain("text-success");
+  });
+});

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -14,6 +14,10 @@ const badgeVariants = cva(
           "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        success:
+          "bg-success/20 text-success focus-visible:ring-success/20 dark:bg-success/30 dark:focus-visible:ring-success/40 [a]:hover:bg-success/30",
+        warning:
+          "bg-warning/25 text-warning focus-visible:ring-warning/20 dark:bg-warning/35 dark:focus-visible:ring-warning/40 [a]:hover:bg-warning/35",
         outline:
           "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost:

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -33,6 +33,8 @@
     --color-ring: var(--ring);
     --color-input: var(--input);
     --color-border: var(--border);
+    --color-warning: var(--warning);
+    --color-success: var(--success);
     --color-destructive: var(--destructive);
     --color-accent-foreground: var(--accent-foreground);
     --color-accent: var(--accent);
@@ -93,6 +95,8 @@
     --accent: var(--brand-soft);
     --accent-foreground: var(--brand-soft-foreground);
     --destructive: oklch(0.577 0.245 27.325);
+    --success: oklch(0.42 0.13 155);
+    --warning: oklch(0.44 0.13 60);
     --border: oklch(0.92 0 0);
     --input: oklch(0.92 0 0);
     --ring: var(--purple-400);
@@ -149,6 +153,8 @@
     --accent: oklch(0.30 0.06 278);
     --accent-foreground: oklch(0.985 0 0);
     --destructive: oklch(0.704 0.191 22.216);
+    --success: oklch(0.62 0.13 155);
+    --warning: oklch(0.64 0.13 60);
     --border: oklch(1 0 0 / 12%);
     --input: oklch(1 0 0 / 15%);
     --ring: var(--purple-400);


### PR DESCRIPTION
## Summary
- Add `success` and `warning` badge variants using OKLCH colors from design system kit reference
- Define `--success` and `--warning` CSS variables in `:root` and `.dark` with `@theme inline` registration
- Success: green tones (oklch hue 155), Warning: amber tones (oklch hue 60)
- Badge variants follow existing CVA pattern with opacity backgrounds (`bg-success/20`, `bg-warning/25`)
- Add badge.test.tsx with 7 unit tests covering all variants, className merge, asChild, and exports

## Review Findings Addressed
- 0 P0 (MUST FIX) findings
- 0 P1 (SHOULD FIX) actionable — 2 dismissed (light-mode values intentional per kit.css reference; className test assertions follow existing codebase pattern)
- 2 P2 (NITPICK) skipped (opacity asymmetry intentional per kit.css; asChild test follows existing button.test.tsx pattern)
- Acceptance: 1 PASS, 1 PARTIAL (non-blocking — colors follow kit.css reference rather than spec suggestions, which is correct precedent)

## Test plan
- [x] Unit tests pass (118/118, 12 files)
- [x] Lint passes
- [x] Vite build succeeds
- [x] Independent review agents passed (Blind Hunter + Acceptance Auditor)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)