### PR TITLE
feat: add KPI strip component with responsive grid (DS-3.1)

### DIFF
--- a/frontend/src/components/ui/__tests__/kpi-strip.test.tsx
+++ b/frontend/src/components/ui/__tests__/kpi-strip.test.tsx
@@ -31,8 +31,8 @@ describe("KpiStrip", () => {
       <KpiStrip items={[{ label: "Users", value: 10, delta: "+5%", trend: "up" }]} />
     );
     const delta = container.querySelector('[data-slot="kpi-delta"]');
-    expect(delta).toBeInTheDocument();
-    expect(delta!.className).toContain("text-success");
+    expect(delta).not.toBeNull();
+    expect(delta).toHaveClass("text-success");
     expect(delta).toHaveTextContent("+5%");
   });
 
@@ -41,7 +41,8 @@ describe("KpiStrip", () => {
       <KpiStrip items={[{ label: "Errors", value: 3, delta: "-8%", trend: "down" }]} />
     );
     const delta = container.querySelector('[data-slot="kpi-delta"]');
-    expect(delta!.className).toContain("text-destructive");
+    expect(delta).not.toBeNull();
+    expect(delta).toHaveClass("text-destructive");
   });
 
   it("renders neutral delta with muted color", () => {
@@ -49,7 +50,8 @@ describe("KpiStrip", () => {
       <KpiStrip items={[{ label: "Latency", value: "120ms", delta: "0%", trend: "neutral" }]} />
     );
     const delta = container.querySelector('[data-slot="kpi-delta"]');
-    expect(delta!.className).toContain("text-muted-foreground");
+    expect(delta).not.toBeNull();
+    expect(delta).toHaveClass("text-muted-foreground");
   });
 
   it("uses muted color when trend is omitted", () => {
@@ -57,7 +59,8 @@ describe("KpiStrip", () => {
       <KpiStrip items={[{ label: "Latency", value: "120ms", delta: "0%" }]} />
     );
     const delta = container.querySelector('[data-slot="kpi-delta"]');
-    expect(delta!.className).toContain("text-muted-foreground");
+    expect(delta).not.toBeNull();
+    expect(delta).toHaveClass("text-muted-foreground");
   });
 
   it("omits delta element when delta is not provided", () => {
@@ -70,8 +73,8 @@ describe("KpiStrip", () => {
   it("renders empty container for empty items", () => {
     const { container } = render(<KpiStrip items={[]} />);
     const strip = container.querySelector('[data-slot="kpi-strip"]');
-    expect(strip).toBeInTheDocument();
-    expect(strip!.children).toHaveLength(0);
+    expect(strip).not.toBeNull();
+    expect(strip?.children).toHaveLength(0);
   });
 
   it("merges custom className", () => {
@@ -79,6 +82,7 @@ describe("KpiStrip", () => {
       <KpiStrip items={baseItems} className="custom-class" />
     );
     const strip = container.querySelector('[data-slot="kpi-strip"]');
-    expect(strip!.className).toContain("custom-class");
+    expect(strip).not.toBeNull();
+    expect(strip).toHaveClass("custom-class");
   });
 });

--- a/frontend/src/components/ui/__tests__/kpi-strip.test.tsx
+++ b/frontend/src/components/ui/__tests__/kpi-strip.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { KpiStrip, type KpiItem } from "../kpi-strip";
+
+const baseItems: KpiItem[] = [
+  { label: "Users", value: "1,234" },
+  { label: "Syncs", value: 42, delta: "+12%", trend: "up" },
+  { label: "Errors", value: 3, delta: "-8%", trend: "down" },
+  { label: "Latency", value: "120ms", delta: "0%", trend: "neutral" },
+];
+
+describe("KpiStrip", () => {
+  it("renders all items with labels and values", () => {
+    render(<KpiStrip items={baseItems} />);
+    expect(screen.getByText("Users")).toBeInTheDocument();
+    expect(screen.getByText("1,234")).toBeInTheDocument();
+    expect(screen.getByText("Syncs")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("Errors")).toBeInTheDocument();
+    expect(screen.getByText("Latency")).toBeInTheDocument();
+  });
+
+  it("applies data-slot attributes", () => {
+    const { container } = render(<KpiStrip items={baseItems} />);
+    expect(container.querySelector('[data-slot="kpi-strip"]')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="kpi-item"]')).toHaveLength(4);
+  });
+
+  it("renders positive delta with success color", () => {
+    const { container } = render(
+      <KpiStrip items={[{ label: "Users", value: 10, delta: "+5%", trend: "up" }]} />
+    );
+    const delta = container.querySelector('[data-slot="kpi-delta"]');
+    expect(delta).toBeInTheDocument();
+    expect(delta!.className).toContain("text-success");
+    expect(delta).toHaveTextContent("+5%");
+  });
+
+  it("renders negative delta with destructive color", () => {
+    const { container } = render(
+      <KpiStrip items={[{ label: "Errors", value: 3, delta: "-8%", trend: "down" }]} />
+    );
+    const delta = container.querySelector('[data-slot="kpi-delta"]');
+    expect(delta!.className).toContain("text-destructive");
+  });
+
+  it("renders neutral delta with muted color", () => {
+    const { container } = render(
+      <KpiStrip items={[{ label: "Latency", value: "120ms", delta: "0%", trend: "neutral" }]} />
+    );
+    const delta = container.querySelector('[data-slot="kpi-delta"]');
+    expect(delta!.className).toContain("text-muted-foreground");
+  });
+
+  it("uses muted color when trend is omitted", () => {
+    const { container } = render(
+      <KpiStrip items={[{ label: "Latency", value: "120ms", delta: "0%" }]} />
+    );
+    const delta = container.querySelector('[data-slot="kpi-delta"]');
+    expect(delta!.className).toContain("text-muted-foreground");
+  });
+
+  it("omits delta element when delta is not provided", () => {
+    const { container } = render(
+      <KpiStrip items={[{ label: "Users", value: 100 }]} />
+    );
+    expect(container.querySelector('[data-slot="kpi-delta"]')).not.toBeInTheDocument();
+  });
+
+  it("renders empty container for empty items", () => {
+    const { container } = render(<KpiStrip items={[]} />);
+    const strip = container.querySelector('[data-slot="kpi-strip"]');
+    expect(strip).toBeInTheDocument();
+    expect(strip!.children).toHaveLength(0);
+  });
+
+  it("merges custom className", () => {
+    const { container } = render(
+      <KpiStrip items={baseItems} className="custom-class" />
+    );
+    const strip = container.querySelector('[data-slot="kpi-strip"]');
+    expect(strip!.className).toContain("custom-class");
+  });
+});

--- a/frontend/src/components/ui/kpi-strip.tsx
+++ b/frontend/src/components/ui/kpi-strip.tsx
@@ -1,0 +1,77 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+type Trend = "up" | "down" | "neutral"
+
+interface KpiItem {
+  label: string
+  value: string | number
+  delta?: string
+  trend?: Trend
+}
+
+const trendClass: Record<Trend, string> = {
+  up: "text-success",
+  down: "text-destructive",
+  neutral: "text-muted-foreground",
+}
+
+function KpiStrip({
+  items,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & { items: KpiItem[] }) {
+  return (
+    <div
+      data-slot="kpi-strip"
+      className={cn(
+        "grid grid-cols-2 overflow-hidden rounded-xl border border-border bg-card md:grid-cols-[repeat(auto-fit,minmax(180px,1fr))]",
+        className,
+      )}
+      {...props}
+    >
+      {items.map((item, i) => (
+        <KpiItemCell key={i} item={item} isLast={i === items.length - 1} />
+      ))}
+    </div>
+  )
+}
+
+function KpiItemCell({
+  item,
+  isLast,
+}: {
+  item: KpiItem
+  isLast: boolean
+}) {
+  return (
+    <div
+      data-slot="kpi-item"
+      className={cn(
+        "px-5 py-4",
+        !isLast && "border-r border-border max-md:[&:nth-child(2n)]:border-r-0",
+      )}
+    >
+      <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        {item.label}
+      </div>
+      <div className="mt-1.5 text-2xl font-semibold leading-tight tracking-tight tabular-nums">
+        {item.value}
+      </div>
+      {item.delta && (
+        <div
+          data-slot="kpi-delta"
+          className={cn(
+            "mt-1 text-xs tabular-nums",
+            trendClass[item.trend ?? "neutral"],
+          )}
+        >
+          {item.delta}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export { KpiStrip, type KpiItem, type Trend }

--- a/frontend/src/components/ui/kpi-strip.tsx
+++ b/frontend/src/components/ui/kpi-strip.tsx
@@ -26,13 +26,17 @@ function KpiStrip({
     <div
       data-slot="kpi-strip"
       className={cn(
-        "grid grid-cols-2 overflow-hidden rounded-xl border border-border bg-card md:grid-cols-[repeat(auto-fit,minmax(180px,1fr))]",
+        "grid grid-cols-1 overflow-hidden rounded-xl border border-border bg-card sm:grid-cols-2 lg:grid-cols-4",
         className,
       )}
       {...props}
     >
       {items.map((item, i) => (
-        <KpiItemCell key={i} item={item} isLast={i === items.length - 1} />
+        <KpiItemCell
+          key={item.label}
+          item={item}
+          isLast={i === items.length - 1}
+        />
       ))}
     </div>
   )
@@ -50,7 +54,8 @@ function KpiItemCell({
       data-slot="kpi-item"
       className={cn(
         "px-5 py-4",
-        !isLast && "border-r border-border max-md:[&:nth-child(2n)]:border-r-0",
+        !isLast &&
+          "border-border sm:border-r sm:[&:nth-child(2n)]:border-r-0 lg:[&:nth-child(2n)]:border-r lg:[&:nth-child(4n)]:border-r-0",
       )}
     >
       <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">


### PR DESCRIPTION
## Summary
- New `KpiStrip` component with responsive grid layout (stacked mobile, 2-col tablet, 4-col desktop)
- `KpiItemCell` renders label, value, optional delta with trend-based color coding (success/destructive/muted)
- Uses design system tokens, `cn()` utility, `data-slot` attributes per shadcn convention
- 9 unit tests covering all rendering paths, delta colors, edge cases

## Review Findings Addressed
- **P0 (2 fixed):** Grid responsive layout corrected — stacked mobile (grid-cols-1), 2-col tablet (sm:grid-cols-2), 4-col desktop (lg:grid-cols-4)
- **P1 (3 fixed):** Array index keys → label-based keys, border visual gaps fixed for responsive breakpoints, non-null test assertions replaced with proper guards
- **P2 (2 skipped):** CSS-only isLast and memoization — deferred as non-critical

## Test plan
- [x] Unit tests pass (138 tests, 14 files)
- [x] Lint passes
- [x] Build succeeds
- [x] Independent review agents passed (Blind Hunter + Acceptance Auditor)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)