### PR TITLE
feat: add useBreakpoint hook and sidebar tablet auto-collapse (DS-2.2)

### DIFF
--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -72,14 +72,10 @@ function SidebarProvider({
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
-  const [_open, _setOpen] = React.useState(defaultOpen)
-
-  // Auto-collapse to icon mode on tablet
-  React.useEffect(() => {
-    if (isTablet) {
-      _setOpen(false)
-    }
-  }, [isTablet])
+  // Initialize collapsed when mounting at tablet width to avoid flash.
+  const [_open, _setOpen] = React.useState(() =>
+    isTablet ? false : defaultOpen
+  )
   const open = openProp ?? _open
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
@@ -95,6 +91,17 @@ function SidebarProvider({
     },
     [setOpenProp, open]
   )
+
+  // Auto-collapse to icon mode when transitioning to tablet width.
+  // Uses setOpen (not _setOpen) so controlled consumers are notified.
+  // Only fires on transition, not on mount (initial state handles that).
+  const prevIsTablet = React.useRef(isTablet)
+  React.useEffect(() => {
+    if (isTablet && !prevIsTablet.current) {
+      setOpen(false)
+    }
+    prevIsTablet.current = isTablet
+  }, [isTablet, setOpen])
 
   // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(() => {

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
-import { useIsMobile } from "@/hooks/use-mobile"
+import { useBreakpoint } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -65,12 +65,21 @@ function SidebarProvider({
   open?: boolean
   onOpenChange?: (open: boolean) => void
 }) {
-  const isMobile = useIsMobile()
+  const breakpoint = useBreakpoint()
+  const isMobile = breakpoint === "mobile"
+  const isTablet = breakpoint === "tablet"
   const [openMobile, setOpenMobile] = React.useState(false)
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
   const [_open, _setOpen] = React.useState(defaultOpen)
+
+  // Auto-collapse to icon mode on tablet
+  React.useEffect(() => {
+    if (isTablet) {
+      _setOpen(false)
+    }
+  }, [isTablet])
   const open = openProp ?? _open
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {

--- a/frontend/src/hooks/__tests__/use-mobile.test.ts
+++ b/frontend/src/hooks/__tests__/use-mobile.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+type ChangeHandler = () => void;
+
+interface MockMediaQueryList {
+  matches: boolean;
+  media: string;
+  onchange: null;
+  addListener: () => void;
+  removeListener: () => void;
+  addEventListener: (event: string, handler: ChangeHandler) => void;
+  removeEventListener: (event: string, handler: ChangeHandler) => void;
+  dispatchEvent: () => boolean;
+}
+
+const changeHandlers: ChangeHandler[] = [];
+let mockWidth = 1280;
+
+function createMockMQL(query: string): MockMediaQueryList {
+  return {
+    get matches() {
+      if (query.includes("max-width: 767px")) {
+        return mockWidth < 768;
+      }
+      if (query.includes("min-width: 768px") && query.includes("max-width: 1023px")) {
+        return mockWidth >= 768 && mockWidth < 1024;
+      }
+      return false;
+    },
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: (_event: string, handler: ChangeHandler) => {
+      changeHandlers.push(handler);
+    },
+    removeEventListener: (_event: string, handler: ChangeHandler) => {
+      const idx = changeHandlers.indexOf(handler);
+      if (idx >= 0) changeHandlers.splice(idx, 1);
+    },
+    dispatchEvent: () => false,
+  };
+}
+
+beforeEach(() => {
+  mockWidth = 1280;
+  changeHandlers.length = 0;
+  vi.stubGlobal("matchMedia", (query: string) => createMockMQL(query));
+  Object.defineProperty(window, "innerWidth", {
+    writable: true,
+    configurable: true,
+    value: mockWidth,
+  });
+});
+
+function setWidth(w: number) {
+  mockWidth = w;
+  Object.defineProperty(window, "innerWidth", {
+    writable: true,
+    configurable: true,
+    value: w,
+  });
+}
+
+describe("useBreakpoint", () => {
+  it("returns 'desktop' above 1024px", async () => {
+    setWidth(1280);
+    const { useBreakpoint } = await import("../use-mobile");
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe("desktop");
+  });
+
+  it("returns 'tablet' between 768-1024px", async () => {
+    setWidth(900);
+    vi.resetModules();
+    const { useBreakpoint } = await import("../use-mobile");
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe("tablet");
+  });
+
+  it("returns 'mobile' below 768px", async () => {
+    setWidth(500);
+    vi.resetModules();
+    const { useBreakpoint } = await import("../use-mobile");
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe("mobile");
+  });
+
+  it("returns 'tablet' at exactly 768px", async () => {
+    setWidth(768);
+    vi.resetModules();
+    const { useBreakpoint } = await import("../use-mobile");
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe("tablet");
+  });
+
+  it("returns 'desktop' at exactly 1024px", async () => {
+    setWidth(1024);
+    vi.resetModules();
+    const { useBreakpoint } = await import("../use-mobile");
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe("desktop");
+  });
+
+  it("updates when matchMedia listeners fire", async () => {
+    setWidth(1280);
+    vi.resetModules();
+    const { useBreakpoint } = await import("../use-mobile");
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe("desktop");
+
+    act(() => {
+      setWidth(500);
+      changeHandlers.forEach((h) => h());
+    });
+    expect(result.current).toBe("mobile");
+  });
+});
+
+describe("useIsMobile", () => {
+  it("returns false above 768px", async () => {
+    setWidth(1280);
+    vi.resetModules();
+    const { useIsMobile } = await import("../use-mobile");
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true below 768px", async () => {
+    setWidth(500);
+    vi.resetModules();
+    const { useIsMobile } = await import("../use-mobile");
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false at tablet width (backwards compatible)", async () => {
+    setWidth(900);
+    vi.resetModules();
+    const { useIsMobile } = await import("../use-mobile");
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+});

--- a/frontend/src/hooks/__tests__/use-mobile.test.ts
+++ b/frontend/src/hooks/__tests__/use-mobile.test.ts
@@ -66,6 +66,7 @@ function setWidth(w: number) {
 describe("useBreakpoint", () => {
   it("returns 'desktop' above 1024px", async () => {
     setWidth(1280);
+    vi.resetModules();
     const { useBreakpoint } = await import("../use-mobile");
     const { result } = renderHook(() => useBreakpoint());
     expect(result.current).toBe("desktop");

--- a/frontend/src/hooks/use-mobile.ts
+++ b/frontend/src/hooks/use-mobile.ts
@@ -1,20 +1,48 @@
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
+const TABLET_BREAKPOINT = 1024
 
-export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean>(
-    () => window.innerWidth < MOBILE_BREAKPOINT
-  )
+export type Breakpoint = "mobile" | "tablet" | "desktop"
+
+export function useBreakpoint(): Breakpoint {
+  const [breakpoint, setBreakpoint] = React.useState<Breakpoint>(() => {
+    const w = window.innerWidth
+    if (w < MOBILE_BREAKPOINT) return "mobile"
+    if (w < TABLET_BREAKPOINT) return "tablet"
+    return "desktop"
+  })
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    const mobileQuery = window.matchMedia(
+      `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+    )
+    const tabletQuery = window.matchMedia(
+      `(min-width: ${MOBILE_BREAKPOINT}px) and (max-width: ${TABLET_BREAKPOINT - 1}px)`
+    )
+
+    const update = () => {
+      if (mobileQuery.matches) {
+        setBreakpoint("mobile")
+      } else if (tabletQuery.matches) {
+        setBreakpoint("tablet")
+      } else {
+        setBreakpoint("desktop")
+      }
     }
-    mql.addEventListener("change", onChange)
-    return () => mql.removeEventListener("change", onChange)
+
+    mobileQuery.addEventListener("change", update)
+    tabletQuery.addEventListener("change", update)
+    return () => {
+      mobileQuery.removeEventListener("change", update)
+      tabletQuery.removeEventListener("change", update)
+    }
   }, [])
 
-  return !!isMobile
+  return breakpoint
+}
+
+export function useIsMobile() {
+  const breakpoint = useBreakpoint()
+  return breakpoint === "mobile"
 }


### PR DESCRIPTION
## Summary
- Added `useBreakpoint()` hook returning `'mobile' | 'tablet' | 'desktop'` based on viewport width (768px / 1024px breakpoints)
- Reimplemented `useIsMobile()` to delegate to `useBreakpoint()` for backwards compatibility
- Sidebar auto-collapses to icon mode (not drawer) at tablet width, with tablet-aware initial state to avoid flash
- Added 9 unit tests covering all breakpoints, boundary values, and backwards compatibility

## Review Findings Addressed
- 1 MUST FIX: sidebar useEffect auto-collapse fixed — uses `setOpen` (controlled mode aware), `prevIsTablet` ref (fires on transition only, not mount), and tablet-aware initializer
- 2 SHOULD FIX fixed: tablet-aware initial state eliminates flash; test consistency improved with `vi.resetModules()`
- 2 SHOULD FIX skipped: SSR window access (existing pattern), changeHandlers array (vitest sequential by default)
- 2 NITPICK skipped: extra matchMedia listener cost (negligible), TABLET_BREAKPOINT naming (clear from usage)
- Acceptance: 3/3 PASS

## Test plan
- [x] Unit tests pass (127 tests, 13 files)
- [x] Lint passes
- [x] Build succeeds
- [x] Independent review agents passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)