### PR TITLE
feat: add grouped sidebar nav with platform section (DS-2.3)

### DIFF
--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -1,4 +1,16 @@
-import { Home, Users, Shield, Key, Settings, User, Lock } from "lucide-react"
+import {
+  Home,
+  Users,
+  Shield,
+  Key,
+  Settings,
+  User,
+  Lock,
+  Globe,
+  RefreshCw,
+  Activity,
+  UserPlus,
+} from "lucide-react"
 import { useLocation, Link } from "react-router-dom"
 import { useRBAC } from "@/hooks/useRBAC"
 import {
@@ -12,21 +24,60 @@ import {
   SidebarMenuButton,
 } from "@/components/ui/sidebar"
 
-const navItems = [
-  { to: "/", label: "Dashboard", icon: Home },
-  { to: "/members", label: "Members", icon: Users, adminOnly: true },
-  { to: "/roles", label: "Roles", icon: Shield, adminOnly: true },
-  { to: "/keys", label: "Access Keys", icon: Key, adminOnly: true },
-  { to: "/fga", label: "FGA", icon: Lock, adminOnly: true },
-  { to: "/settings", label: "Tenant Settings", icon: Settings },
-  { to: "/profile", label: "Profile", icon: User },
+interface NavItem {
+  to: string
+  label: string
+  icon: React.ComponentType
+  adminOnly?: boolean
+}
+
+interface NavSection {
+  label: string
+  items: NavItem[]
+}
+
+const navSections: NavSection[] = [
+  {
+    label: "Workspace",
+    items: [
+      { to: "/", label: "Dashboard", icon: Home },
+      { to: "/members", label: "Members", icon: Users, adminOnly: true },
+      { to: "/roles", label: "Roles", icon: Shield, adminOnly: true },
+      { to: "/keys", label: "Access Keys", icon: Key, adminOnly: true },
+      { to: "/fga", label: "FGA", icon: Lock, adminOnly: true },
+    ],
+  },
+  {
+    label: "Platform",
+    items: [
+      { to: "/providers", label: "Providers", icon: Globe, adminOnly: true },
+      {
+        to: "/sync",
+        label: "Sync Dashboard",
+        icon: RefreshCw,
+        adminOnly: true,
+      },
+      { to: "/events", label: "Events", icon: Activity, adminOnly: true },
+      {
+        to: "/provisional",
+        label: "Provisional Users",
+        icon: UserPlus,
+        adminOnly: true,
+      },
+    ],
+  },
+  {
+    label: "Tenant",
+    items: [
+      { to: "/settings", label: "Tenant Settings", icon: Settings },
+      { to: "/profile", label: "Profile", icon: User },
+    ],
+  },
 ]
 
 export function AppSidebar() {
   const location = useLocation()
   const { isAdmin } = useRBAC()
-
-  const visibleItems = navItems.filter((item) => !item.adminOnly || isAdmin)
 
   return (
     <Sidebar>
@@ -34,27 +85,35 @@ export function AppSidebar() {
         <span className="text-lg font-semibold">Descope Starter</span>
       </SidebarHeader>
       <SidebarContent>
-        <SidebarGroup>
-          <SidebarGroupLabel>Navigation</SidebarGroupLabel>
-          <SidebarMenu>
-            {visibleItems.map((item) => {
-              const isActive =
-                item.to === "/"
-                  ? location.pathname === "/"
-                  : location.pathname.startsWith(item.to)
-              return (
-                <SidebarMenuItem key={item.to}>
-                  <SidebarMenuButton asChild isActive={isActive}>
-                    <Link to={item.to}>
-                      <item.icon />
-                      <span>{item.label}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              )
-            })}
-          </SidebarMenu>
-        </SidebarGroup>
+        {navSections.map((section) => {
+          const visibleItems = section.items.filter(
+            (item) => !item.adminOnly || isAdmin
+          )
+          if (visibleItems.length === 0) return null
+          return (
+            <SidebarGroup key={section.label}>
+              <SidebarGroupLabel>{section.label}</SidebarGroupLabel>
+              <SidebarMenu>
+                {visibleItems.map((item) => {
+                  const isActive =
+                    item.to === "/"
+                      ? location.pathname === "/"
+                      : location.pathname.startsWith(item.to)
+                  return (
+                    <SidebarMenuItem key={item.to}>
+                      <SidebarMenuButton asChild isActive={isActive}>
+                        <Link to={item.to}>
+                          <item.icon />
+                          <span>{item.label}</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  )
+                })}
+              </SidebarMenu>
+            </SidebarGroup>
+          )
+        })}
       </SidebarContent>
     </Sidebar>
   )

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -10,6 +10,11 @@ const routeLabels: Record<string, string> = {
   "/members": "Members",
   "/roles": "Roles",
   "/keys": "Access Keys",
+  "/fga": "FGA",
+  "/providers": "Providers",
+  "/sync": "Sync Dashboard",
+  "/events": "Events",
+  "/provisional": "Provisional Users",
   "/settings": "Tenant Settings",
   "/profile": "Profile",
 }

--- a/frontend/src/components/layout/__tests__/AppSidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppSidebar.test.tsx
@@ -21,6 +21,15 @@ function renderSidebar(path = "/") {
 }
 
 describe("AppSidebar", () => {
+  it("renders group labels for admin users", () => {
+    mockUseRBAC.mockReturnValue({ isAdmin: true });
+    renderSidebar();
+
+    expect(screen.getByText("Workspace")).toBeInTheDocument();
+    expect(screen.getByText("Platform")).toBeInTheDocument();
+    expect(screen.getByText("Tenant")).toBeInTheDocument();
+  });
+
   it("shows all nav items for admin users", () => {
     mockUseRBAC.mockReturnValue({ isAdmin: true });
     renderSidebar();
@@ -29,6 +38,11 @@ describe("AppSidebar", () => {
     expect(screen.getByText("Members")).toBeInTheDocument();
     expect(screen.getByText("Roles")).toBeInTheDocument();
     expect(screen.getByText("Access Keys")).toBeInTheDocument();
+    expect(screen.getByText("FGA")).toBeInTheDocument();
+    expect(screen.getByText("Providers")).toBeInTheDocument();
+    expect(screen.getByText("Sync Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Events")).toBeInTheDocument();
+    expect(screen.getByText("Provisional Users")).toBeInTheDocument();
     expect(screen.getByText("Tenant Settings")).toBeInTheDocument();
     expect(screen.getByText("Profile")).toBeInTheDocument();
   });
@@ -41,8 +55,22 @@ describe("AppSidebar", () => {
     expect(screen.queryByText("Members")).not.toBeInTheDocument();
     expect(screen.queryByText("Roles")).not.toBeInTheDocument();
     expect(screen.queryByText("Access Keys")).not.toBeInTheDocument();
+    expect(screen.queryByText("FGA")).not.toBeInTheDocument();
+    expect(screen.queryByText("Providers")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sync Dashboard")).not.toBeInTheDocument();
+    expect(screen.queryByText("Events")).not.toBeInTheDocument();
+    expect(screen.queryByText("Provisional Users")).not.toBeInTheDocument();
     expect(screen.getByText("Tenant Settings")).toBeInTheDocument();
     expect(screen.getByText("Profile")).toBeInTheDocument();
+  });
+
+  it("hides Platform group for non-admin users", () => {
+    mockUseRBAC.mockReturnValue({ isAdmin: false });
+    renderSidebar();
+
+    expect(screen.getByText("Workspace")).toBeInTheDocument();
+    expect(screen.queryByText("Platform")).not.toBeInTheDocument();
+    expect(screen.getByText("Tenant")).toBeInTheDocument();
   });
 
   it("renders app name in header", () => {


### PR DESCRIPTION
## Summary
- Reorganized sidebar navigation from flat list into 3 grouped sections: Workspace, Platform, Tenant
- Added Platform section with 4 new admin-only nav items: Providers, Sync Dashboard, Events, Provisional Users
- Added route labels in Header for new platform pages and missing FGA label
- Sections with no visible items (after RBAC filtering) are hidden entirely

Refs #216

## Review Findings Addressed
- Blind Hunter: 0 MUST FIX, 1 SHOULD FIX (skipped — pre-existing pattern), 1 NITPICK (skipped)
- Acceptance Auditor: 3/3 PASS

## Test plan
- [x] Unit tests pass (129 tests, 13 files)
- [x] Lint passes
- [x] Build succeeds
- [x] Independent review agents passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)