### PR TITLE
refactor: extract BaseRepository[T] from repository classes

### DIFF
--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,0 +1,5 @@
+"""Repository layer — data access only, no business logic."""
+
+from app.repositories.base import BaseRepository, RepositoryConflictError
+
+__all__ = ["BaseRepository", "RepositoryConflictError"]

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,5 +1,22 @@
 """Repository layer — data access only, no business logic."""
 
+from app.repositories.assignment import UserTenantRoleRepository
 from app.repositories.base import BaseRepository, RepositoryConflictError
+from app.repositories.idp_link import IdPLinkRepository
+from app.repositories.permission import PermissionRepository
+from app.repositories.provider import ProviderRepository
+from app.repositories.role import RoleRepository
+from app.repositories.tenant import TenantRepository
+from app.repositories.user import UserRepository
 
-__all__ = ["BaseRepository", "RepositoryConflictError"]
+__all__ = [
+    "BaseRepository",
+    "IdPLinkRepository",
+    "PermissionRepository",
+    "ProviderRepository",
+    "RepositoryConflictError",
+    "RoleRepository",
+    "TenantRepository",
+    "UserRepository",
+    "UserTenantRoleRepository",
+]

--- a/backend/app/repositories/assignment.py
+++ b/backend/app/repositories/assignment.py
@@ -9,33 +9,18 @@ from __future__ import annotations
 import uuid
 
 import sqlalchemy as sa
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.identity.assignment import UserTenantRole
-from app.repositories.user import RepositoryConflictError
+from app.repositories.base import BaseRepository
 
 
-class UserTenantRoleRepository:
+class UserTenantRoleRepository(BaseRepository[UserTenantRole]):
     """Repository for UserTenantRole table operations.
 
     Takes AsyncSession via constructor injection (inner layer of onion architecture).
     """
 
-    def __init__(self, session: AsyncSession) -> None:
-        self._session = session
-
-    async def create(self, assignment: UserTenantRole) -> UserTenantRole:
-        """Add a new role assignment and flush.
-
-        Raises RepositoryConflictError if the assignment already exists.
-        """
-        self._session.add(assignment)
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            raise RepositoryConflictError(str(exc)) from exc
-        return assignment
+    _model = UserTenantRole
 
     async def get(self, user_id: uuid.UUID, tenant_id: uuid.UUID, role_id: uuid.UUID) -> UserTenantRole | None:
         """Fetch an assignment by composite primary key. Returns None if not found."""
@@ -84,11 +69,3 @@ class UserTenantRoleRepository:
         result = await self._session.execute(stmt)
         await self._session.flush()
         return result.rowcount
-
-    async def commit(self) -> None:
-        """Commit the current transaction."""
-        await self._session.commit()
-
-    async def rollback(self) -> None:
-        """Roll back the current transaction."""
-        await self._session.rollback()

--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -7,20 +7,17 @@ methods that every concrete repository previously implemented individually.
 from __future__ import annotations
 
 import uuid
-from typing import Generic, TypeVar
 
 import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-
-T = TypeVar("T")
 
 
 class RepositoryConflictError(Exception):
     """Raised when a database constraint violation indicates a conflict."""
 
 
-class BaseRepository(Generic[T]):
+class BaseRepository[T]:
     """Base repository with shared CRUD and transaction operations.
 
     Subclasses set ``_model`` class attribute to their SQLAlchemy model.

--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -1,0 +1,76 @@
+"""BaseRepository — generic base class for shared CRUD and transaction operations.
+
+Consolidates duplicated __init__, create, get, update, delete, commit, rollback
+methods that every concrete repository previously implemented individually.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Generic, TypeVar
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+T = TypeVar("T")
+
+
+class RepositoryConflictError(Exception):
+    """Raised when a database constraint violation indicates a conflict."""
+
+
+class BaseRepository(Generic[T]):
+    """Base repository with shared CRUD and transaction operations.
+
+    Subclasses set ``_model`` class attribute to their SQLAlchemy model.
+    """
+
+    _model: type[T]
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(self, entity: T) -> T:
+        """Add a new entity to the session and flush to generate defaults.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        Does NOT rollback — the service layer owns the transaction boundary.
+        """
+        self._session.add(entity)
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return entity
+
+    async def get(self, entity_id: uuid.UUID) -> T | None:
+        """Fetch an entity by primary key. Returns None if not found."""
+        return await self._session.get(self._model, entity_id)
+
+    async def update(self, entity: T) -> T:
+        """Flush updated entity state.
+
+        Raises RepositoryConflictError if a uniqueness constraint is violated.
+        Does NOT rollback — the service layer owns the transaction boundary.
+        """
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            raise RepositoryConflictError(str(exc)) from exc
+        return entity
+
+    async def delete(self, entity_id: uuid.UUID) -> bool:
+        """Delete an entity by ID. Returns True if deleted, False if not found."""
+        stmt = sa.delete(self._model).where(self._model.id == entity_id)
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return result.rowcount > 0
+
+    async def commit(self) -> None:
+        """Commit the current transaction."""
+        await self._session.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the current transaction."""
+        await self._session.rollback()

--- a/backend/app/repositories/idp_link.py
+++ b/backend/app/repositories/idp_link.py
@@ -9,26 +9,19 @@ from __future__ import annotations
 import uuid
 
 import sqlalchemy as sa
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.identity.provider import Provider
 from app.models.identity.user import IdPLink
-from app.repositories.user import RepositoryConflictError
+from app.repositories.base import BaseRepository
 
 
-class IdPLinkRepository:
+class IdPLinkRepository(BaseRepository[IdPLink]):
     """Repository for IdPLink table operations.
 
     Takes AsyncSession via constructor injection (inner layer of onion architecture).
     """
 
-    def __init__(self, session: AsyncSession) -> None:
-        self._session = session
-
-    async def get(self, link_id: uuid.UUID) -> IdPLink | None:
-        """Fetch an IdP link by primary key. Returns None if not found."""
-        return await self._session.get(IdPLink, link_id)
+    _model = IdPLink
 
     async def delete(self, link_id: uuid.UUID) -> bool:
         """Delete an IdP link by primary key. Returns True if deleted, False if not found."""
@@ -48,19 +41,6 @@ class IdPLinkRepository:
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none()
 
-    async def create(self, link: IdPLink) -> IdPLink:
-        """Add a new IdP link to the session and flush to generate defaults.
-
-        Raises RepositoryConflictError if a uniqueness constraint is violated.
-        Does NOT rollback — the caller (service layer) owns the transaction.
-        """
-        self._session.add(link)
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            raise RepositoryConflictError(str(exc)) from exc
-        return link
-
     async def get_by_provider_name_and_sub(self, provider_name: str, external_sub: str) -> IdPLink | None:
         """Fetch an IdP link by provider name and external subject (joins Provider table).
 
@@ -79,11 +59,3 @@ class IdPLinkRepository:
         stmt = sa.select(IdPLink).where(IdPLink.user_id == user_id)
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
-
-    async def commit(self) -> None:
-        """Commit the current transaction."""
-        await self._session.commit()
-
-    async def rollback(self) -> None:
-        """Roll back the current transaction."""
-        await self._session.rollback()

--- a/backend/app/repositories/permission.py
+++ b/backend/app/repositories/permission.py
@@ -6,40 +6,19 @@ Contains NO business logic, NO OTel spans, NO adapter calls — data access only
 
 from __future__ import annotations
 
-import uuid
-
 import sqlalchemy as sa
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.identity.role import Permission
-from app.repositories.user import RepositoryConflictError
+from app.repositories.base import BaseRepository
 
 
-class PermissionRepository:
+class PermissionRepository(BaseRepository[Permission]):
     """Repository for Permission table operations.
 
     Takes AsyncSession via constructor injection (inner layer of onion architecture).
     """
 
-    def __init__(self, session: AsyncSession) -> None:
-        self._session = session
-
-    async def create(self, permission: Permission) -> Permission:
-        """Add a new permission to the session and flush to generate defaults.
-
-        Raises RepositoryConflictError if a uniqueness constraint is violated.
-        """
-        self._session.add(permission)
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            raise RepositoryConflictError(str(exc)) from exc
-        return permission
-
-    async def get(self, permission_id: uuid.UUID) -> Permission | None:
-        """Fetch a permission by primary key. Returns None if not found."""
-        return await self._session.get(Permission, permission_id)
+    _model = Permission
 
     async def get_by_name(self, name: str) -> Permission | None:
         """Fetch a permission by name. Returns None if not found."""
@@ -52,29 +31,3 @@ class PermissionRepository:
         stmt = sa.select(Permission).order_by(Permission.created_at.desc())
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
-
-    async def update(self, permission: Permission) -> Permission:
-        """Flush updated permission state.
-
-        Raises RepositoryConflictError if a uniqueness constraint is violated.
-        """
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            raise RepositoryConflictError(str(exc)) from exc
-        return permission
-
-    async def delete(self, permission_id: uuid.UUID) -> bool:
-        """Delete a permission by ID. Returns True if deleted, False if not found."""
-        stmt = sa.delete(Permission).where(Permission.id == permission_id)
-        result = await self._session.execute(stmt)
-        await self._session.flush()
-        return result.rowcount > 0
-
-    async def commit(self) -> None:
-        """Commit the current transaction."""
-        await self._session.commit()
-
-    async def rollback(self) -> None:
-        """Roll back the current transaction."""
-        await self._session.rollback()

--- a/backend/app/repositories/provider.py
+++ b/backend/app/repositories/provider.py
@@ -6,51 +6,19 @@ Contains NO business logic, NO OTel spans, NO adapter calls — data access only
 
 from __future__ import annotations
 
-import uuid
-
 import sqlalchemy as sa
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.identity.provider import Provider, ProviderType
-from app.repositories.user import RepositoryConflictError
+from app.repositories.base import BaseRepository
 
 
-class ProviderRepository:
+class ProviderRepository(BaseRepository[Provider]):
     """Repository for Provider table operations.
 
     Takes AsyncSession via constructor injection (inner layer of onion architecture).
     """
 
-    def __init__(self, session: AsyncSession) -> None:
-        self._session = session
-
-    async def create(self, provider: Provider) -> Provider:
-        """Add a new provider to the session and flush to generate defaults.
-
-        Raises RepositoryConflictError if a uniqueness constraint is violated.
-        Rolls back the session before raising so it is not left in an invalid state.
-        """
-        self._session.add(provider)
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            await self._session.rollback()
-            raise RepositoryConflictError(str(exc)) from exc
-        return provider
-
-    async def update(self, provider: Provider) -> Provider:
-        """Flush pending mutations on a provider already attached to the session.
-
-        Raises RepositoryConflictError if a uniqueness constraint is violated.
-        Rolls back the session before raising so it is not left in an invalid state.
-        """
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            await self._session.rollback()
-            raise RepositoryConflictError(str(exc)) from exc
-        return provider
+    _model = Provider
 
     async def get_by_type(self, provider_type: ProviderType) -> Provider | None:
         """Fetch a provider by type. Returns the first match or None.
@@ -73,15 +41,3 @@ class ProviderRepository:
         stmt = sa.select(Provider).order_by(Provider.name)
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
-
-    async def get(self, provider_id: uuid.UUID) -> Provider | None:
-        """Fetch a provider by primary key. Returns None if not found."""
-        return await self._session.get(Provider, provider_id)
-
-    async def commit(self) -> None:
-        """Commit the current transaction."""
-        await self._session.commit()
-
-    async def rollback(self) -> None:
-        """Roll back the current transaction."""
-        await self._session.rollback()

--- a/backend/app/repositories/role.py
+++ b/backend/app/repositories/role.py
@@ -10,36 +10,18 @@ import uuid
 
 import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.identity.role import Permission, Role, RolePermission
-from app.repositories.user import RepositoryConflictError
+from app.repositories.base import BaseRepository, RepositoryConflictError
 
 
-class RoleRepository:
+class RoleRepository(BaseRepository[Role]):
     """Repository for Role table operations.
 
     Takes AsyncSession via constructor injection (inner layer of onion architecture).
     """
 
-    def __init__(self, session: AsyncSession) -> None:
-        self._session = session
-
-    async def create(self, role: Role) -> Role:
-        """Add a new role to the session and flush to generate defaults.
-
-        Raises RepositoryConflictError if a uniqueness constraint is violated.
-        """
-        self._session.add(role)
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            raise RepositoryConflictError(str(exc)) from exc
-        return role
-
-    async def get(self, role_id: uuid.UUID) -> Role | None:
-        """Fetch a role by primary key. Returns None if not found."""
-        return await self._session.get(Role, role_id)
+    _model = Role
 
     async def get_by_name(self, name: str, tenant_id: uuid.UUID | None = None) -> Role | None:
         """Fetch a role by name within a tenant scope. Returns None if not found."""
@@ -61,17 +43,6 @@ class RoleRepository:
         stmt = stmt.order_by(Role.created_at.desc())
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
-
-    async def update(self, role: Role) -> Role:
-        """Flush updated role state.
-
-        Raises RepositoryConflictError if a uniqueness constraint is violated.
-        """
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            raise RepositoryConflictError(str(exc)) from exc
-        return role
 
     async def add_permission(self, role_id: uuid.UUID, permission_id: uuid.UUID) -> RolePermission:
         """Create a role-permission mapping.
@@ -109,18 +80,3 @@ class RoleRepository:
         )
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
-
-    async def delete(self, role_id: uuid.UUID) -> bool:
-        """Delete a role by ID. Returns True if deleted, False if not found."""
-        stmt = sa.delete(Role).where(Role.id == role_id)
-        result = await self._session.execute(stmt)
-        await self._session.flush()
-        return result.rowcount > 0
-
-    async def commit(self) -> None:
-        """Commit the current transaction."""
-        await self._session.commit()
-
-    async def rollback(self) -> None:
-        """Roll back the current transaction."""
-        await self._session.rollback()

--- a/backend/app/repositories/tenant.py
+++ b/backend/app/repositories/tenant.py
@@ -9,40 +9,21 @@ from __future__ import annotations
 import uuid
 
 import sqlalchemy as sa
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.identity.assignment import UserTenantRole
 from app.models.identity.role import Role
 from app.models.identity.tenant import Tenant
 from app.models.identity.user import User
-from app.repositories.user import RepositoryConflictError
+from app.repositories.base import BaseRepository
 
 
-class TenantRepository:
+class TenantRepository(BaseRepository[Tenant]):
     """Repository for Tenant table operations.
 
     Takes AsyncSession via constructor injection (inner layer of onion architecture).
     """
 
-    def __init__(self, session: AsyncSession) -> None:
-        self._session = session
-
-    async def create(self, tenant: Tenant) -> Tenant:
-        """Add a new tenant to the session and flush to generate defaults.
-
-        Raises RepositoryConflictError if a uniqueness constraint is violated.
-        """
-        self._session.add(tenant)
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            raise RepositoryConflictError(str(exc)) from exc
-        return tenant
-
-    async def get(self, tenant_id: uuid.UUID) -> Tenant | None:
-        """Fetch a tenant by primary key. Returns None if not found."""
-        return await self._session.get(Tenant, tenant_id)
+    _model = Tenant
 
     async def get_by_name(self, name: str) -> Tenant | None:
         """Fetch a tenant by name. Returns None if not found."""
@@ -55,17 +36,6 @@ class TenantRepository:
         stmt = sa.select(Tenant).order_by(Tenant.created_at.desc())
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
-
-    async def update(self, tenant: Tenant) -> Tenant:
-        """Flush updated tenant state.
-
-        Raises RepositoryConflictError if a uniqueness constraint is violated.
-        """
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            raise RepositoryConflictError(str(exc)) from exc
-        return tenant
 
     async def get_users_with_roles(self, tenant_id: uuid.UUID) -> list[tuple]:
         """Get all users and their roles for a tenant via 3-way JOIN.
@@ -81,11 +51,3 @@ class TenantRepository:
         )
         result = await self._session.execute(stmt)
         return list(result.all())
-
-    async def commit(self) -> None:
-        """Commit the current transaction."""
-        await self._session.commit()
-
-    async def rollback(self) -> None:
-        """Roll back the current transaction."""
-        await self._session.rollback()

--- a/backend/app/repositories/user.py
+++ b/backend/app/repositories/user.py
@@ -9,15 +9,10 @@ from __future__ import annotations
 import uuid
 
 import sqlalchemy as sa
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.identity.assignment import UserTenantRole
 from app.models.identity.user import User, UserStatus
-
-
-class RepositoryConflictError(Exception):
-    """Raised when a database constraint violation indicates a conflict."""
+from app.repositories.base import BaseRepository
 
 
 def _escape_like(value: str) -> str:
@@ -25,49 +20,19 @@ def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
-class UserRepository:
+class UserRepository(BaseRepository[User]):
     """Repository for User table operations.
 
     Takes AsyncSession via constructor injection (inner layer of onion architecture).
     """
 
-    def __init__(self, session: AsyncSession) -> None:
-        self._session = session
-
-    async def create(self, user: User) -> User:
-        """Add a new user to the session and flush to generate defaults.
-
-        Raises RepositoryConflictError if a uniqueness constraint is violated.
-        """
-        self._session.add(user)
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            await self._session.rollback()
-            raise RepositoryConflictError(str(exc)) from exc
-        return user
-
-    async def get(self, user_id: uuid.UUID) -> User | None:
-        """Fetch a user by primary key. Returns None if not found."""
-        return await self._session.get(User, user_id)
+    _model = User
 
     async def get_by_email(self, email: str) -> User | None:
         """Fetch a user by email address. Returns None if not found."""
         stmt = sa.select(User).where(User.email == email)
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none()
-
-    async def update(self, user: User) -> User:
-        """Flush updated user state.
-
-        Raises RepositoryConflictError if a uniqueness constraint is violated.
-        """
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            await self._session.rollback()
-            raise RepositoryConflictError(str(exc)) from exc
-        return user
 
     async def search(
         self,
@@ -127,11 +92,3 @@ class UserRepository:
         )
         result = await self._session.execute(stmt)
         return bool(result.scalar())
-
-    async def commit(self) -> None:
-        """Commit the current transaction."""
-        await self._session.commit()
-
-    async def rollback(self) -> None:
-        """Roll back the current transaction."""
-        await self._session.rollback()

--- a/backend/app/services/idp_link.py
+++ b/backend/app/services/idp_link.py
@@ -15,9 +15,10 @@ from opentelemetry import trace
 
 from app.errors.identity import Conflict, IdentityError, NotFound
 from app.models.identity.user import IdPLink
+from app.repositories.base import RepositoryConflictError
 from app.repositories.idp_link import IdPLinkRepository
 from app.repositories.provider import ProviderRepository
-from app.repositories.user import RepositoryConflictError, UserRepository
+from app.repositories.user import UserRepository
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)

--- a/backend/app/services/inbound_sync.py
+++ b/backend/app/services/inbound_sync.py
@@ -16,9 +16,10 @@ from opentelemetry import trace
 from app.errors.identity import Conflict, IdentityError, NotFound, ValidationError
 from app.models.identity.provider import ProviderType
 from app.models.identity.user import IdPLink, User, UserStatus
+from app.repositories.base import RepositoryConflictError
 from app.repositories.idp_link import IdPLinkRepository
 from app.repositories.provider import ProviderRepository
-from app.repositories.user import RepositoryConflictError, UserRepository
+from app.repositories.user import UserRepository
 from app.services.cache_invalidation import CacheInvalidationPublisher
 
 logger = logging.getLogger(__name__)

--- a/backend/app/services/permission.py
+++ b/backend/app/services/permission.py
@@ -15,8 +15,8 @@ from opentelemetry import trace
 
 from app.errors.identity import Conflict, IdentityError, NotFound
 from app.models.identity.role import Permission
+from app.repositories.base import RepositoryConflictError
 from app.repositories.permission import PermissionRepository
-from app.repositories.user import RepositoryConflictError
 from app.services.adapters.base import IdentityProviderAdapter, SyncError
 from app.services.cache_invalidation import CacheInvalidationPublisher
 

--- a/backend/app/services/provider.py
+++ b/backend/app/services/provider.py
@@ -15,8 +15,8 @@ from opentelemetry import trace
 
 from app.errors.identity import Conflict, IdentityError, NotFound
 from app.models.identity.provider import Provider, ProviderType
+from app.repositories.base import RepositoryConflictError
 from app.repositories.provider import ProviderRepository
-from app.repositories.user import RepositoryConflictError
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)

--- a/backend/app/services/reconciliation.py
+++ b/backend/app/services/reconciliation.py
@@ -25,12 +25,13 @@ from app.models.identity.provider import ProviderType
 from app.models.identity.role import Permission, Role
 from app.models.identity.tenant import Tenant, TenantStatus
 from app.models.identity.user import IdPLink, User, UserStatus
+from app.repositories.base import RepositoryConflictError
 from app.repositories.idp_link import IdPLinkRepository
 from app.repositories.permission import PermissionRepository
 from app.repositories.provider import ProviderRepository
 from app.repositories.role import RoleRepository
 from app.repositories.tenant import TenantRepository
-from app.repositories.user import RepositoryConflictError, UserRepository
+from app.repositories.user import UserRepository
 from app.services.cache_invalidation import CacheInvalidationPublisher
 from app.services.descope import DescopeManagementClient
 

--- a/backend/app/services/role.py
+++ b/backend/app/services/role.py
@@ -18,9 +18,9 @@ from app.errors.identity import Conflict, IdentityError, NotFound
 from app.models.identity.assignment import UserTenantRole
 from app.models.identity.role import Role
 from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.base import RepositoryConflictError
 from app.repositories.permission import PermissionRepository
 from app.repositories.role import RoleRepository
-from app.repositories.user import RepositoryConflictError
 from app.services.adapters.base import IdentityProviderAdapter, SyncError
 from app.services.cache_invalidation import CacheInvalidationPublisher
 

--- a/backend/app/services/tenant.py
+++ b/backend/app/services/tenant.py
@@ -15,8 +15,8 @@ from opentelemetry import trace
 
 from app.errors.identity import Conflict, IdentityError, NotFound
 from app.models.identity.tenant import Tenant
+from app.repositories.base import RepositoryConflictError
 from app.repositories.tenant import TenantRepository
-from app.repositories.user import RepositoryConflictError
 from app.services.adapters.base import IdentityProviderAdapter, SyncError
 from app.services.cache_invalidation import CacheInvalidationPublisher
 

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -16,7 +16,8 @@ from opentelemetry import trace
 from app.errors.identity import Conflict, Forbidden, IdentityError, NotFound
 from app.models.identity.user import User, UserStatus
 from app.repositories.assignment import UserTenantRoleRepository
-from app.repositories.user import RepositoryConflictError, UserRepository
+from app.repositories.base import RepositoryConflictError
+from app.repositories.user import UserRepository
 from app.services.adapters.base import IdentityProviderAdapter, SyncError
 from app.services.cache_invalidation import CacheInvalidationPublisher
 

--- a/backend/tests/e2e/helpers/api.py
+++ b/backend/tests/e2e/helpers/api.py
@@ -1,0 +1,12 @@
+"""Shared E2E API test helpers — unique names and constants."""
+
+import uuid
+
+
+def unique_name(prefix: str) -> str:
+    """Generate a unique name for test resources to avoid collisions."""
+    return f"{prefix}-e2e-{uuid.uuid4().hex[:8]}"
+
+
+# Alias used by FGA and document tests.
+unique_id = unique_name

--- a/backend/tests/e2e/helpers/api.py
+++ b/backend/tests/e2e/helpers/api.py
@@ -6,7 +6,3 @@ import uuid
 def unique_name(prefix: str) -> str:
     """Generate a unique name for test resources to avoid collisions."""
     return f"{prefix}-e2e-{uuid.uuid4().hex[:8]}"
-
-
-# Alias used by FGA and document tests.
-unique_id = unique_name

--- a/backend/tests/e2e/test_async_db_migration.py
+++ b/backend/tests/e2e/test_async_db_migration.py
@@ -18,40 +18,14 @@ Requires DESCOPE_CLIENT_ID/DESCOPE_CLIENT_SECRET for auth-level tests.
 
 import contextlib
 import os
-import time
-import uuid
 
 import pytest
 from playwright.sync_api import APIRequestContext
 
-MAX_API_RESPONSE_MS = 2000
+from tests.e2e.helpers.api import unique_name
+
 _DUMMY_UUID = "00000000-0000-0000-0000-000000000000"
 _NONEXISTENT_UUID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
-
-
-def _unique_name(prefix: str) -> str:
-    """Generate a unique name for test resources to avoid collisions."""
-    return f"{prefix}-e2e-{uuid.uuid4().hex[:8]}"
-
-
-def _timed_request(context: APIRequestContext, method: str, url: str, **kwargs) -> tuple:
-    """Execute a request and return (response, elapsed_ms)."""
-    method = method.upper()
-    start = time.monotonic()
-    if method == "GET":
-        resp = context.get(url, **kwargs)
-    elif method == "POST":
-        resp = context.post(url, **kwargs)
-    elif method == "PUT":
-        resp = context.put(url, **kwargs)
-    elif method == "DELETE":
-        resp = context.delete(url, **kwargs)
-    else:
-        raise ValueError(f"Unsupported method: {method}")
-    elapsed_ms = (time.monotonic() - start) * 1000
-    if not (200 <= resp.status < 300):
-        print(f"[E2E] {method} {url} -> {resp.status}: {resp.text()}")
-    return resp, elapsed_ms
 
 
 # ---------------------------------------------------------------------------
@@ -64,17 +38,15 @@ class TestAsyncHealthCheck:
 
     def test_health_returns_ok_with_async_db(self, api_context: APIRequestContext, backend_url: str):
         """Health endpoint returns 200, proving async engine connected during lifespan startup."""
-        resp, elapsed_ms = _timed_request(api_context, "GET", f"{backend_url}/api/health")
+        resp = api_context.get(f"{backend_url}/api/health")
         assert resp.status == 200
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         body = resp.json()
         assert body["status"] == "ok"
 
     def test_openapi_schema_loads_with_async_routers(self, api_context: APIRequestContext, backend_url: str):
         """OpenAPI schema generation succeeds with async route handlers."""
-        resp, elapsed_ms = _timed_request(api_context, "GET", f"{backend_url}/openapi.json")
+        resp = api_context.get(f"{backend_url}/openapi.json")
         assert resp.status == 200
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         body = resp.json()
         # Verify document and tenant paths are registered (async routers loaded)
         assert "/api/documents" in body["paths"]
@@ -140,9 +112,8 @@ class TestAsyncTenantEndpoints:
 
     def test_list_tenants_returns_list(self, auth_api_context: APIRequestContext, backend_url: str):
         """GET /api/tenants returns tenant list from JWT claims (no DB hit, but validates async middleware chain)."""
-        resp, elapsed_ms = _timed_request(auth_api_context, "GET", f"{backend_url}/api/tenants")
+        resp = auth_api_context.get(f"{backend_url}/api/tenants")
         assert resp.status == 200
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         body = resp.json()
         assert "tenants" in body
         assert isinstance(body["tenants"], list)
@@ -152,9 +123,8 @@ class TestAsyncTenantEndpoints:
 
         Returns 200 (with tenant info) or 403 (no dct claim) — never 500.
         """
-        resp, elapsed_ms = _timed_request(auth_api_context, "GET", f"{backend_url}/api/tenants/current")
+        resp = auth_api_context.get(f"{backend_url}/api/tenants/current")
         assert resp.status < 500, f"/api/tenants/current returned {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
 
 @pytest.mark.skipif(
@@ -168,12 +138,9 @@ class TestAsyncTenantResourcesCRUD:
         self, admin_api_context: APIRequestContext, backend_url: str, test_tenant_id: str
     ):
         """GET /api/tenants/{id}/resources returns list via async session, never 5xx."""
-        resp, elapsed_ms = _timed_request(
-            admin_api_context, "GET", f"{backend_url}/api/tenants/{test_tenant_id}/resources"
-        )
+        resp = admin_api_context.get(f"{backend_url}/api/tenants/{test_tenant_id}/resources")
         # 200 (success) or 403 (not a member) — never 500 from async session errors
         assert resp.status in (200, 403), f"Expected 200 or 403, got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         if resp.status == 200:
             body = resp.json()
             assert "resources" in body
@@ -183,13 +150,11 @@ class TestAsyncTenantResourcesCRUD:
         self, admin_api_context: APIRequestContext, backend_url: str, test_tenant_id: str
     ):
         """POST then GET tenant resources — verifies async session.add() + commit() + refresh()."""
-        resource_name = _unique_name("res")
+        resource_name = unique_name("res")
         base = f"{backend_url}/api/tenants/{test_tenant_id}/resources"
 
         # Create resource
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             base,
             data={"name": resource_name, "description": "E2E async migration test"},
         )
@@ -199,16 +164,14 @@ class TestAsyncTenantResourcesCRUD:
         if resp.status == 409:
             pytest.skip("Resource name collision — retry would need different name")
         assert resp.status in (200, 201), f"Create resource failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
         created = resp.json()
         assert "id" in created
         assert created["name"] == resource_name
 
         # Verify it appears in list
-        resp, elapsed_ms = _timed_request(admin_api_context, "GET", base)
+        resp = admin_api_context.get(base)
         assert resp.status == 200
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         resources = resp.json().get("resources", [])
         resource_names = [r["name"] for r in resources]
         assert resource_name in resource_names, f"Created resource '{resource_name}' not found in list response"
@@ -217,13 +180,11 @@ class TestAsyncTenantResourcesCRUD:
         self, admin_api_context: APIRequestContext, backend_url: str, test_tenant_id: str
     ):
         """Duplicate resource name returns 409 — verifies async IntegrityError handling."""
-        resource_name = _unique_name("dup-res")
+        resource_name = unique_name("dup-res")
         base = f"{backend_url}/api/tenants/{test_tenant_id}/resources"
 
         # Create first
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             base,
             data={"name": resource_name, "description": "first"},
         )
@@ -234,14 +195,11 @@ class TestAsyncTenantResourcesCRUD:
 
         try:
             # Duplicate should fail with 409
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 base,
                 data={"name": resource_name, "description": "duplicate"},
             )
             assert resp.status == 409, f"Duplicate create should return 409, got {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
         finally:
             # No delete endpoint for tenant resources — cleanup is best-effort via test isolation
             pass
@@ -266,10 +224,8 @@ class TestAsyncDocumentCRUD:
 
     def _create_doc(self, ctx: APIRequestContext, base: str, title: str = "") -> dict | None:
         """Create a document and return its data, or None if FGA not operational."""
-        title = title or _unique_name("doc")
-        resp, _ = _timed_request(
-            ctx, "POST", f"{base}/api/documents", data={"title": title, "content": "E2E async test"}
-        )
+        title = title or unique_name("doc")
+        resp = ctx.post(f"{base}/api/documents", data={"title": title, "content": "E2E async test"})
         if resp.status == 502:
             return None  # FGA not operational
         if resp.status != 201:
@@ -285,17 +241,14 @@ class TestAsyncDocumentCRUD:
 
     def test_create_document_returns_201(self, admin_api_context: APIRequestContext, backend_url: str):
         """POST /api/documents creates document via async session.add() + commit()."""
-        title = _unique_name("create-doc")
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        title = unique_name("create-doc")
+        resp = admin_api_context.post(
             f"{backend_url}/api/documents",
             data={"title": title, "content": "Async migration test content"},
         )
         if resp.status == 502:
             pytest.skip("FGA not operational — document creation requires FGA")
         assert resp.status == 201, f"Create document failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
         body = resp.json()
         assert "id" in body
@@ -313,9 +266,8 @@ class TestAsyncDocumentCRUD:
         doc_id = doc["id"]
 
         try:
-            resp, elapsed_ms = _timed_request(admin_api_context, "GET", f"{backend_url}/api/documents")
+            resp = admin_api_context.get(f"{backend_url}/api/documents")
             assert resp.status == 200
-            assert elapsed_ms < MAX_API_RESPONSE_MS
             body = resp.json()
             assert "documents" in body
             assert isinstance(body["documents"], list)
@@ -332,9 +284,8 @@ class TestAsyncDocumentCRUD:
         doc_id = doc["id"]
 
         try:
-            resp, elapsed_ms = _timed_request(admin_api_context, "GET", f"{backend_url}/api/documents/{doc_id}")
+            resp = admin_api_context.get(f"{backend_url}/api/documents/{doc_id}")
             assert resp.status == 200, f"Get document failed: {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
             body = resp.json()
             assert body["id"] == doc_id
             assert body["title"] == doc["title"]
@@ -349,21 +300,18 @@ class TestAsyncDocumentCRUD:
         doc_id = doc["id"]
 
         try:
-            new_title = _unique_name("updated-doc")
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "PUT",
+            new_title = unique_name("updated-doc")
+            resp = admin_api_context.put(
                 f"{backend_url}/api/documents/{doc_id}",
                 data={"title": new_title, "content": "Updated async content"},
             )
             assert resp.status == 200, f"Update document failed: {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
             body = resp.json()
             assert body["title"] == new_title
             assert body["content"] == "Updated async content"
 
             # Verify persistence via GET
-            resp, _ = _timed_request(admin_api_context, "GET", f"{backend_url}/api/documents/{doc_id}")
+            resp = admin_api_context.get(f"{backend_url}/api/documents/{doc_id}")
             assert resp.status == 200
             assert resp.json()["title"] == new_title
         finally:
@@ -376,15 +324,14 @@ class TestAsyncDocumentCRUD:
             pytest.skip("FGA not operational — document creation failed")
         doc_id = doc["id"]
 
-        resp, elapsed_ms = _timed_request(admin_api_context, "DELETE", f"{backend_url}/api/documents/{doc_id}")
+        resp = admin_api_context.delete(f"{backend_url}/api/documents/{doc_id}")
         assert resp.status == 200, f"Delete document failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         body = resp.json()
         assert body["status"] == "deleted"
         assert body["id"] == doc_id
 
         # Verify document is gone (GET should return 403 from FGA or 404)
-        resp, _ = _timed_request(admin_api_context, "GET", f"{backend_url}/api/documents/{doc_id}")
+        resp = admin_api_context.get(f"{backend_url}/api/documents/{doc_id}")
         assert resp.status in (403, 404), f"Deleted document should not be accessible, got {resp.status}"
 
     def test_full_document_lifecycle(self, admin_api_context: APIRequestContext, backend_url: str):
@@ -393,12 +340,10 @@ class TestAsyncDocumentCRUD:
         Exercises every async session operation in sequence to verify no
         session state leaks between operations.
         """
-        title = _unique_name("lifecycle-doc")
+        title = unique_name("lifecycle-doc")
 
         # Create
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/documents",
             data={"title": title, "content": "lifecycle start"},
         )
@@ -409,15 +354,13 @@ class TestAsyncDocumentCRUD:
 
         try:
             # Get
-            resp, _ = _timed_request(admin_api_context, "GET", f"{backend_url}/api/documents/{doc_id}")
+            resp = admin_api_context.get(f"{backend_url}/api/documents/{doc_id}")
             assert resp.status == 200
             assert resp.json()["title"] == title
 
             # Update
             updated_title = title + "-updated"
-            resp, _ = _timed_request(
-                admin_api_context,
-                "PUT",
+            resp = admin_api_context.put(
                 f"{backend_url}/api/documents/{doc_id}",
                 data={"title": updated_title},
             )
@@ -425,7 +368,7 @@ class TestAsyncDocumentCRUD:
             assert resp.json()["title"] == updated_title
 
             # List (verify updated title appears)
-            resp, _ = _timed_request(admin_api_context, "GET", f"{backend_url}/api/documents")
+            resp = admin_api_context.get(f"{backend_url}/api/documents")
             assert resp.status == 200
             docs = resp.json().get("documents", [])
             matching = [d for d in docs if d["id"] == doc_id]
@@ -433,7 +376,7 @@ class TestAsyncDocumentCRUD:
             assert matching[0]["title"] == updated_title
 
             # Delete
-            resp, _ = _timed_request(admin_api_context, "DELETE", f"{backend_url}/api/documents/{doc_id}")
+            resp = admin_api_context.delete(f"{backend_url}/api/documents/{doc_id}")
             assert resp.status == 200
             doc_id = None  # Mark as deleted so finally block skips cleanup
         finally:
@@ -459,49 +402,38 @@ class TestAsyncErrorResponses:
         FGA check runs before DB lookup — may return 403 (no FGA relation) or
         404 (not found in DB). Either way, response must have 'detail' field.
         """
-        resp, elapsed_ms = _timed_request(admin_api_context, "GET", f"{backend_url}/api/documents/{_NONEXISTENT_UUID}")
+        resp = admin_api_context.get(f"{backend_url}/api/documents/{_NONEXISTENT_UUID}")
         assert resp.status in (403, 404), f"Expected 403 or 404, got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         body = resp.json()
         assert "detail" in body, f"Error response missing 'detail' field: {body}"
 
     def test_update_nonexistent_document_returns_error(self, admin_api_context: APIRequestContext, backend_url: str):
         """PUT /api/documents/{nonexistent} returns 403 or 404 with detail message."""
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "PUT",
+        resp = admin_api_context.put(
             f"{backend_url}/api/documents/{_NONEXISTENT_UUID}",
             data={"title": "ghost"},
         )
         assert resp.status in (403, 404), f"Expected 403 or 404, got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         body = resp.json()
         assert "detail" in body
 
     def test_delete_nonexistent_document_returns_error(self, admin_api_context: APIRequestContext, backend_url: str):
         """DELETE /api/documents/{nonexistent} returns 403 or 404 with detail message."""
-        resp, elapsed_ms = _timed_request(
-            admin_api_context, "DELETE", f"{backend_url}/api/documents/{_NONEXISTENT_UUID}"
-        )
+        resp = admin_api_context.delete(f"{backend_url}/api/documents/{_NONEXISTENT_UUID}")
         assert resp.status in (403, 404), f"Expected 403 or 404, got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         body = resp.json()
         assert "detail" in body
 
     def test_invalid_document_id_format_returns_422(self, admin_api_context: APIRequestContext, backend_url: str):
         """Non-UUID document_id returns 422 validation error (path param regex enforcement)."""
-        resp, elapsed_ms = _timed_request(admin_api_context, "GET", f"{backend_url}/api/documents/not-a-uuid")
+        resp = admin_api_context.get(f"{backend_url}/api/documents/not-a-uuid")
         assert resp.status == 422, f"Expected 422 for invalid UUID, got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
     def test_tenant_resources_nonmember_returns_403(self, admin_api_context: APIRequestContext, backend_url: str):
         """GET /api/tenants/{nonexistent}/resources returns 403 for non-member tenant."""
-        fake_tenant = _unique_name("fake-tenant")
-        resp, elapsed_ms = _timed_request(
-            admin_api_context, "GET", f"{backend_url}/api/tenants/{fake_tenant}/resources"
-        )
+        fake_tenant = unique_name("fake-tenant")
+        resp = admin_api_context.get(f"{backend_url}/api/tenants/{fake_tenant}/resources")
         assert resp.status == 403, f"Expected 403 for non-member tenant, got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         body = resp.json()
         assert "detail" in body
 
@@ -520,9 +452,7 @@ class TestAsyncDocumentValidation:
 
     def test_create_document_empty_title_rejected(self, admin_api_context: APIRequestContext, backend_url: str):
         """POST /api/documents with empty title returns 422."""
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/documents",
             data={"title": "", "content": "test"},
         )
@@ -530,9 +460,7 @@ class TestAsyncDocumentValidation:
 
     def test_create_document_missing_title_rejected(self, admin_api_context: APIRequestContext, backend_url: str):
         """POST /api/documents without title field returns 422."""
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/documents",
             data={"content": "no title"},
         )
@@ -542,9 +470,7 @@ class TestAsyncDocumentValidation:
         self, admin_api_context: APIRequestContext, backend_url: str, test_tenant_id: str
     ):
         """POST /api/tenants/{id}/resources with empty name returns 422."""
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/tenants/{test_tenant_id}/resources",
             data={"name": "", "description": "test"},
         )

--- a/backend/tests/e2e/test_documents_e2e.py
+++ b/backend/tests/e2e/test_documents_e2e.py
@@ -18,7 +18,7 @@ import os
 import pytest
 from playwright.sync_api import APIRequestContext
 
-from tests.e2e.helpers.api import unique_id
+from tests.e2e.helpers.api import unique_name
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("DESCOPE_MANAGEMENT_KEY"),
@@ -30,7 +30,7 @@ _DUMMY_UUID = "00000000-0000-0000-0000-000000000000"
 
 def _create_doc(ctx: APIRequestContext, base: str, title: str = "") -> dict | None:
     """Create a document and return its data, or None if FGA not operational."""
-    title = title or unique_id("doc")
+    title = title or unique_name("doc")
     resp = ctx.post(f"{base}/api/documents", data={"title": title, "content": "E2E test"})
     if resp.status == 502:
         return None  # FGA not operational
@@ -83,8 +83,8 @@ def test_create_document_creates_fga_owner(admin_api_context: APIRequestContext,
 
 def test_owner_has_all_permissions(admin_api_context: APIRequestContext, backend_url: str):
     """Owner should have can_view, can_edit, and can_delete permissions."""
-    resource_id = unique_id("perm-doc")
-    target = unique_id("user")
+    resource_id = unique_name("perm-doc")
+    target = unique_name("user")
 
     # Create owner relation directly
     resp = admin_api_context.post(
@@ -115,8 +115,8 @@ def test_owner_has_all_permissions(admin_api_context: APIRequestContext, backend
 
 def test_editor_has_view_and_edit_not_delete(admin_api_context: APIRequestContext, backend_url: str):
     """Editor should have can_view and can_edit but NOT can_delete."""
-    resource_id = unique_id("perm-doc")
-    target = unique_id("user")
+    resource_id = unique_name("perm-doc")
+    target = unique_name("user")
 
     resp = admin_api_context.post(
         f"{backend_url}/api/fga/relations",
@@ -157,8 +157,8 @@ def test_editor_has_view_and_edit_not_delete(admin_api_context: APIRequestContex
 
 def test_viewer_has_view_only(admin_api_context: APIRequestContext, backend_url: str):
     """Viewer should have can_view but NOT can_edit or can_delete."""
-    resource_id = unique_id("perm-doc")
-    target = unique_id("user")
+    resource_id = unique_name("perm-doc")
+    target = unique_name("user")
 
     resp = admin_api_context.post(
         f"{backend_url}/api/fga/relations",
@@ -262,7 +262,7 @@ def test_permission_derivation_through_endpoints(admin_api_context: APIRequestCo
 
         # Verify FGA check confirms editor permissions are a proper subset of owner
         # An editor target should have can_view and can_edit but NOT can_delete
-        editor_target = unique_id("editor-user")
+        editor_target = unique_name("editor-user")
         resp = admin_api_context.post(
             f"{backend_url}/api/fga/relations",
             data={"resource_type": "document", "resource_id": doc_id, "relation": "editor", "target": editor_target},
@@ -396,7 +396,7 @@ def test_document_delete_cleans_fga_relations(admin_api_context: APIRequestConte
 
 def test_list_documents_returns_authorized(admin_api_context: APIRequestContext, backend_url: str):
     """GET /api/documents returns documents the caller is authorized to view."""
-    doc = _create_doc(admin_api_context, backend_url, title=unique_id("list-doc"))
+    doc = _create_doc(admin_api_context, backend_url, title=unique_name("list-doc"))
     if doc is None:
         pytest.skip("FGA not operational — document creation failed")
     doc_id = doc["id"]
@@ -417,10 +417,10 @@ def test_list_documents_returns_authorized(admin_api_context: APIRequestContext,
 def test_list_documents_excludes_unauthorized(admin_api_context: APIRequestContext, backend_url: str):
     """GET /api/documents excludes documents the caller has lost FGA access to."""
     # Create two real documents via the API (both get owner relations for the admin)
-    doc_a = _create_doc(admin_api_context, backend_url, title=unique_id("keep-doc"))
+    doc_a = _create_doc(admin_api_context, backend_url, title=unique_name("keep-doc"))
     if doc_a is None:
         pytest.skip("FGA not operational — document creation failed")
-    doc_b = _create_doc(admin_api_context, backend_url, title=unique_id("revoke-doc"))
+    doc_b = _create_doc(admin_api_context, backend_url, title=unique_name("revoke-doc"))
     if doc_b is None:
         _cleanup_doc(admin_api_context, backend_url, doc_a["id"])
         pytest.skip("FGA not operational — second document creation failed")
@@ -570,8 +570,8 @@ def test_revoke_share_denies_access(admin_api_context: APIRequestContext, backen
 
 def test_sequential_relation_revocation_no_stale_grants(admin_api_context: APIRequestContext, backend_url: str):
     """Delete→check→re-create cycles: permission check must never return true after delete."""
-    resource_id = unique_id("revoke-doc")
-    target = unique_id("user")
+    resource_id = unique_name("revoke-doc")
+    target = unique_name("user")
     base_body = {"resource_type": "document", "resource_id": resource_id, "relation": "viewer", "target": target}
 
     # Create the relation first to verify FGA is operational

--- a/backend/tests/e2e/test_documents_e2e.py
+++ b/backend/tests/e2e/test_documents_e2e.py
@@ -14,49 +14,24 @@ Known gaps (tracked):
 
 import contextlib
 import os
-import time
-import uuid
 
 import pytest
 from playwright.sync_api import APIRequestContext
+
+from tests.e2e.helpers.api import unique_id
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("DESCOPE_MANAGEMENT_KEY"),
     reason="DESCOPE_MANAGEMENT_KEY not set",
 )
 
-MAX_API_RESPONSE_MS = 2000
 _DUMMY_UUID = "00000000-0000-0000-0000-000000000000"
-
-
-def _unique_id(prefix: str) -> str:
-    return f"{prefix}-e2e-{uuid.uuid4().hex[:8]}"
-
-
-def _timed_request(context: APIRequestContext, method: str, url: str, **kwargs) -> tuple:
-    """Execute a request and return (response, elapsed_ms)."""
-    method = method.upper()
-    start = time.monotonic()
-    if method == "GET":
-        resp = context.get(url, **kwargs)
-    elif method == "POST":
-        resp = context.post(url, **kwargs)
-    elif method == "PUT":
-        resp = context.put(url, **kwargs)
-    elif method == "DELETE":
-        resp = context.delete(url, **kwargs)
-    else:
-        raise ValueError(f"Unsupported method: {method}")
-    elapsed_ms = (time.monotonic() - start) * 1000
-    if not (200 <= resp.status < 300):
-        print(f"[E2E] {method} {url} → {resp.status}: {resp.text()}")
-    return resp, elapsed_ms
 
 
 def _create_doc(ctx: APIRequestContext, base: str, title: str = "") -> dict | None:
     """Create a document and return its data, or None if FGA not operational."""
-    title = title or _unique_id("doc")
-    resp, _ = _timed_request(ctx, "POST", f"{base}/api/documents", data={"title": title, "content": "E2E test"})
+    title = title or unique_id("doc")
+    resp = ctx.post(f"{base}/api/documents", data={"title": title, "content": "E2E test"})
     if resp.status == 502:
         return None  # FGA not operational
     if resp.status != 201:
@@ -91,14 +66,11 @@ def test_create_document_creates_fga_owner(admin_api_context: APIRequestContext,
 
     try:
         # Verify owner relation via FGA admin endpoint
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "GET",
+        resp = admin_api_context.get(
             f"{backend_url}/api/fga/relations",
             params={"resource_type": "document", "resource_id": doc_id},
         )
         assert resp.status == 200
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         relations = resp.json().get("relations", [])
         owner_rels = [r for r in relations if r.get("relationDefinition") == "owner"]
         assert len(owner_rels) == 1, f"Expected exactly 1 owner relation, got {owner_rels}"
@@ -111,13 +83,11 @@ def test_create_document_creates_fga_owner(admin_api_context: APIRequestContext,
 
 def test_owner_has_all_permissions(admin_api_context: APIRequestContext, backend_url: str):
     """Owner should have can_view, can_edit, and can_delete permissions."""
-    resource_id = _unique_id("perm-doc")
-    target = _unique_id("user")
+    resource_id = unique_id("perm-doc")
+    target = unique_id("user")
 
     # Create owner relation directly
-    resp, _ = _timed_request(
-        admin_api_context,
-        "POST",
+    resp = admin_api_context.post(
         f"{backend_url}/api/fga/relations",
         data={"resource_type": "document", "resource_id": resource_id, "relation": "owner", "target": target},
     )
@@ -127,16 +97,13 @@ def test_owner_has_all_permissions(admin_api_context: APIRequestContext, backend
 
     try:
         for relation in ("can_view", "can_edit", "can_delete"):
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/fga/check",
                 data={"resource_type": "document", "resource_id": resource_id, "relation": relation, "target": target},
             )
             if resp.status == 502:
                 pytest.skip("FGA check not operational")
             assert resp.status == 200, f"Check {relation} returned {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
             _assert_fga_allowed(resp, True, f"Owner should have {relation}")
     finally:
         with contextlib.suppress(Exception):
@@ -148,12 +115,10 @@ def test_owner_has_all_permissions(admin_api_context: APIRequestContext, backend
 
 def test_editor_has_view_and_edit_not_delete(admin_api_context: APIRequestContext, backend_url: str):
     """Editor should have can_view and can_edit but NOT can_delete."""
-    resource_id = _unique_id("perm-doc")
-    target = _unique_id("user")
+    resource_id = unique_id("perm-doc")
+    target = unique_id("user")
 
-    resp, _ = _timed_request(
-        admin_api_context,
-        "POST",
+    resp = admin_api_context.post(
         f"{backend_url}/api/fga/relations",
         data={"resource_type": "document", "resource_id": resource_id, "relation": "editor", "target": target},
     )
@@ -164,9 +129,7 @@ def test_editor_has_view_and_edit_not_delete(admin_api_context: APIRequestContex
     try:
         # Editor should have can_view and can_edit
         for relation in ("can_view", "can_edit"):
-            resp, _ = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/fga/check",
                 data={"resource_type": "document", "resource_id": resource_id, "relation": relation, "target": target},
             )
@@ -176,9 +139,7 @@ def test_editor_has_view_and_edit_not_delete(admin_api_context: APIRequestContex
             _assert_fga_allowed(resp, True, f"Editor should have {relation}")
 
         # Editor should NOT have can_delete
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/fga/check",
             data={"resource_type": "document", "resource_id": resource_id, "relation": "can_delete", "target": target},
         )
@@ -196,12 +157,10 @@ def test_editor_has_view_and_edit_not_delete(admin_api_context: APIRequestContex
 
 def test_viewer_has_view_only(admin_api_context: APIRequestContext, backend_url: str):
     """Viewer should have can_view but NOT can_edit or can_delete."""
-    resource_id = _unique_id("perm-doc")
-    target = _unique_id("user")
+    resource_id = unique_id("perm-doc")
+    target = unique_id("user")
 
-    resp, _ = _timed_request(
-        admin_api_context,
-        "POST",
+    resp = admin_api_context.post(
         f"{backend_url}/api/fga/relations",
         data={"resource_type": "document", "resource_id": resource_id, "relation": "viewer", "target": target},
     )
@@ -211,9 +170,7 @@ def test_viewer_has_view_only(admin_api_context: APIRequestContext, backend_url:
 
     try:
         # Viewer should have can_view
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/fga/check",
             data={"resource_type": "document", "resource_id": resource_id, "relation": "can_view", "target": target},
         )
@@ -224,9 +181,7 @@ def test_viewer_has_view_only(admin_api_context: APIRequestContext, backend_url:
 
         # Viewer should NOT have can_edit or can_delete
         for relation in ("can_edit", "can_delete"):
-            resp, _ = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/fga/check",
                 data={
                     "resource_type": "document",
@@ -258,9 +213,8 @@ def test_document_get_allowed_for_owner(admin_api_context: APIRequestContext, ba
     doc_id = doc["id"]
 
     try:
-        resp, elapsed_ms = _timed_request(admin_api_context, "GET", f"{backend_url}/api/documents/{doc_id}")
+        resp = admin_api_context.get(f"{backend_url}/api/documents/{doc_id}")
         assert resp.status == 200, f"Owner should be able to view document, got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         assert resp.json()["id"] == doc_id
     finally:
         _cleanup_doc(admin_api_context, backend_url, doc_id)
@@ -274,14 +228,11 @@ def test_document_update_allowed_for_owner(admin_api_context: APIRequestContext,
     doc_id = doc["id"]
 
     try:
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "PUT",
+        resp = admin_api_context.put(
             f"{backend_url}/api/documents/{doc_id}",
             data={"title": "Updated E2E Title"},
         )
         assert resp.status == 200, f"Owner should be able to edit document, got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         assert resp.json()["title"] == "Updated E2E Title"
     finally:
         _cleanup_doc(admin_api_context, backend_url, doc_id)
@@ -302,22 +253,17 @@ def test_permission_derivation_through_endpoints(admin_api_context: APIRequestCo
 
     try:
         # Owner can edit via PUT (require_fga checks can_edit)
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "PUT",
+        resp = admin_api_context.put(
             f"{backend_url}/api/documents/{doc_id}",
             data={"title": "Derivation Test Updated"},
         )
         assert resp.status == 200, f"Owner PUT should succeed (can_edit derived from owner), got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         assert resp.json()["title"] == "Derivation Test Updated"
 
         # Verify FGA check confirms editor permissions are a proper subset of owner
         # An editor target should have can_view and can_edit but NOT can_delete
-        editor_target = _unique_id("editor-user")
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        editor_target = unique_id("editor-user")
+        resp = admin_api_context.post(
             f"{backend_url}/api/fga/relations",
             data={"resource_type": "document", "resource_id": doc_id, "relation": "editor", "target": editor_target},
         )
@@ -334,9 +280,7 @@ def test_permission_derivation_through_endpoints(admin_api_context: APIRequestCo
                     "relation": relation,
                     "target": editor_target,
                 }
-                resp, _ = _timed_request(
-                    admin_api_context,
-                    "POST",
+                resp = admin_api_context.post(
                     f"{backend_url}/api/fga/check",
                     data=check_data,
                 )
@@ -352,9 +296,7 @@ def test_permission_derivation_through_endpoints(admin_api_context: APIRequestCo
                 "relation": "can_delete",
                 "target": editor_target,
             }
-            resp, _ = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/fga/check",
                 data=check_data,
             )
@@ -376,9 +318,8 @@ def test_permission_derivation_through_endpoints(admin_api_context: APIRequestCo
                 )
 
         # Owner can delete via DELETE (require_fga checks can_delete)
-        resp, elapsed_ms = _timed_request(admin_api_context, "DELETE", f"{backend_url}/api/documents/{doc_id}")
+        resp = admin_api_context.delete(f"{backend_url}/api/documents/{doc_id}")
         assert resp.status == 200, f"Owner DELETE should succeed (can_delete derived from owner), got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         doc_id = None  # Mark as already deleted so finally block skips cleanup
     finally:
         if doc_id is not None:
@@ -393,9 +334,7 @@ def test_document_fga_denies_without_relation(admin_api_context: APIRequestConte
     doc_id = doc["id"]
 
     # Find the owner relation target (the admin user's ID in FGA)
-    resp, _ = _timed_request(
-        admin_api_context,
-        "GET",
+    resp = admin_api_context.get(
         f"{backend_url}/api/fga/relations",
         params={"resource_type": "document", "resource_id": doc_id},
     )
@@ -407,23 +346,19 @@ def test_document_fga_denies_without_relation(admin_api_context: APIRequestConte
 
     try:
         # Remove owner relation
-        resp, _ = _timed_request(
-            admin_api_context,
-            "DELETE",
+        resp = admin_api_context.delete(
             f"{backend_url}/api/fga/relations",
             data={"resource_type": "document", "resource_id": doc_id, "relation": "owner", "target": owner_target},
         )
         assert resp.status == 200, f"Failed to delete owner relation: {resp.status}"
 
         # Now GET should be denied (403 from require_fga)
-        resp, _ = _timed_request(admin_api_context, "GET", f"{backend_url}/api/documents/{doc_id}")
+        resp = admin_api_context.get(f"{backend_url}/api/documents/{doc_id}")
         assert resp.status == 403, f"Should be denied without FGA relation, got {resp.status}"
     finally:
         # Re-create owner relation so cleanup can delete the document
         with contextlib.suppress(Exception):
-            _timed_request(
-                admin_api_context,
-                "POST",
+            admin_api_context.post(
                 f"{backend_url}/api/fga/relations",
                 data={
                     "resource_type": "document",
@@ -443,14 +378,11 @@ def test_document_delete_cleans_fga_relations(admin_api_context: APIRequestConte
     doc_id = doc["id"]
 
     # Delete document (owner can delete)
-    resp, elapsed_ms = _timed_request(admin_api_context, "DELETE", f"{backend_url}/api/documents/{doc_id}")
+    resp = admin_api_context.delete(f"{backend_url}/api/documents/{doc_id}")
     assert resp.status == 200, f"Owner should be able to delete document, got {resp.status}"
-    assert elapsed_ms < MAX_API_RESPONSE_MS
 
     # Verify FGA relations are cleaned up
-    resp, _ = _timed_request(
-        admin_api_context,
-        "GET",
+    resp = admin_api_context.get(
         f"{backend_url}/api/fga/relations",
         params={"resource_type": "document", "resource_id": doc_id},
     )
@@ -464,15 +396,14 @@ def test_document_delete_cleans_fga_relations(admin_api_context: APIRequestConte
 
 def test_list_documents_returns_authorized(admin_api_context: APIRequestContext, backend_url: str):
     """GET /api/documents returns documents the caller is authorized to view."""
-    doc = _create_doc(admin_api_context, backend_url, title=_unique_id("list-doc"))
+    doc = _create_doc(admin_api_context, backend_url, title=unique_id("list-doc"))
     if doc is None:
         pytest.skip("FGA not operational — document creation failed")
     doc_id = doc["id"]
 
     try:
-        resp, elapsed_ms = _timed_request(admin_api_context, "GET", f"{backend_url}/api/documents")
+        resp = admin_api_context.get(f"{backend_url}/api/documents")
         assert resp.status == 200
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         body = resp.json()
         assert isinstance(body, dict), f"Expected dict response, got {type(body)}"
         documents = body.get("documents")
@@ -486,10 +417,10 @@ def test_list_documents_returns_authorized(admin_api_context: APIRequestContext,
 def test_list_documents_excludes_unauthorized(admin_api_context: APIRequestContext, backend_url: str):
     """GET /api/documents excludes documents the caller has lost FGA access to."""
     # Create two real documents via the API (both get owner relations for the admin)
-    doc_a = _create_doc(admin_api_context, backend_url, title=_unique_id("keep-doc"))
+    doc_a = _create_doc(admin_api_context, backend_url, title=unique_id("keep-doc"))
     if doc_a is None:
         pytest.skip("FGA not operational — document creation failed")
-    doc_b = _create_doc(admin_api_context, backend_url, title=_unique_id("revoke-doc"))
+    doc_b = _create_doc(admin_api_context, backend_url, title=unique_id("revoke-doc"))
     if doc_b is None:
         _cleanup_doc(admin_api_context, backend_url, doc_a["id"])
         pytest.skip("FGA not operational — second document creation failed")
@@ -498,9 +429,7 @@ def test_list_documents_excludes_unauthorized(admin_api_context: APIRequestConte
     doc_b_id = doc_b["id"]
 
     # Find the owner relation target for doc_b so we can revoke it
-    resp, _ = _timed_request(
-        admin_api_context,
-        "GET",
+    resp = admin_api_context.get(
         f"{backend_url}/api/fga/relations",
         params={"resource_type": "document", "resource_id": doc_b_id},
     )
@@ -512,16 +441,14 @@ def test_list_documents_excludes_unauthorized(admin_api_context: APIRequestConte
 
     try:
         # Remove the owner relation for doc_b (admin loses FGA access)
-        resp, _ = _timed_request(
-            admin_api_context,
-            "DELETE",
+        resp = admin_api_context.delete(
             f"{backend_url}/api/fga/relations",
             data={"resource_type": "document", "resource_id": doc_b_id, "relation": "owner", "target": owner_target},
         )
         assert resp.status == 200, f"Failed to delete owner relation for doc_b: {resp.status}"
 
         # List documents — doc_a should appear, doc_b should NOT
-        resp, _ = _timed_request(admin_api_context, "GET", f"{backend_url}/api/documents")
+        resp = admin_api_context.get(f"{backend_url}/api/documents")
         assert resp.status == 200
         documents = resp.json().get("documents", [])
         doc_ids = [d["id"] for d in documents]
@@ -530,9 +457,7 @@ def test_list_documents_excludes_unauthorized(admin_api_context: APIRequestConte
     finally:
         # Re-create owner relation for doc_b so cleanup can delete it
         with contextlib.suppress(Exception):
-            _timed_request(
-                admin_api_context,
-                "POST",
+            admin_api_context.post(
                 f"{backend_url}/api/fga/relations",
                 data={
                     "resource_type": "document",
@@ -557,9 +482,7 @@ def test_share_document_grants_access(admin_api_context: APIRequestContext, back
 
     try:
         # Share with test user as viewer
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/documents/{doc_id}/share",
             data={"user_id": test_user_id, "relation": "viewer"},
         )
@@ -570,9 +493,7 @@ def test_share_document_grants_access(admin_api_context: APIRequestContext, back
         assert resp.status == 200, f"Share failed: {resp.status}"
 
         # Verify via FGA check that the target user now has can_view
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/fga/check",
             data={"resource_type": "document", "resource_id": doc_id, "relation": "can_view", "target": test_user_id},
         )
@@ -599,9 +520,7 @@ def test_revoke_share_denies_access(admin_api_context: APIRequestContext, backen
 
     try:
         # Share first
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/documents/{doc_id}/share",
             data={"user_id": test_user_id, "relation": "viewer"},
         )
@@ -610,9 +529,7 @@ def test_revoke_share_denies_access(admin_api_context: APIRequestContext, backen
         assert resp.status == 200, f"Share failed: {resp.status}"
 
         # Verify access granted
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/fga/check",
             data={"resource_type": "document", "resource_id": doc_id, "relation": "can_view", "target": test_user_id},
         )
@@ -622,9 +539,7 @@ def test_revoke_share_denies_access(admin_api_context: APIRequestContext, backen
         _assert_fga_allowed(resp, True, "User should have access after share")
 
         # Revoke
-        resp, _ = _timed_request(
-            admin_api_context,
-            "DELETE",
+        resp = admin_api_context.delete(
             f"{backend_url}/api/documents/{doc_id}/share/{test_user_id}",
         )
         if resp.status == 403:
@@ -632,9 +547,7 @@ def test_revoke_share_denies_access(admin_api_context: APIRequestContext, backen
         assert resp.status == 200, f"Revoke failed: {resp.status}"
 
         # Verify access denied
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/fga/check",
             data={"resource_type": "document", "resource_id": doc_id, "relation": "can_view", "target": test_user_id},
         )
@@ -657,12 +570,12 @@ def test_revoke_share_denies_access(admin_api_context: APIRequestContext, backen
 
 def test_sequential_relation_revocation_no_stale_grants(admin_api_context: APIRequestContext, backend_url: str):
     """Delete→check→re-create cycles: permission check must never return true after delete."""
-    resource_id = _unique_id("revoke-doc")
-    target = _unique_id("user")
+    resource_id = unique_id("revoke-doc")
+    target = unique_id("user")
     base_body = {"resource_type": "document", "resource_id": resource_id, "relation": "viewer", "target": target}
 
     # Create the relation first to verify FGA is operational
-    resp, _ = _timed_request(admin_api_context, "POST", f"{backend_url}/api/fga/relations", data=base_body)
+    resp = admin_api_context.post(f"{backend_url}/api/fga/relations", data=base_body)
     if resp.status in (400, 502):
         pytest.skip(f"FGA not operational (status {resp.status})")
     assert resp.status == 201
@@ -671,13 +584,11 @@ def test_sequential_relation_revocation_no_stale_grants(admin_api_context: APIRe
         # Cycles: delete then immediately check — should never get allowed=true after delete
         for _ in range(3):
             # Delete
-            resp, _ = _timed_request(admin_api_context, "DELETE", f"{backend_url}/api/fga/relations", data=base_body)
+            resp = admin_api_context.delete(f"{backend_url}/api/fga/relations", data=base_body)
             assert resp.status == 200
 
             # Immediate check — must not be allowed
-            resp, _ = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/fga/check",
                 data={
                     "resource_type": "document",
@@ -692,7 +603,7 @@ def test_sequential_relation_revocation_no_stale_grants(admin_api_context: APIRe
             _assert_fga_allowed(resp, False, "Should be denied after relation deleted")
 
             # Re-create for next cycle
-            resp, _ = _timed_request(admin_api_context, "POST", f"{backend_url}/api/fga/relations", data=base_body)
+            resp = admin_api_context.post(f"{backend_url}/api/fga/relations", data=base_body)
             assert resp.status == 201
     finally:
         # Cleanup

--- a/backend/tests/e2e/test_fga_api.py
+++ b/backend/tests/e2e/test_fga_api.py
@@ -7,43 +7,16 @@ They exercise the real Descope FGA API via the backend's /api/fga/* endpoints.
 import contextlib
 import json
 import os
-import time
-import uuid
 
 import pytest
 from playwright.sync_api import APIRequestContext
+
+from tests.e2e.helpers.api import unique_id
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("DESCOPE_MANAGEMENT_KEY"),
     reason="DESCOPE_MANAGEMENT_KEY not set",
 )
-
-MAX_API_RESPONSE_MS = 2000
-
-
-def _unique_id(prefix: str) -> str:
-    """Generate a unique ID for test resources."""
-    return f"{prefix}-e2e-{uuid.uuid4().hex[:8]}"
-
-
-def _timed_request(context: APIRequestContext, method: str, url: str, **kwargs) -> tuple:
-    """Execute a request and return (response, elapsed_ms)."""
-    method = method.upper()
-    start = time.monotonic()
-    if method == "GET":
-        resp = context.get(url, **kwargs)
-    elif method == "POST":
-        resp = context.post(url, **kwargs)
-    elif method == "PUT":
-        resp = context.put(url, **kwargs)
-    elif method == "DELETE":
-        resp = context.delete(url, **kwargs)
-    else:
-        raise ValueError(f"Unsupported method: {method}")
-    elapsed_ms = (time.monotonic() - start) * 1000
-    if not (200 <= resp.status < 300):
-        print(f"[E2E] {method} {url} → {resp.status}: {resp.text()}")
-    return resp, elapsed_ms
 
 
 # --- AC-1: Schema retrieval ---
@@ -51,9 +24,8 @@ def _timed_request(context: APIRequestContext, method: str, url: str, **kwargs) 
 
 def test_get_fga_schema(admin_api_context: APIRequestContext, backend_url: str):
     """GET /api/fga/schema returns current schema (may be empty for fresh project)."""
-    resp, elapsed_ms = _timed_request(admin_api_context, "GET", f"{backend_url}/api/fga/schema")
+    resp = admin_api_context.get(f"{backend_url}/api/fga/schema")
     assert resp.status == 200, f"Expected 200, got {resp.status}"
-    assert elapsed_ms < MAX_API_RESPONSE_MS
 
     body = resp.json()
     assert "schema" in body
@@ -66,18 +38,16 @@ def test_get_fga_schema(admin_api_context: APIRequestContext, backend_url: str):
 
 def test_relation_create_and_delete(admin_api_context: APIRequestContext, backend_url: str):
     """Relation can be created and deleted via API."""
-    resource_id = _unique_id("doc")
+    resource_id = unique_id("doc")
     relation_body = {
         "resource_type": "document",
         "resource_id": resource_id,
         "relation": "owner",
-        "target": f"user:{_unique_id('u')}",
+        "target": f"user:{unique_id('u')}",
     }
 
     # Create relation
-    resp, elapsed_ms = _timed_request(
-        admin_api_context,
-        "POST",
+    resp = admin_api_context.post(
         f"{backend_url}/api/fga/relations",
         data=relation_body,
     )
@@ -85,29 +55,22 @@ def test_relation_create_and_delete(admin_api_context: APIRequestContext, backen
     if resp.status in (400, 502):
         pytest.skip(f"FGA not operational in this Descope project (status {resp.status})")
     assert resp.status == 201, f"Create failed: {resp.status}"
-    assert elapsed_ms < MAX_API_RESPONSE_MS
 
     # Verify via list
-    resp, elapsed_ms = _timed_request(
-        admin_api_context,
-        "GET",
+    resp = admin_api_context.get(
         f"{backend_url}/api/fga/relations",
         params={"resource_type": "document", "resource_id": resource_id},
     )
     assert resp.status == 200
-    assert elapsed_ms < MAX_API_RESPONSE_MS
     relations = resp.json().get("relations", [])
     assert any(r["target"] == relation_body["target"] for r in relations), "Created relation not found in list"
 
     # Delete relation
-    resp, elapsed_ms = _timed_request(
-        admin_api_context,
-        "DELETE",
+    resp = admin_api_context.delete(
         f"{backend_url}/api/fga/relations",
         data=relation_body,
     )
     assert resp.status == 200, f"Delete failed: {resp.status}"
-    assert elapsed_ms < MAX_API_RESPONSE_MS
 
 
 # --- AC-2: List relations ---
@@ -115,9 +78,7 @@ def test_relation_create_and_delete(admin_api_context: APIRequestContext, backen
 
 def test_list_relations_empty(admin_api_context: APIRequestContext, backend_url: str):
     """GET /api/fga/relations returns empty list or 400 for non-existent resource."""
-    resp, elapsed_ms = _timed_request(
-        admin_api_context,
-        "GET",
+    resp = admin_api_context.get(
         f"{backend_url}/api/fga/relations",
         params={"resource_type": "nonexistent", "resource_id": "nope-000"},
     )
@@ -125,7 +86,6 @@ def test_list_relations_empty(admin_api_context: APIRequestContext, backend_url:
     if resp.status == 400:
         pytest.skip("Descope API rejected request for unknown resource type")
     assert resp.status == 200
-    assert elapsed_ms < MAX_API_RESPONSE_MS
     body = resp.json()
     assert body["relations"] == []
 
@@ -135,13 +95,11 @@ def test_list_relations_empty(admin_api_context: APIRequestContext, backend_url:
 
 def test_check_permission_denied_for_nonexistent(admin_api_context: APIRequestContext, backend_url: str):
     """POST /api/fga/check returns denied for a resource with no relations."""
-    resp, elapsed_ms = _timed_request(
-        admin_api_context,
-        "POST",
+    resp = admin_api_context.post(
         f"{backend_url}/api/fga/check",
         data={
             "resource_type": "document",
-            "resource_id": _unique_id("nonexist"),
+            "resource_id": unique_id("nonexist"),
             "relation": "viewer",
             "target": "user:nobody",
         },
@@ -150,7 +108,6 @@ def test_check_permission_denied_for_nonexistent(admin_api_context: APIRequestCo
     if resp.status == 502:
         pytest.skip("FGA not configured in this Descope project")
     assert resp.status == 200, f"Expected 200, got {resp.status}"
-    assert elapsed_ms < MAX_API_RESPONSE_MS
     assert resp.json()["allowed"] is False
 
 
@@ -191,9 +148,7 @@ def test_fga_endpoints_reject_no_auth(api_context: APIRequestContext, backend_ur
 
 def test_create_relation_validation(admin_api_context: APIRequestContext, backend_url: str):
     """POST /api/fga/relations rejects empty fields."""
-    resp, _ = _timed_request(
-        admin_api_context,
-        "POST",
+    resp = admin_api_context.post(
         f"{backend_url}/api/fga/relations",
         data={"resource_type": "", "resource_id": "1", "relation": "owner", "target": "u1"},
     )
@@ -202,19 +157,13 @@ def test_create_relation_validation(admin_api_context: APIRequestContext, backen
 
 def test_list_relations_validation(admin_api_context: APIRequestContext, backend_url: str):
     """GET /api/fga/relations rejects missing query params."""
-    resp, _ = _timed_request(
-        admin_api_context,
-        "GET",
-        f"{backend_url}/api/fga/relations",
-    )
+    resp = admin_api_context.get(f"{backend_url}/api/fga/relations")
     assert resp.status == 422, f"Expected 422 for missing params, got {resp.status}"
 
 
 def test_check_permission_validation(admin_api_context: APIRequestContext, backend_url: str):
     """POST /api/fga/check rejects incomplete payload."""
-    resp, _ = _timed_request(
-        admin_api_context,
-        "POST",
+    resp = admin_api_context.post(
         f"{backend_url}/api/fga/check",
         data={"resource_type": "doc", "resource_id": "1"},
     )
@@ -226,8 +175,8 @@ def test_check_permission_validation(admin_api_context: APIRequestContext, backe
 
 def test_relation_lifecycle_with_permission_check(admin_api_context: APIRequestContext, backend_url: str):
     """Create relation → verify allowed → delete → verify denied (full lifecycle)."""
-    resource_id = _unique_id("lifecycle")
-    target = f"user:{_unique_id('u')}"
+    resource_id = unique_id("lifecycle")
+    target = f"user:{unique_id('u')}"
     relation_body = {
         "resource_type": "document",
         "resource_id": resource_id,
@@ -236,7 +185,7 @@ def test_relation_lifecycle_with_permission_check(admin_api_context: APIRequestC
     }
 
     # Create
-    resp, _ = _timed_request(admin_api_context, "POST", f"{backend_url}/api/fga/relations", data=relation_body)
+    resp = admin_api_context.post(f"{backend_url}/api/fga/relations", data=relation_body)
     if resp.status in (400, 502):
         pytest.skip(f"FGA not operational (status {resp.status})")
     assert resp.status == 201
@@ -249,21 +198,20 @@ def test_relation_lifecycle_with_permission_check(admin_api_context: APIRequestC
             "relation": "can_view",
             "target": target,
         }
-        resp, elapsed_ms = _timed_request(admin_api_context, "POST", f"{backend_url}/api/fga/check", data=check_body)
+        resp = admin_api_context.post(f"{backend_url}/api/fga/check", data=check_body)
         if resp.status == 502:
             pytest.skip("FGA check not operational")
         assert resp.status == 200
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         body = resp.json()
         assert "allowed" in body, f"FGA check response missing 'allowed' key: {body}"
         assert body["allowed"] is True, "Viewer should have can_view"
 
         # Delete
-        resp, _ = _timed_request(admin_api_context, "DELETE", f"{backend_url}/api/fga/relations", data=relation_body)
+        resp = admin_api_context.delete(f"{backend_url}/api/fga/relations", data=relation_body)
         assert resp.status == 200
 
         # Check again — should be denied
-        resp, _ = _timed_request(admin_api_context, "POST", f"{backend_url}/api/fga/check", data=check_body)
+        resp = admin_api_context.post(f"{backend_url}/api/fga/check", data=check_body)
         if resp.status == 502:
             pytest.skip("FGA check not operational")
         assert resp.status == 200
@@ -282,7 +230,7 @@ def test_relation_lifecycle_with_permission_check(admin_api_context: APIRequestC
 def test_update_fga_schema(admin_api_context: APIRequestContext, backend_url: str):
     """PUT /api/fga/schema updates the schema and returns the result."""
     # Read current schema first
-    resp, _ = _timed_request(admin_api_context, "GET", f"{backend_url}/api/fga/schema")
+    resp = admin_api_context.get(f"{backend_url}/api/fga/schema")
     assert resp.status == 200
     original = resp.json().get("schema", "")
 
@@ -291,14 +239,11 @@ def test_update_fga_schema(admin_api_context: APIRequestContext, backend_url: st
 
     # Re-save the same schema (idempotent — safe for concurrent runs)
     schema_str = original if isinstance(original, str) else json.dumps(original)
-    resp, elapsed_ms = _timed_request(
-        admin_api_context,
-        "PUT",
+    resp = admin_api_context.put(
         f"{backend_url}/api/fga/schema",
         data={"schema": schema_str},
     )
     if resp.status in (400, 502):
         pytest.skip(f"Schema update not supported (status {resp.status})")
     assert resp.status == 200
-    assert elapsed_ms < MAX_API_RESPONSE_MS
     assert "schema" in resp.json()

--- a/backend/tests/e2e/test_fga_api.py
+++ b/backend/tests/e2e/test_fga_api.py
@@ -11,7 +11,7 @@ import os
 import pytest
 from playwright.sync_api import APIRequestContext
 
-from tests.e2e.helpers.api import unique_id
+from tests.e2e.helpers.api import unique_name
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("DESCOPE_MANAGEMENT_KEY"),
@@ -38,12 +38,12 @@ def test_get_fga_schema(admin_api_context: APIRequestContext, backend_url: str):
 
 def test_relation_create_and_delete(admin_api_context: APIRequestContext, backend_url: str):
     """Relation can be created and deleted via API."""
-    resource_id = unique_id("doc")
+    resource_id = unique_name("doc")
     relation_body = {
         "resource_type": "document",
         "resource_id": resource_id,
         "relation": "owner",
-        "target": f"user:{unique_id('u')}",
+        "target": f"user:{unique_name('u')}",
     }
 
     # Create relation
@@ -99,7 +99,7 @@ def test_check_permission_denied_for_nonexistent(admin_api_context: APIRequestCo
         f"{backend_url}/api/fga/check",
         data={
             "resource_type": "document",
-            "resource_id": unique_id("nonexist"),
+            "resource_id": unique_name("nonexist"),
             "relation": "viewer",
             "target": "user:nobody",
         },
@@ -175,8 +175,8 @@ def test_check_permission_validation(admin_api_context: APIRequestContext, backe
 
 def test_relation_lifecycle_with_permission_check(admin_api_context: APIRequestContext, backend_url: str):
     """Create relation → verify allowed → delete → verify denied (full lifecycle)."""
-    resource_id = unique_id("lifecycle")
-    target = f"user:{unique_id('u')}"
+    resource_id = unique_name("lifecycle")
+    target = f"user:{unique_name('u')}"
     relation_body = {
         "resource_type": "document",
         "resource_id": resource_id,

--- a/backend/tests/e2e/test_identity_crud_e2e.py
+++ b/backend/tests/e2e/test_identity_crud_e2e.py
@@ -12,42 +12,17 @@ Auth tiers:
 
 import contextlib
 import os
-import time
 import uuid
 
 import pytest
 from playwright.sync_api import APIRequestContext
 
+from tests.e2e.helpers.api import unique_name
+
 pytestmark = pytest.mark.skipif(
     not os.environ.get("DESCOPE_MANAGEMENT_KEY"),
     reason="DESCOPE_MANAGEMENT_KEY not set",
 )
-
-MAX_API_RESPONSE_MS = 2000
-
-
-def _unique_name(prefix: str) -> str:
-    """Generate a unique name for test resources to avoid collisions."""
-    return f"{prefix}-e2e-{uuid.uuid4().hex[:8]}"
-
-
-def _timed_request(context: APIRequestContext, method: str, url: str, **kwargs) -> tuple:
-    """Execute a request and return (response, elapsed_ms)."""
-    start = time.monotonic()
-    if method == "GET":
-        resp = context.get(url, **kwargs)
-    elif method == "POST":
-        resp = context.post(url, **kwargs)
-    elif method == "PUT":
-        resp = context.put(url, **kwargs)
-    elif method == "DELETE":
-        resp = context.delete(url, **kwargs)
-    else:
-        raise ValueError(f"Unsupported method: {method}")
-    elapsed_ms = (time.monotonic() - start) * 1000
-    if not (200 <= resp.status < 300):
-        print(f"[E2E] {method} {url} → {resp.status}")
-    return resp, elapsed_ms
 
 
 # =============================================================================
@@ -245,16 +220,13 @@ class TestPermissionCrudCanonical:
 
     def test_permission_create_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
         """POST /permissions returns response with id (UUID), created_at, updated_at."""
-        perm_name = _unique_name("canon-perm")
+        perm_name = unique_name("canon-perm")
         try:
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/permissions",
                 data={"name": perm_name, "description": "canonical field test"},
             )
             assert resp.status == 201, f"Create failed: {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
 
             body = resp.json()
             # Verify canonical fields exist
@@ -271,24 +243,17 @@ class TestPermissionCrudCanonical:
 
     def test_permission_list_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
         """GET /permissions returns list with canonical fields per item."""
-        perm_name = _unique_name("list-perm")
+        perm_name = unique_name("list-perm")
         try:
             # Create a permission so the list is non-empty
-            resp, _ = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/permissions",
                 data={"name": perm_name, "description": "list test"},
             )
             assert resp.status == 201
 
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "GET",
-                f"{backend_url}/api/permissions",
-            )
+            resp = admin_api_context.get(f"{backend_url}/api/permissions")
             assert resp.status == 200, f"List failed: {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
 
             body = resp.json()
             assert "permissions" in body
@@ -308,27 +273,22 @@ class TestPermissionCrudCanonical:
 
     def test_permission_update_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
         """PUT /permissions/{name} returns updated resource with canonical fields."""
-        perm_name = _unique_name("upd-perm")
+        perm_name = unique_name("upd-perm")
         new_name = perm_name + "-renamed"
         cleanup_name = perm_name
         try:
-            resp, _ = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/permissions",
                 data={"name": perm_name, "description": "update test"},
             )
             assert resp.status == 201
 
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "PUT",
+            resp = admin_api_context.put(
                 f"{backend_url}/api/permissions/{perm_name}",
                 data={"new_name": new_name, "description": "updated"},
             )
             assert resp.status == 200, f"Update failed: {resp.status}"
             cleanup_name = new_name  # update before further assertions — rename already happened
-            assert elapsed_ms < MAX_API_RESPONSE_MS
 
             body = resp.json()
             assert "id" in body
@@ -344,16 +304,13 @@ class TestRoleCrudCanonical:
 
     def test_role_create_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
         """POST /roles returns response with id (UUID), created_at, updated_at."""
-        role_name = _unique_name("canon-role")
+        role_name = unique_name("canon-role")
         try:
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/roles",
                 data={"name": role_name, "description": "canonical field test"},
             )
             assert resp.status == 201, f"Create failed: {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
 
             body = resp.json()
             assert "id" in body, f"Missing 'id' in response: {body}"
@@ -368,23 +325,16 @@ class TestRoleCrudCanonical:
 
     def test_role_list_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
         """GET /roles returns list with canonical fields per item."""
-        role_name = _unique_name("list-role")
+        role_name = unique_name("list-role")
         try:
-            resp, _ = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/roles",
                 data={"name": role_name, "description": "list test"},
             )
             assert resp.status == 201
 
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "GET",
-                f"{backend_url}/api/roles",
-            )
+            resp = admin_api_context.get(f"{backend_url}/api/roles")
             assert resp.status == 200, f"List failed: {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
 
             body = resp.json()
             assert "roles" in body
@@ -403,27 +353,22 @@ class TestRoleCrudCanonical:
 
     def test_role_update_returns_canonical_fields(self, admin_api_context: APIRequestContext, backend_url: str):
         """PUT /roles/{name} returns updated resource with canonical fields."""
-        role_name = _unique_name("upd-role")
+        role_name = unique_name("upd-role")
         new_name = role_name + "-renamed"
         cleanup_name = role_name
         try:
-            resp, _ = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/roles",
                 data={"name": role_name, "description": "update test"},
             )
             assert resp.status == 201
 
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "PUT",
+            resp = admin_api_context.put(
                 f"{backend_url}/api/roles/{role_name}",
                 data={"new_name": new_name, "description": "updated"},
             )
             assert resp.status == 200, f"Update failed: {resp.status}"
             cleanup_name = new_name  # update before further assertions — rename already happened
-            assert elapsed_ms < MAX_API_RESPONSE_MS
 
             body = resp.json()
             assert "id" in body
@@ -439,13 +384,8 @@ class TestMemberCrud:
 
     def test_list_members(self, admin_api_context: APIRequestContext, backend_url: str):
         """GET /members returns list of tenant members."""
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "GET",
-            f"{backend_url}/api/members",
-        )
+        resp = admin_api_context.get(f"{backend_url}/api/members")
         assert resp.status == 200, f"List members failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
         body = resp.json()
         assert "members" in body
@@ -456,15 +396,12 @@ class TestMemberCrud:
         test_email = f"e2e-invite-{uuid.uuid4().hex[:8]}@test.example.com"
         created_user_id = None
         try:
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/members/invite",
                 data={"email": test_email, "role_names": ["member"]},
             )
             # Router returns 200 (no status_code=201 on decorator) or 207 (sync failed)
             assert resp.status in (200, 207), f"Invite failed: {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
 
             body = resp.json()
             if resp.status == 207:
@@ -487,9 +424,7 @@ class TestMemberCrud:
         created_user_id = None
         try:
             # Invite
-            resp, _ = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/members/invite",
                 data={"email": test_email, "role_names": ["member"]},
             )
@@ -503,35 +438,24 @@ class TestMemberCrud:
                 pytest.skip("Could not extract user_id from invite response")
 
             # Deactivate
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/members/{created_user_id}/deactivate",
             )
             assert resp.status == 200, f"Deactivate failed: {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
             body = resp.json()
             assert body.get("status") == "deactivated"
 
             # Activate
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/members/{created_user_id}/activate",
             )
             assert resp.status == 200, f"Activate failed: {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
             body = resp.json()
             assert body.get("status") == "activated"
 
             # Remove
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "DELETE",
-                f"{backend_url}/api/members/{created_user_id}",
-            )
+            resp = admin_api_context.delete(f"{backend_url}/api/members/{created_user_id}")
             assert resp.status == 200, f"Remove failed: {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
             body = resp.json()
             assert body.get("status") == "removed"
             created_user_id = None  # cleaned up
@@ -546,13 +470,8 @@ class TestTenantOperations:
 
     def test_list_tenants_returns_jwt_tenants(self, admin_api_context: APIRequestContext, backend_url: str):
         """GET /tenants returns tenants from JWT claims."""
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "GET",
-            f"{backend_url}/api/tenants",
-        )
+        resp = admin_api_context.get(f"{backend_url}/api/tenants")
         assert resp.status == 200, f"List tenants failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
         body = resp.json()
         assert "tenants" in body
@@ -568,13 +487,8 @@ class TestTenantOperations:
 
     def test_get_current_tenant(self, admin_api_context: APIRequestContext, backend_url: str):
         """GET /tenants/current returns current tenant context from dct claim."""
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "GET",
-            f"{backend_url}/api/tenants/current",
-        )
+        resp = admin_api_context.get(f"{backend_url}/api/tenants/current")
         assert resp.status == 200, f"Get current tenant failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
         body = resp.json()
         assert "tenant_id" in body

--- a/backend/tests/e2e/test_identity_repository_api.py
+++ b/backend/tests/e2e/test_identity_repository_api.py
@@ -9,74 +9,41 @@ Requires DESCOPE_MANAGEMENT_KEY env var for admin token.
 
 import contextlib
 import os
-import time
-import uuid
 
 import pytest
 from playwright.sync_api import APIRequestContext
+
+from tests.e2e.helpers.api import unique_name
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("DESCOPE_MANAGEMENT_KEY"),
     reason="DESCOPE_MANAGEMENT_KEY not set",
 )
 
-MAX_API_RESPONSE_MS = 2000
-
-
-def _unique_name(prefix: str) -> str:
-    """Generate a unique name for test resources to avoid collisions."""
-    return f"{prefix}-e2e-{uuid.uuid4().hex[:8]}"
-
-
-def _timed_request(context: APIRequestContext, method: str, url: str, **kwargs) -> tuple:
-    """Execute a request and return (response, elapsed_ms)."""
-    start = time.monotonic()
-    if method == "GET":
-        resp = context.get(url, **kwargs)
-    elif method == "POST":
-        resp = context.post(url, **kwargs)
-    elif method == "PUT":
-        resp = context.put(url, **kwargs)
-    elif method == "DELETE":
-        resp = context.delete(url, **kwargs)
-    else:
-        raise ValueError(f"Unsupported method: {method}")
-    elapsed_ms = (time.monotonic() - start) * 1000
-    if not (200 <= resp.status < 300):
-        print(f"[E2E] {method} {url} → {resp.status}: {resp.text()}")
-    return resp, elapsed_ms
-
 
 # --- Test 1: Full lifecycle chain across multiple repos ---
 
 
 def test_full_lifecycle_chain(admin_api_context: APIRequestContext, backend_url: str):
-    """Create permission → role with permission → verify role has permission → delete all.
+    """Create permission → role with permission → delete role → delete permission.
 
     Exercises PermissionRepository, RoleRepository in one flow via BaseRepository
     create/get/delete methods.
     """
-    perm_name = _unique_name("chain-perm")
-    role_name = _unique_name("chain-role")
+    perm_name = unique_name("chain-perm")
+    role_name = unique_name("chain-role")
     cleanup_perm = None
     cleanup_role = None
 
     try:
-        # 1. Create a permission
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/permissions",
             data={"name": perm_name, "description": "E2E lifecycle chain test"},
         )
         assert resp.status == 201, f"Create permission failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         cleanup_perm = perm_name
 
-        # 2. Create a role with that permission
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/roles",
             data={
                 "name": role_name,
@@ -85,27 +52,14 @@ def test_full_lifecycle_chain(admin_api_context: APIRequestContext, backend_url:
             },
         )
         assert resp.status == 201, f"Create role failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         cleanup_role = role_name
 
-        # 3. Delete role first (depends on permission)
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "DELETE",
-            f"{backend_url}/api/roles/{role_name}",
-        )
+        resp = admin_api_context.delete(f"{backend_url}/api/roles/{role_name}")
         assert resp.status == 200, f"Delete role failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         cleanup_role = None
 
-        # 4. Delete permission
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "DELETE",
-            f"{backend_url}/api/permissions/{perm_name}",
-        )
+        resp = admin_api_context.delete(f"{backend_url}/api/permissions/{perm_name}")
         assert resp.status == 200, f"Delete permission failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         cleanup_perm = None
 
     finally:
@@ -126,48 +80,32 @@ def test_conflict_handling_permission(admin_api_context: APIRequestContext, back
     Validates RepositoryConflictError propagates correctly through
     service → router → HTTP 409 response after the base class refactor.
     """
-    perm_name = _unique_name("conflict-perm")
+    perm_name = unique_name("conflict-perm")
     cleanup_name = None
 
     try:
-        # Create permission
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/permissions",
             data={"name": perm_name, "description": "conflict test"},
         )
         assert resp.status == 201, f"Create failed: {resp.status}"
         cleanup_name = perm_name
 
-        # Attempt duplicate → expect 409 or 400
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/permissions",
             data={"name": perm_name, "description": "duplicate"},
         )
         assert resp.status in (400, 409), f"Duplicate should fail, got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
-        # Delete
-        resp, _ = _timed_request(
-            admin_api_context,
-            "DELETE",
-            f"{backend_url}/api/permissions/{perm_name}",
-        )
+        resp = admin_api_context.delete(f"{backend_url}/api/permissions/{perm_name}")
         assert resp.status == 200, f"Delete failed: {resp.status}"
         cleanup_name = None
 
-        # Re-create should succeed (conflict cleared)
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/permissions",
             data={"name": perm_name, "description": "re-created after delete"},
         )
         assert resp.status == 201, f"Re-create after delete should succeed, got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         cleanup_name = perm_name
 
     finally:
@@ -178,48 +116,32 @@ def test_conflict_handling_permission(admin_api_context: APIRequestContext, back
 
 def test_conflict_handling_role(admin_api_context: APIRequestContext, backend_url: str):
     """Create duplicate role → 409, delete → re-create succeeds."""
-    role_name = _unique_name("conflict-role")
+    role_name = unique_name("conflict-role")
     cleanup_name = None
 
     try:
-        # Create role
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/roles",
             data={"name": role_name, "description": "conflict test"},
         )
         assert resp.status == 201, f"Create failed: {resp.status}"
         cleanup_name = role_name
 
-        # Attempt duplicate → expect 409 or 400
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/roles",
             data={"name": role_name, "description": "duplicate"},
         )
         assert resp.status in (400, 409), f"Duplicate should fail, got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
-        # Delete
-        resp, _ = _timed_request(
-            admin_api_context,
-            "DELETE",
-            f"{backend_url}/api/roles/{role_name}",
-        )
+        resp = admin_api_context.delete(f"{backend_url}/api/roles/{role_name}")
         assert resp.status == 200, f"Delete failed: {resp.status}"
         cleanup_name = None
 
-        # Re-create should succeed
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/roles",
             data={"name": role_name, "description": "re-created after delete"},
         )
         assert resp.status == 201, f"Re-create after delete should succeed, got {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         cleanup_name = role_name
 
     finally:
@@ -237,29 +159,22 @@ def test_concurrent_entity_operations(admin_api_context: APIRequestContext, back
     Validates flush/commit consistency across the BaseRepository when multiple
     entities are created in sequence within the same session lifetime.
     """
-    perm_names = [_unique_name(f"batch-perm-{i}") for i in range(3)]
-    role_names = [_unique_name(f"batch-role-{i}") for i in range(2)]
+    perm_names = [unique_name(f"batch-perm-{i}") for i in range(3)]
+    role_names = [unique_name(f"batch-role-{i}") for i in range(2)]
     created_perms = []
     created_roles = []
 
     try:
-        # Create 3 permissions
         for perm_name in perm_names:
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/permissions",
                 data={"name": perm_name, "description": "batch test"},
             )
             assert resp.status == 201, f"Create permission '{perm_name}' failed: {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
             created_perms.append(perm_name)
 
-        # Create 2 roles with the created permissions
         for i, role_name in enumerate(role_names):
-            resp, elapsed_ms = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/roles",
                 data={
                     "name": role_name,
@@ -268,59 +183,35 @@ def test_concurrent_entity_operations(admin_api_context: APIRequestContext, back
                 },
             )
             assert resp.status == 201, f"Create role '{role_name}' failed: {resp.status}"
-            assert elapsed_ms < MAX_API_RESPONSE_MS
             created_roles.append(role_name)
 
         # Verify all permissions exist via list
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "GET",
-            f"{backend_url}/api/permissions",
-        )
+        resp = admin_api_context.get(f"{backend_url}/api/permissions")
         assert resp.status == 200
-        assert elapsed_ms < MAX_API_RESPONSE_MS
-        body = resp.json()
-        listed_names = {p["name"] for p in body.get("permissions", [])}
+        listed_names = {p["name"] for p in resp.json().get("permissions", [])}
         for perm_name in perm_names:
             assert perm_name in listed_names, f"Permission '{perm_name}' not found in list"
 
         # Verify all roles exist via list
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "GET",
-            f"{backend_url}/api/roles",
-        )
+        resp = admin_api_context.get(f"{backend_url}/api/roles")
         assert resp.status == 200
-        assert elapsed_ms < MAX_API_RESPONSE_MS
-        body = resp.json()
-        listed_roles = {r["name"] for r in body.get("roles", [])}
+        listed_roles = {r["name"] for r in resp.json().get("roles", [])}
         for role_name in role_names:
             assert role_name in listed_roles, f"Role '{role_name}' not found in list"
 
         # Delete roles first (depend on permissions)
         for role_name in created_roles:
-            resp, _ = _timed_request(
-                admin_api_context,
-                "DELETE",
-                f"{backend_url}/api/roles/{role_name}",
-            )
+            resp = admin_api_context.delete(f"{backend_url}/api/roles/{role_name}")
             assert resp.status == 200, f"Delete role '{role_name}' failed: {resp.status}"
         created_roles.clear()
 
-        # Delete all permissions
         for perm_name in created_perms:
-            resp, _ = _timed_request(
-                admin_api_context,
-                "DELETE",
-                f"{backend_url}/api/permissions/{perm_name}",
-            )
+            resp = admin_api_context.delete(f"{backend_url}/api/permissions/{perm_name}")
             assert resp.status == 200, f"Delete permission '{perm_name}' failed: {resp.status}"
         created_perms.clear()
 
         # Verify cleanup — re-create one permission to prove it's gone
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/permissions",
             data={"name": perm_names[0], "description": "verify cleanup"},
         )

--- a/backend/tests/e2e/test_identity_repository_api.py
+++ b/backend/tests/e2e/test_identity_repository_api.py
@@ -1,0 +1,336 @@
+"""E2E API tests for repository base class refactor — cross-entity consistency.
+
+Validates that the BaseRepository refactor did not break any API behavior.
+Tests exercise multiple repositories in a single flow to verify flush/commit
+consistency across the base class.
+
+Requires DESCOPE_MANAGEMENT_KEY env var for admin token.
+"""
+
+import contextlib
+import os
+import time
+import uuid
+
+import pytest
+from playwright.sync_api import APIRequestContext
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DESCOPE_MANAGEMENT_KEY"),
+    reason="DESCOPE_MANAGEMENT_KEY not set",
+)
+
+MAX_API_RESPONSE_MS = 2000
+
+
+def _unique_name(prefix: str) -> str:
+    """Generate a unique name for test resources to avoid collisions."""
+    return f"{prefix}-e2e-{uuid.uuid4().hex[:8]}"
+
+
+def _timed_request(context: APIRequestContext, method: str, url: str, **kwargs) -> tuple:
+    """Execute a request and return (response, elapsed_ms)."""
+    start = time.monotonic()
+    if method == "GET":
+        resp = context.get(url, **kwargs)
+    elif method == "POST":
+        resp = context.post(url, **kwargs)
+    elif method == "PUT":
+        resp = context.put(url, **kwargs)
+    elif method == "DELETE":
+        resp = context.delete(url, **kwargs)
+    else:
+        raise ValueError(f"Unsupported method: {method}")
+    elapsed_ms = (time.monotonic() - start) * 1000
+    if not (200 <= resp.status < 300):
+        print(f"[E2E] {method} {url} → {resp.status}: {resp.text()}")
+    return resp, elapsed_ms
+
+
+# --- Test 1: Full lifecycle chain across multiple repos ---
+
+
+def test_full_lifecycle_chain(admin_api_context: APIRequestContext, backend_url: str):
+    """Create permission → role with permission → verify role has permission → delete all.
+
+    Exercises PermissionRepository, RoleRepository in one flow via BaseRepository
+    create/get/delete methods.
+    """
+    perm_name = _unique_name("chain-perm")
+    role_name = _unique_name("chain-role")
+    cleanup_perm = None
+    cleanup_role = None
+
+    try:
+        # 1. Create a permission
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "POST",
+            f"{backend_url}/api/permissions",
+            data={"name": perm_name, "description": "E2E lifecycle chain test"},
+        )
+        assert resp.status == 201, f"Create permission failed: {resp.status}"
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+        cleanup_perm = perm_name
+
+        # 2. Create a role with that permission
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "POST",
+            f"{backend_url}/api/roles",
+            data={
+                "name": role_name,
+                "description": "E2E lifecycle chain test",
+                "permission_names": [perm_name],
+            },
+        )
+        assert resp.status == 201, f"Create role failed: {resp.status}"
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+        cleanup_role = role_name
+
+        # 3. Delete role first (depends on permission)
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "DELETE",
+            f"{backend_url}/api/roles/{role_name}",
+        )
+        assert resp.status == 200, f"Delete role failed: {resp.status}"
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+        cleanup_role = None
+
+        # 4. Delete permission
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "DELETE",
+            f"{backend_url}/api/permissions/{perm_name}",
+        )
+        assert resp.status == 200, f"Delete permission failed: {resp.status}"
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+        cleanup_perm = None
+
+    finally:
+        if cleanup_role:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/roles/{cleanup_role}")
+        if cleanup_perm:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/permissions/{cleanup_perm}")
+
+
+# --- Test 2: Conflict handling (RepositoryConflictError → 409) ---
+
+
+def test_conflict_handling_permission(admin_api_context: APIRequestContext, backend_url: str):
+    """Create duplicate permission → 409, delete → re-create succeeds.
+
+    Validates RepositoryConflictError propagates correctly through
+    service → router → HTTP 409 response after the base class refactor.
+    """
+    perm_name = _unique_name("conflict-perm")
+    cleanup_name = None
+
+    try:
+        # Create permission
+        resp, _ = _timed_request(
+            admin_api_context,
+            "POST",
+            f"{backend_url}/api/permissions",
+            data={"name": perm_name, "description": "conflict test"},
+        )
+        assert resp.status == 201, f"Create failed: {resp.status}"
+        cleanup_name = perm_name
+
+        # Attempt duplicate → expect 409 or 400
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "POST",
+            f"{backend_url}/api/permissions",
+            data={"name": perm_name, "description": "duplicate"},
+        )
+        assert resp.status in (400, 409), f"Duplicate should fail, got {resp.status}"
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+
+        # Delete
+        resp, _ = _timed_request(
+            admin_api_context,
+            "DELETE",
+            f"{backend_url}/api/permissions/{perm_name}",
+        )
+        assert resp.status == 200, f"Delete failed: {resp.status}"
+        cleanup_name = None
+
+        # Re-create should succeed (conflict cleared)
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "POST",
+            f"{backend_url}/api/permissions",
+            data={"name": perm_name, "description": "re-created after delete"},
+        )
+        assert resp.status == 201, f"Re-create after delete should succeed, got {resp.status}"
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+        cleanup_name = perm_name
+
+    finally:
+        if cleanup_name:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/permissions/{cleanup_name}")
+
+
+def test_conflict_handling_role(admin_api_context: APIRequestContext, backend_url: str):
+    """Create duplicate role → 409, delete → re-create succeeds."""
+    role_name = _unique_name("conflict-role")
+    cleanup_name = None
+
+    try:
+        # Create role
+        resp, _ = _timed_request(
+            admin_api_context,
+            "POST",
+            f"{backend_url}/api/roles",
+            data={"name": role_name, "description": "conflict test"},
+        )
+        assert resp.status == 201, f"Create failed: {resp.status}"
+        cleanup_name = role_name
+
+        # Attempt duplicate → expect 409 or 400
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "POST",
+            f"{backend_url}/api/roles",
+            data={"name": role_name, "description": "duplicate"},
+        )
+        assert resp.status in (400, 409), f"Duplicate should fail, got {resp.status}"
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+
+        # Delete
+        resp, _ = _timed_request(
+            admin_api_context,
+            "DELETE",
+            f"{backend_url}/api/roles/{role_name}",
+        )
+        assert resp.status == 200, f"Delete failed: {resp.status}"
+        cleanup_name = None
+
+        # Re-create should succeed
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "POST",
+            f"{backend_url}/api/roles",
+            data={"name": role_name, "description": "re-created after delete"},
+        )
+        assert resp.status == 201, f"Re-create after delete should succeed, got {resp.status}"
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+        cleanup_name = role_name
+
+    finally:
+        if cleanup_name:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/roles/{cleanup_name}")
+
+
+# --- Test 3: Concurrent entity operations ---
+
+
+def test_concurrent_entity_operations(admin_api_context: APIRequestContext, backend_url: str):
+    """Create multiple permissions and roles in sequence, verify all exist, delete all.
+
+    Validates flush/commit consistency across the BaseRepository when multiple
+    entities are created in sequence within the same session lifetime.
+    """
+    perm_names = [_unique_name(f"batch-perm-{i}") for i in range(3)]
+    role_names = [_unique_name(f"batch-role-{i}") for i in range(2)]
+    created_perms = []
+    created_roles = []
+
+    try:
+        # Create 3 permissions
+        for perm_name in perm_names:
+            resp, elapsed_ms = _timed_request(
+                admin_api_context,
+                "POST",
+                f"{backend_url}/api/permissions",
+                data={"name": perm_name, "description": "batch test"},
+            )
+            assert resp.status == 201, f"Create permission '{perm_name}' failed: {resp.status}"
+            assert elapsed_ms < MAX_API_RESPONSE_MS
+            created_perms.append(perm_name)
+
+        # Create 2 roles with the created permissions
+        for i, role_name in enumerate(role_names):
+            resp, elapsed_ms = _timed_request(
+                admin_api_context,
+                "POST",
+                f"{backend_url}/api/roles",
+                data={
+                    "name": role_name,
+                    "description": "batch test",
+                    "permission_names": [perm_names[i]],
+                },
+            )
+            assert resp.status == 201, f"Create role '{role_name}' failed: {resp.status}"
+            assert elapsed_ms < MAX_API_RESPONSE_MS
+            created_roles.append(role_name)
+
+        # Verify all permissions exist via list
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "GET",
+            f"{backend_url}/api/permissions",
+        )
+        assert resp.status == 200
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+        body = resp.json()
+        listed_names = {p["name"] for p in body.get("permissions", [])}
+        for perm_name in perm_names:
+            assert perm_name in listed_names, f"Permission '{perm_name}' not found in list"
+
+        # Verify all roles exist via list
+        resp, elapsed_ms = _timed_request(
+            admin_api_context,
+            "GET",
+            f"{backend_url}/api/roles",
+        )
+        assert resp.status == 200
+        assert elapsed_ms < MAX_API_RESPONSE_MS
+        body = resp.json()
+        listed_roles = {r["name"] for r in body.get("roles", [])}
+        for role_name in role_names:
+            assert role_name in listed_roles, f"Role '{role_name}' not found in list"
+
+        # Delete roles first (depend on permissions)
+        for role_name in created_roles:
+            resp, _ = _timed_request(
+                admin_api_context,
+                "DELETE",
+                f"{backend_url}/api/roles/{role_name}",
+            )
+            assert resp.status == 200, f"Delete role '{role_name}' failed: {resp.status}"
+        created_roles.clear()
+
+        # Delete all permissions
+        for perm_name in created_perms:
+            resp, _ = _timed_request(
+                admin_api_context,
+                "DELETE",
+                f"{backend_url}/api/permissions/{perm_name}",
+            )
+            assert resp.status == 200, f"Delete permission '{perm_name}' failed: {resp.status}"
+        created_perms.clear()
+
+        # Verify cleanup — re-create one permission to prove it's gone
+        resp, _ = _timed_request(
+            admin_api_context,
+            "POST",
+            f"{backend_url}/api/permissions",
+            data={"name": perm_names[0], "description": "verify cleanup"},
+        )
+        assert resp.status == 201, f"Re-create after cleanup should succeed, got {resp.status}"
+        created_perms.append(perm_names[0])
+
+    finally:
+        for role_name in created_roles:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/roles/{role_name}")
+        for perm_name in created_perms:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/permissions/{perm_name}")

--- a/backend/tests/e2e/test_identity_repository_ui.py
+++ b/backend/tests/e2e/test_identity_repository_ui.py
@@ -9,59 +9,39 @@ Requires DESCOPE_MANAGEMENT_KEY, DESCOPE_CLIENT_ID, DESCOPE_CLIENT_SECRET.
 
 import contextlib
 import os
-import time
 import uuid
 
 import pytest
 from playwright.sync_api import APIRequestContext, Page, expect
+
+from tests.e2e.helpers.api import unique_name
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("DESCOPE_MANAGEMENT_KEY") or not os.environ.get("DESCOPE_CLIENT_ID"),
     reason="DESCOPE credentials not set",
 )
 
-MAX_API_RESPONSE_MS = 2000
-
-
-def _unique_name(prefix: str) -> str:
-    return f"{prefix}-e2e-{uuid.uuid4().hex[:8]}"
-
-
-def _timed_request(context: APIRequestContext, method: str, url: str, **kwargs) -> tuple:
-    start = time.monotonic()
-    if method == "GET":
-        resp = context.get(url, **kwargs)
-    elif method == "POST":
-        resp = context.post(url, **kwargs)
-    elif method == "DELETE":
-        resp = context.delete(url, **kwargs)
-    else:
-        raise ValueError(f"Unsupported method: {method}")
-    elapsed_ms = (time.monotonic() - start) * 1000
-    return resp, elapsed_ms
-
 
 # --- Test 1: Authenticated navigation to identity pages ---
 
 
-def test_navigate_to_roles_page(auth_page: Page):
+def test_navigate_to_roles_page(auth_page: Page, frontend_url: str):
     """Navigate to /roles and verify the page loads without errors."""
-    auth_page.goto(auth_page.url.split("/")[0] + "//" + auth_page.url.split("/")[2] + "/roles")
+    auth_page.goto(f"{frontend_url}/roles")
     auth_page.wait_for_load_state("networkidle")
-    # Page should not redirect to login
     expect(auth_page).not_to_have_url("**/login**")
 
 
-def test_navigate_to_members_page(auth_page: Page):
+def test_navigate_to_members_page(auth_page: Page, frontend_url: str):
     """Navigate to /members and verify the page loads without errors."""
-    auth_page.goto(auth_page.url.split("/")[0] + "//" + auth_page.url.split("/")[2] + "/members")
+    auth_page.goto(f"{frontend_url}/members")
     auth_page.wait_for_load_state("networkidle")
     expect(auth_page).not_to_have_url("**/login**")
 
 
-def test_navigate_to_settings_page(auth_page: Page):
+def test_navigate_to_settings_page(auth_page: Page, frontend_url: str):
     """Navigate to /settings (tenant settings) and verify the page loads."""
-    auth_page.goto(auth_page.url.split("/")[0] + "//" + auth_page.url.split("/")[2] + "/settings")
+    auth_page.goto(f"{frontend_url}/settings")
     auth_page.wait_for_load_state("networkidle")
     expect(auth_page).not_to_have_url("**/login**")
     expect(auth_page.get_by_text("Tenant Settings")).to_be_visible()
@@ -77,25 +57,19 @@ def test_role_created_via_api_visible_in_ui(
     frontend_url: str,
 ):
     """Create a role via API, navigate to /roles in browser, verify it appears."""
-    role_name = _unique_name("ui-role")
+    role_name = unique_name("ui-role")
     cleanup_role = None
 
     try:
-        # Create role via API
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/roles",
             data={"name": role_name, "description": "UI visibility test"},
         )
         assert resp.status == 201, f"Create role failed: {resp.status}"
         cleanup_role = role_name
 
-        # Navigate to roles page
         auth_page.goto(f"{frontend_url}/roles")
         auth_page.wait_for_load_state("networkidle")
-
-        # Verify the role appears somewhere on the page
         expect(auth_page.get_by_text(role_name)).to_be_visible(timeout=10000)
 
     finally:
@@ -113,7 +87,5 @@ def test_nonexistent_route_shows_error(auth_page: Page, frontend_url: str):
     auth_page.goto(f"{frontend_url}/admin/users/{fake_id}")
     auth_page.wait_for_load_state("networkidle")
 
-    # The page should either show a not-found message or redirect to a valid page
-    # — it should NOT show a blank/crashed page
     body = auth_page.locator("body")
     expect(body).not_to_be_empty()

--- a/backend/tests/e2e/test_identity_repository_ui.py
+++ b/backend/tests/e2e/test_identity_repository_ui.py
@@ -1,0 +1,119 @@
+"""E2E UI tests for repository base class refactor — frontend renders correctly.
+
+Validates that the UI still displays identity data correctly after the
+BaseRepository refactor. The repository layer feeds the API, which feeds
+the React frontend.
+
+Requires DESCOPE_MANAGEMENT_KEY, DESCOPE_CLIENT_ID, DESCOPE_CLIENT_SECRET.
+"""
+
+import contextlib
+import os
+import time
+import uuid
+
+import pytest
+from playwright.sync_api import APIRequestContext, Page, expect
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DESCOPE_MANAGEMENT_KEY") or not os.environ.get("DESCOPE_CLIENT_ID"),
+    reason="DESCOPE credentials not set",
+)
+
+MAX_API_RESPONSE_MS = 2000
+
+
+def _unique_name(prefix: str) -> str:
+    return f"{prefix}-e2e-{uuid.uuid4().hex[:8]}"
+
+
+def _timed_request(context: APIRequestContext, method: str, url: str, **kwargs) -> tuple:
+    start = time.monotonic()
+    if method == "GET":
+        resp = context.get(url, **kwargs)
+    elif method == "POST":
+        resp = context.post(url, **kwargs)
+    elif method == "DELETE":
+        resp = context.delete(url, **kwargs)
+    else:
+        raise ValueError(f"Unsupported method: {method}")
+    elapsed_ms = (time.monotonic() - start) * 1000
+    return resp, elapsed_ms
+
+
+# --- Test 1: Authenticated navigation to identity pages ---
+
+
+def test_navigate_to_roles_page(auth_page: Page):
+    """Navigate to /roles and verify the page loads without errors."""
+    auth_page.goto(auth_page.url.split("/")[0] + "//" + auth_page.url.split("/")[2] + "/roles")
+    auth_page.wait_for_load_state("networkidle")
+    # Page should not redirect to login
+    expect(auth_page).not_to_have_url("**/login**")
+
+
+def test_navigate_to_members_page(auth_page: Page):
+    """Navigate to /members and verify the page loads without errors."""
+    auth_page.goto(auth_page.url.split("/")[0] + "//" + auth_page.url.split("/")[2] + "/members")
+    auth_page.wait_for_load_state("networkidle")
+    expect(auth_page).not_to_have_url("**/login**")
+
+
+def test_navigate_to_settings_page(auth_page: Page):
+    """Navigate to /settings (tenant settings) and verify the page loads."""
+    auth_page.goto(auth_page.url.split("/")[0] + "//" + auth_page.url.split("/")[2] + "/settings")
+    auth_page.wait_for_load_state("networkidle")
+    expect(auth_page).not_to_have_url("**/login**")
+    expect(auth_page.get_by_text("Tenant Settings")).to_be_visible()
+
+
+# --- Test 2: Data display — create role via API, verify in UI ---
+
+
+def test_role_created_via_api_visible_in_ui(
+    auth_page: Page,
+    admin_api_context: APIRequestContext,
+    backend_url: str,
+    frontend_url: str,
+):
+    """Create a role via API, navigate to /roles in browser, verify it appears."""
+    role_name = _unique_name("ui-role")
+    cleanup_role = None
+
+    try:
+        # Create role via API
+        resp, _ = _timed_request(
+            admin_api_context,
+            "POST",
+            f"{backend_url}/api/roles",
+            data={"name": role_name, "description": "UI visibility test"},
+        )
+        assert resp.status == 201, f"Create role failed: {resp.status}"
+        cleanup_role = role_name
+
+        # Navigate to roles page
+        auth_page.goto(f"{frontend_url}/roles")
+        auth_page.wait_for_load_state("networkidle")
+
+        # Verify the role appears somewhere on the page
+        expect(auth_page.get_by_text(role_name)).to_be_visible(timeout=10000)
+
+    finally:
+        if cleanup_role:
+            with contextlib.suppress(Exception):
+                admin_api_context.delete(f"{backend_url}/api/roles/{cleanup_role}")
+
+
+# --- Test 3: Error states — nonexistent resource URL ---
+
+
+def test_nonexistent_route_shows_error(auth_page: Page, frontend_url: str):
+    """Navigate to a nonexistent route and verify the UI doesn't crash."""
+    fake_id = uuid.uuid4()
+    auth_page.goto(f"{frontend_url}/admin/users/{fake_id}")
+    auth_page.wait_for_load_state("networkidle")
+
+    # The page should either show a not-found message or redirect to a valid page
+    # — it should NOT show a blank/crashed page
+    body = auth_page.locator("body")
+    expect(body).not_to_be_empty()

--- a/backend/tests/e2e/test_rbac_api.py
+++ b/backend/tests/e2e/test_rbac_api.py
@@ -10,20 +10,17 @@ via create → duplicate-conflict → update → delete → re-create cycle inst
 
 import contextlib
 import os
-import time
 import uuid
 
 import pytest
 from playwright.sync_api import APIRequestContext
 
+from tests.e2e.helpers.api import unique_name
+
 pytestmark = pytest.mark.skipif(
     not os.environ.get("DESCOPE_MANAGEMENT_KEY"),
     reason="DESCOPE_MANAGEMENT_KEY not set",
 )
-
-# --- Constants ---
-
-MAX_API_RESPONSE_MS = 2000
 
 # TF-seeded role/permission names (source: infra/rbac.tf)
 TF_SEEDED_PERMISSIONS = sorted(
@@ -51,39 +48,14 @@ TF_SEEDED_ROLES = {
 }
 
 
-def _unique_name(prefix: str) -> str:
-    """Generate a unique name for test resources to avoid collisions."""
-    return f"{prefix}-e2e-{uuid.uuid4().hex[:8]}"
-
-
-def _timed_request(context: APIRequestContext, method: str, url: str, **kwargs) -> tuple:
-    """Execute a request and return (response, elapsed_ms)."""
-    start = time.monotonic()
-    if method == "GET":
-        resp = context.get(url, **kwargs)
-    elif method == "POST":
-        resp = context.post(url, **kwargs)
-    elif method == "PUT":
-        resp = context.put(url, **kwargs)
-    elif method == "DELETE":
-        resp = context.delete(url, **kwargs)
-    else:
-        raise ValueError(f"Unsupported method: {method}")
-    elapsed_ms = (time.monotonic() - start) * 1000
-    if not (200 <= resp.status < 300):
-        print(f"[E2E] {method} {url} → {resp.status}: {resp.text()}")
-    return resp, elapsed_ms
-
-
 # --- AC-1: TF-seeded roles (requires listing — Descope returns 500) ---
 
 
 @pytest.mark.xfail(reason="Descope API returns 500 (E010009) on /v1/mgmt/role/all", strict=False)
 def test_tf_seeded_roles_present(admin_api_context: APIRequestContext, backend_url: str):
     """GET /api/roles returns all 4 TF-seeded roles with correct permission counts."""
-    resp, elapsed_ms = _timed_request(admin_api_context, "GET", f"{backend_url}/api/roles")
+    resp = admin_api_context.get(f"{backend_url}/api/roles")
     assert resp.status == 200, f"Expected 200, got {resp.status}"
-    assert elapsed_ms < MAX_API_RESPONSE_MS
 
     body = resp.json()
     roles = body.get("roles", [])
@@ -103,9 +75,8 @@ def test_tf_seeded_roles_present(admin_api_context: APIRequestContext, backend_u
 @pytest.mark.xfail(reason="Descope API returns 500 (E010009) on /v1/mgmt/permission/all", strict=False)
 def test_tf_seeded_permissions_present(admin_api_context: APIRequestContext, backend_url: str):
     """GET /api/permissions returns all 12 TF-seeded permissions."""
-    resp, elapsed_ms = _timed_request(admin_api_context, "GET", f"{backend_url}/api/permissions")
+    resp = admin_api_context.get(f"{backend_url}/api/permissions")
     assert resp.status == 200, f"Expected 200, got {resp.status}"
-    assert elapsed_ms < MAX_API_RESPONSE_MS
 
     body = resp.json()
     permissions = body.get("permissions", [])
@@ -120,35 +91,25 @@ def test_tf_seeded_permissions_present(admin_api_context: APIRequestContext, bac
 
 def test_runtime_permission_create_and_delete(admin_api_context: APIRequestContext, backend_url: str):
     """Runtime-created permission can be created and deleted via API."""
-    perm_name = _unique_name("test-perm")
+    perm_name = unique_name("test-perm")
     try:
         # Create runtime permission
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/permissions",
             data={"name": perm_name, "description": "E2E test permission"},
         )
         assert resp.status == 201, f"Create failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
         # Verify it exists by trying to create duplicate (expect 409 or 400)
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/permissions",
             data={"name": perm_name, "description": "duplicate"},
         )
         assert resp.status in (400, 409), f"Duplicate create should fail, got {resp.status}"
 
         # Delete
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "DELETE",
-            f"{backend_url}/api/permissions/{perm_name}",
-        )
+        resp = admin_api_context.delete(f"{backend_url}/api/permissions/{perm_name}")
         assert resp.status == 200, f"Delete failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         perm_name = None  # cleaned up
     finally:
         if perm_name:
@@ -158,35 +119,25 @@ def test_runtime_permission_create_and_delete(admin_api_context: APIRequestConte
 
 def test_runtime_role_create_and_delete(admin_api_context: APIRequestContext, backend_url: str):
     """Runtime-created role can be created and deleted via API."""
-    role_name = _unique_name("test-role")
+    role_name = unique_name("test-role")
     try:
         # Create runtime role (no permission_names since TF-seeded perms may not exist)
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/roles",
             data={"name": role_name, "description": "E2E test role"},
         )
         assert resp.status == 201, f"Create failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
         # Verify it exists by trying to create duplicate (expect 409 or 400)
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/roles",
             data={"name": role_name, "description": "duplicate"},
         )
         assert resp.status in (400, 409), f"Duplicate create should fail, got {resp.status}"
 
         # Delete
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "DELETE",
-            f"{backend_url}/api/roles/{role_name}",
-        )
+        resp = admin_api_context.delete(f"{backend_url}/api/roles/{role_name}")
         assert resp.status == 200, f"Delete failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         role_name = None  # cleaned up
     finally:
         if role_name:
@@ -199,36 +150,28 @@ def test_runtime_role_create_and_delete(admin_api_context: APIRequestContext, ba
 
 def test_permission_crud_lifecycle(admin_api_context: APIRequestContext, backend_url: str):
     """Full permission lifecycle: create -> update -> delete -> re-create (verify delete worked)."""
-    perm_name = _unique_name("lifecycle-perm")
+    perm_name = unique_name("lifecycle-perm")
     updated_name = perm_name + "-updated"
     cleanup_name = perm_name
 
     try:
         # Create
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/permissions",
             data={"name": perm_name, "description": "E2E lifecycle test"},
         )
         assert resp.status == 201, f"Create failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
         # Update (rename)
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "PUT",
+        resp = admin_api_context.put(
             f"{backend_url}/api/permissions/{perm_name}",
             data={"new_name": updated_name, "description": "Updated description"},
         )
         assert resp.status == 200, f"Update failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         cleanup_name = updated_name
 
         # Verify old name no longer exists (re-create with old name should succeed)
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/permissions",
             data={"name": perm_name, "description": "re-create after rename"},
         )
@@ -238,19 +181,12 @@ def test_permission_crud_lifecycle(admin_api_context: APIRequestContext, backend
             admin_api_context.delete(f"{backend_url}/api/permissions/{perm_name}")
 
         # Delete the renamed permission
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "DELETE",
-            f"{backend_url}/api/permissions/{updated_name}",
-        )
+        resp = admin_api_context.delete(f"{backend_url}/api/permissions/{updated_name}")
         assert resp.status == 200, f"Delete failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         cleanup_name = None
 
         # Verify deletion by re-creating with same name (should succeed if deleted)
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/permissions",
             data={"name": updated_name, "description": "re-create after delete"},
         )
@@ -271,20 +207,18 @@ def test_role_crud_lifecycle(admin_api_context: APIRequestContext, backend_url: 
     Creates test permissions first since TF-seeded permissions may not exist in the
     Descope project used for CI.
     """
-    role_name = _unique_name("lifecycle-role")
+    role_name = unique_name("lifecycle-role")
     updated_name = role_name + "-updated"
     cleanup_name = role_name
-    perm_a = _unique_name("perm-a")
-    perm_b = _unique_name("perm-b")
-    perm_c = _unique_name("perm-c")
+    perm_a = unique_name("perm-a")
+    perm_b = unique_name("perm-b")
+    perm_c = unique_name("perm-c")
     created_perms = []
 
     try:
         # Create test permissions first
         for perm in [perm_a, perm_b, perm_c]:
-            resp, _ = _timed_request(
-                admin_api_context,
-                "POST",
+            resp = admin_api_context.post(
                 f"{backend_url}/api/permissions",
                 data={"name": perm, "description": "E2E test perm for role lifecycle"},
             )
@@ -292,9 +226,7 @@ def test_role_crud_lifecycle(admin_api_context: APIRequestContext, backend_url: 
             created_perms.append(perm)
 
         # Create role with permissions
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/roles",
             data={
                 "name": role_name,
@@ -303,12 +235,9 @@ def test_role_crud_lifecycle(admin_api_context: APIRequestContext, backend_url: 
             },
         )
         assert resp.status == 201, f"Create role failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
         # Update (rename + change permissions)
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "PUT",
+        resp = admin_api_context.put(
             f"{backend_url}/api/roles/{role_name}",
             data={
                 "new_name": updated_name,
@@ -317,23 +246,15 @@ def test_role_crud_lifecycle(admin_api_context: APIRequestContext, backend_url: 
             },
         )
         assert resp.status == 200, f"Update failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         cleanup_name = updated_name
 
         # Delete
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "DELETE",
-            f"{backend_url}/api/roles/{updated_name}",
-        )
+        resp = admin_api_context.delete(f"{backend_url}/api/roles/{updated_name}")
         assert resp.status == 200, f"Delete failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         cleanup_name = None
 
         # Verify deletion by re-creating with same name
-        resp, _ = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/roles",
             data={"name": updated_name, "description": "re-create after delete"},
         )
@@ -363,7 +284,7 @@ def test_runtime_role_assignment(admin_api_context: APIRequestContext, backend_u
     """
     import httpx as _httpx
 
-    role_name = _unique_name("assign-role")
+    role_name = unique_name("assign-role")
     test_email = f"e2e-assign-{uuid.uuid4().hex[:8]}@test.example.com"
     cleanup_role = False
     cleanup_user = False
@@ -393,35 +314,26 @@ def test_runtime_role_assignment(admin_api_context: APIRequestContext, backend_u
 
     try:
         # Create a runtime role
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/roles",
             data={"name": role_name, "description": "E2E assignment test"},
         )
         assert resp.status == 201, f"Create failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
         cleanup_role = True
 
         # Assign the runtime role to the test user
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/roles/assign",
             data={"user_id": test_email, "tenant_id": test_tenant_id, "role_names": [role_name]},
         )
         assert resp.status == 200, f"Assign failed: {resp.status} — {resp.text()}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
 
         # Remove the assigned role (cleanup user state)
-        resp, elapsed_ms = _timed_request(
-            admin_api_context,
-            "POST",
+        resp = admin_api_context.post(
             f"{backend_url}/api/roles/remove",
             data={"user_id": test_email, "tenant_id": test_tenant_id, "role_names": [role_name]},
         )
         assert resp.status == 200, f"Remove failed: {resp.status}"
-        assert elapsed_ms < MAX_API_RESPONSE_MS
     finally:
         if cleanup_role:
             with contextlib.suppress(Exception):

--- a/backend/tests/unit/repositories/test_assignment_repository.py
+++ b/backend/tests/unit/repositories/test_assignment_repository.py
@@ -18,7 +18,7 @@ from app.models.identity.role import Role
 from app.models.identity.tenant import Tenant
 from app.models.identity.user import User, UserStatus
 from app.repositories.assignment import UserTenantRoleRepository
-from app.repositories.user import RepositoryConflictError
+from app.repositories.base import RepositoryConflictError
 
 pytestmark = pytest.mark.asyncio
 

--- a/backend/tests/unit/repositories/test_base_repository.py
+++ b/backend/tests/unit/repositories/test_base_repository.py
@@ -1,0 +1,120 @@
+"""Unit tests for BaseRepository — verifies generic CRUD, transaction helpers, and RepositoryConflictError.
+
+Tests cover:
+- create: happy path, IntegrityError → RepositoryConflictError (no rollback)
+- get: found, not found
+- update: happy path, IntegrityError → RepositoryConflictError
+- delete: existing entity, non-existent entity
+- commit / rollback: delegate to session
+- RepositoryConflictError importable from app.repositories.base
+- Concrete repos inherit BaseRepository and set _model
+"""
+
+import uuid
+
+import pytest
+
+from app.models.identity.role import Permission
+from app.repositories.base import BaseRepository, RepositoryConflictError
+from app.repositories.permission import PermissionRepository
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_permission(**overrides) -> Permission:
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": f"perm-{uuid.uuid4().hex[:8]}",
+        "description": "test permission",
+    }
+    defaults.update(overrides)
+    return Permission(**defaults)
+
+
+async def test_base_create(db_session):
+    """BaseRepository.create adds entity and flushes."""
+    repo = PermissionRepository(db_session)
+    perm = _make_permission()
+    created = await repo.create(perm)
+    assert created.id == perm.id
+    assert created.created_at is not None
+
+
+async def test_base_create_conflict(db_session):
+    """BaseRepository.create raises RepositoryConflictError on IntegrityError."""
+    repo = PermissionRepository(db_session)
+    name = f"dup-{uuid.uuid4().hex[:8]}"
+    await repo.create(_make_permission(name=name))
+    with pytest.raises(RepositoryConflictError):
+        await repo.create(_make_permission(name=name))
+
+
+async def test_base_get(db_session):
+    """BaseRepository.get returns entity by primary key."""
+    repo = PermissionRepository(db_session)
+    perm = _make_permission()
+    await repo.create(perm)
+    fetched = await repo.get(perm.id)
+    assert fetched is not None
+    assert fetched.id == perm.id
+
+
+async def test_base_get_not_found(db_session):
+    """BaseRepository.get returns None when entity not found."""
+    repo = PermissionRepository(db_session)
+    result = await repo.get(uuid.uuid4())
+    assert result is None
+
+
+async def test_base_update(db_session):
+    """BaseRepository.update flushes mutations."""
+    repo = PermissionRepository(db_session)
+    perm = _make_permission()
+    await repo.create(perm)
+    perm.description = "updated"
+    updated = await repo.update(perm)
+    assert updated.description == "updated"
+
+
+async def test_base_delete(db_session):
+    """BaseRepository.delete removes entity and returns True."""
+    repo = PermissionRepository(db_session)
+    perm = _make_permission()
+    await repo.create(perm)
+    assert await repo.delete(perm.id) is True
+    assert await repo.get(perm.id) is None
+
+
+async def test_base_delete_not_found(db_session):
+    """BaseRepository.delete returns False when entity not found."""
+    repo = PermissionRepository(db_session)
+    assert await repo.delete(uuid.uuid4()) is False
+
+
+async def test_concrete_repos_inherit_base():
+    """All concrete repositories inherit from BaseRepository."""
+    from app.repositories.assignment import UserTenantRoleRepository
+    from app.repositories.idp_link import IdPLinkRepository
+    from app.repositories.provider import ProviderRepository
+    from app.repositories.role import RoleRepository
+    from app.repositories.tenant import TenantRepository
+    from app.repositories.user import UserRepository
+
+    for repo_cls in [
+        UserRepository,
+        RoleRepository,
+        PermissionRepository,
+        TenantRepository,
+        ProviderRepository,
+        IdPLinkRepository,
+        UserTenantRoleRepository,
+    ]:
+        assert issubclass(repo_cls, BaseRepository), f"{repo_cls.__name__} does not inherit BaseRepository"
+        assert hasattr(repo_cls, "_model"), f"{repo_cls.__name__} missing _model attribute"
+
+
+async def test_repository_conflict_error_importable():
+    """RepositoryConflictError is importable from app.repositories.base."""
+    from app.repositories.base import RepositoryConflictError as RCE
+
+    assert issubclass(RCE, Exception)

--- a/backend/tests/unit/repositories/test_idp_link_repository.py
+++ b/backend/tests/unit/repositories/test_idp_link_repository.py
@@ -15,8 +15,8 @@ import pytest
 
 from app.models.identity.provider import Provider, ProviderType
 from app.models.identity.user import IdPLink, User, UserStatus
+from app.repositories.base import RepositoryConflictError
 from app.repositories.idp_link import IdPLinkRepository
-from app.repositories.user import RepositoryConflictError
 
 pytestmark = pytest.mark.asyncio
 

--- a/backend/tests/unit/repositories/test_permission_repository.py
+++ b/backend/tests/unit/repositories/test_permission_repository.py
@@ -14,8 +14,8 @@ import uuid
 import pytest
 
 from app.models.identity.role import Permission
+from app.repositories.base import RepositoryConflictError
 from app.repositories.permission import PermissionRepository
-from app.repositories.user import RepositoryConflictError
 
 pytestmark = pytest.mark.asyncio
 

--- a/backend/tests/unit/repositories/test_provider_repository.py
+++ b/backend/tests/unit/repositories/test_provider_repository.py
@@ -14,8 +14,8 @@ import uuid
 import pytest
 
 from app.models.identity.provider import Provider, ProviderType
+from app.repositories.base import RepositoryConflictError
 from app.repositories.provider import ProviderRepository
-from app.repositories.user import RepositoryConflictError
 
 pytestmark = pytest.mark.asyncio
 

--- a/backend/tests/unit/repositories/test_role_repository.py
+++ b/backend/tests/unit/repositories/test_role_repository.py
@@ -17,8 +17,8 @@ import pytest
 
 from app.models.identity.role import Permission, Role
 from app.models.identity.tenant import Tenant
+from app.repositories.base import RepositoryConflictError
 from app.repositories.role import RoleRepository
-from app.repositories.user import RepositoryConflictError
 
 pytestmark = pytest.mark.asyncio
 

--- a/backend/tests/unit/repositories/test_tenant_repository.py
+++ b/backend/tests/unit/repositories/test_tenant_repository.py
@@ -17,8 +17,8 @@ from app.models.identity.assignment import UserTenantRole
 from app.models.identity.role import Role
 from app.models.identity.tenant import Tenant
 from app.models.identity.user import User, UserStatus
+from app.repositories.base import RepositoryConflictError
 from app.repositories.tenant import TenantRepository
-from app.repositories.user import RepositoryConflictError
 
 pytestmark = pytest.mark.asyncio
 

--- a/backend/tests/unit/repositories/test_user_repository.py
+++ b/backend/tests/unit/repositories/test_user_repository.py
@@ -17,7 +17,8 @@ from app.models.identity.assignment import UserTenantRole
 from app.models.identity.role import Role
 from app.models.identity.tenant import Tenant
 from app.models.identity.user import User, UserStatus
-from app.repositories.user import RepositoryConflictError, UserRepository
+from app.repositories.base import RepositoryConflictError
+from app.repositories.user import UserRepository
 
 pytestmark = pytest.mark.asyncio
 

--- a/backend/tests/unit/test_idp_link_service.py
+++ b/backend/tests/unit/test_idp_link_service.py
@@ -13,9 +13,10 @@ import pytest
 
 from app.errors.identity import Conflict, NotFound
 from app.models.identity.user import IdPLink
+from app.repositories.base import RepositoryConflictError
 from app.repositories.idp_link import IdPLinkRepository
 from app.repositories.provider import ProviderRepository
-from app.repositories.user import RepositoryConflictError, UserRepository
+from app.repositories.user import UserRepository
 from app.services.idp_link import IdPLinkService
 
 

--- a/backend/tests/unit/test_inbound_sync_service.py
+++ b/backend/tests/unit/test_inbound_sync_service.py
@@ -15,9 +15,10 @@ import pytest
 from app.errors.identity import Conflict, NotFound, ValidationError
 from app.models.identity.provider import Provider, ProviderType
 from app.models.identity.user import IdPLink, User, UserStatus
+from app.repositories.base import RepositoryConflictError
 from app.repositories.idp_link import IdPLinkRepository
 from app.repositories.provider import ProviderRepository
-from app.repositories.user import RepositoryConflictError, UserRepository
+from app.repositories.user import UserRepository
 from app.services.inbound_sync import InboundSyncService
 
 PROVIDER_ID = uuid.uuid4()

--- a/backend/tests/unit/test_permission_service.py
+++ b/backend/tests/unit/test_permission_service.py
@@ -13,8 +13,8 @@ from expression import Error, Ok
 
 from app.errors.identity import Conflict, NotFound
 from app.models.identity.role import Permission
+from app.repositories.base import RepositoryConflictError
 from app.repositories.permission import PermissionRepository
-from app.repositories.user import RepositoryConflictError
 from app.services.adapters.base import IdentityProviderAdapter, SyncError
 from app.services.cache_invalidation import CacheInvalidationPublisher
 from app.services.permission import PermissionService

--- a/backend/tests/unit/test_provider_service.py
+++ b/backend/tests/unit/test_provider_service.py
@@ -14,8 +14,8 @@ import pytest
 
 from app.errors.identity import Conflict, NotFound
 from app.models.identity.provider import Provider, ProviderType
+from app.repositories.base import RepositoryConflictError
 from app.repositories.provider import ProviderRepository
-from app.repositories.user import RepositoryConflictError
 from app.services.provider import ProviderService
 
 

--- a/backend/tests/unit/test_reconciliation_service.py
+++ b/backend/tests/unit/test_reconciliation_service.py
@@ -21,12 +21,13 @@ from app.models.identity.provider import Provider, ProviderType
 from app.models.identity.role import Permission, Role
 from app.models.identity.tenant import Tenant, TenantStatus
 from app.models.identity.user import User, UserStatus
+from app.repositories.base import RepositoryConflictError
 from app.repositories.idp_link import IdPLinkRepository
 from app.repositories.permission import PermissionRepository
 from app.repositories.provider import ProviderRepository
 from app.repositories.role import RoleRepository
 from app.repositories.tenant import TenantRepository
-from app.repositories.user import RepositoryConflictError, UserRepository
+from app.repositories.user import UserRepository
 from app.services.cache_invalidation import CacheInvalidationPublisher
 from app.services.descope import DescopeManagementClient
 from app.services.reconciliation import ReconciliationService

--- a/backend/tests/unit/test_role_service.py
+++ b/backend/tests/unit/test_role_service.py
@@ -17,9 +17,9 @@ from app.errors.identity import Conflict, NotFound
 from app.models.identity.assignment import UserTenantRole
 from app.models.identity.role import Permission, Role, RolePermission
 from app.repositories.assignment import UserTenantRoleRepository
+from app.repositories.base import RepositoryConflictError
 from app.repositories.permission import PermissionRepository
 from app.repositories.role import RoleRepository
-from app.repositories.user import RepositoryConflictError
 from app.services.adapters.base import IdentityProviderAdapter, SyncError
 from app.services.cache_invalidation import CacheInvalidationPublisher
 from app.services.role import RoleService

--- a/backend/tests/unit/test_tenant_service.py
+++ b/backend/tests/unit/test_tenant_service.py
@@ -14,8 +14,8 @@ from expression import Error, Ok
 
 from app.errors.identity import Conflict, NotFound
 from app.models.identity.tenant import Tenant
+from app.repositories.base import RepositoryConflictError
 from app.repositories.tenant import TenantRepository
-from app.repositories.user import RepositoryConflictError
 from app.services.adapters.base import IdentityProviderAdapter, SyncError
 from app.services.cache_invalidation import CacheInvalidationPublisher
 from app.services.tenant import TenantService

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -17,7 +17,8 @@ from expression import Error, Ok
 from app.errors.identity import Conflict, Forbidden, NotFound
 from app.models.identity.user import User, UserStatus
 from app.repositories.assignment import UserTenantRoleRepository
-from app.repositories.user import RepositoryConflictError, UserRepository
+from app.repositories.base import RepositoryConflictError
+from app.repositories.user import UserRepository
 from app.services.adapters.base import IdentityProviderAdapter, SyncError
 from app.services.cache_invalidation import CacheInvalidationPublisher
 from app.services.user import UserService

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -50,15 +50,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.12.1"
+version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [package.optional-dependencies]
@@ -759,8 +759,8 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", marker = "extra == 'dev'", specifier = ">=0.20" },
     { name = "alembic", specifier = ">=1.14" },
-    { name = "anyio", extras = ["trio"], marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "asyncpg", specifier = ">=0.30" },
+    { name = "anyio", extras = ["trio"], marker = "extra == 'dev'", specifier = ">=4.13.0" },
+    { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "expression", specifier = ">=5.0" },
     { name = "fastapi", specifier = ">=0.115.0,<1" },
     { name = "httpx", specifier = ">=0.28,<1" },
@@ -768,17 +768,17 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.41b0" },
     { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.41b0" },
-    { name = "opentelemetry-instrumentation-logging", specifier = ">=0.41b0" },
-    { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.41b0" },
-    { name = "opentelemetry-sdk", specifier = ">=1.20" },
+    { name = "opentelemetry-instrumentation-logging", specifier = ">=0.62b0" },
+    { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.62b0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.41.0" },
     { name = "py-identity-model", specifier = ">=2.1.0,<3" },
-    { name = "pydantic", extras = ["email"], specifier = ">=2.0" },
+    { name = "pydantic", extras = ["email"], specifier = ">=2.12.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
-    { name = "python-json-logger", specifier = ">=3.2,<5" },
-    { name = "redis", extras = ["hiredis"], specifier = ">=5.0,<6" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
+    { name = "python-json-logger", specifier = ">=4.1.0,<5" },
+    { name = "redis", extras = ["hiredis"], specifier = ">=7.4.0,<8" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
-    { name = "scalar-fastapi", specifier = ">=1.0.0" },
+    { name = "scalar-fastapi", specifier = ">=1.8.2" },
     { name = "slowapi", specifier = ">=0.1.9,<1" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "sqlmodel", specifier = ">=0.0.22,<1" },
@@ -790,10 +790,10 @@ provides-extras = ["dev"]
 [package.metadata.requires-dev]
 dev = [
     { name = "aiosqlite", specifier = ">=0.20" },
-    { name = "anyio", extras = ["trio"], specifier = ">=4.0" },
+    { name = "anyio", extras = ["trio"], specifier = ">=4.13.0" },
     { name = "pip-audit", specifier = ">=2.9" },
     { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-playwright", specifier = ">=0.7.2" },
     { name = "ruff", specifier = ">=0.9" },
     { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0" },
@@ -997,32 +997,32 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.40.0"
+version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.40.0"
+version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/bc/1559d46557fe6eca0b46c88d4c2676285f1f3be2e8d06bb5d15fbffc814a/opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa", size = 20416, upload-time = "2026-03-04T14:17:23.801Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/28/e8eca94966fe9a1465f6094dc5ddc5398473682180279c94020bc23b4906/opentelemetry_exporter_otlp_proto_common-1.41.0.tar.gz", hash = "sha256:966bbce537e9edb166154779a7c4f8ab6b8654a03a28024aeaf1a3eacb07d6ee", size = 20411, upload-time = "2026-04-09T14:38:36.572Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/ca/8f122055c97a932311a3f640273f084e738008933503d0c2563cd5d591fc/opentelemetry_exporter_otlp_proto_common-1.40.0-py3-none-any.whl", hash = "sha256:7081ff453835a82417bf38dccf122c827c3cbc94f2079b03bba02a3165f25149", size = 18369, upload-time = "2026-03-04T14:17:04.796Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c4/78b9bf2d9c1d5e494f44932988d9d91c51a66b9a7b48adf99b62f7c65318/opentelemetry_exporter_otlp_proto_common-1.41.0-py3-none-any.whl", hash = "sha256:7a99177bf61f85f4f9ed2072f54d676364719c066f6d11f515acc6c745c7acf0", size = 18366, upload-time = "2026-04-09T14:38:15.135Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.40.0"
+version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1033,14 +1033,14 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/7f/b9e60435cfcc7590fa87436edad6822240dddbc184643a2a005301cc31f4/opentelemetry_exporter_otlp_proto_grpc-1.40.0.tar.gz", hash = "sha256:bd4015183e40b635b3dab8da528b27161ba83bf4ef545776b196f0fb4ec47740", size = 25759, upload-time = "2026-03-04T14:17:24.4Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/46/d75a3f8c91915f2e58f61d0a2e4ada63891e7c7a37a20ff7949ba184a6b2/opentelemetry_exporter_otlp_proto_grpc-1.41.0.tar.gz", hash = "sha256:f704201251c6f65772b11bddea1c948000554459101bdbb0116e0a01b70592f6", size = 25754, upload-time = "2026-04-09T14:38:37.423Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/6f/7ee0980afcbdcd2d40362da16f7f9796bd083bf7f0b8e038abfbc0300f5d/opentelemetry_exporter_otlp_proto_grpc-1.40.0-py3-none-any.whl", hash = "sha256:2aa0ca53483fe0cf6405087a7491472b70335bc5c7944378a0a8e72e86995c52", size = 20304, upload-time = "2026-03-04T14:17:05.942Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f6/b09e2e0c9f0b5750cebc6eaf31527b910821453cef40a5a0fe93550422b2/opentelemetry_exporter_otlp_proto_grpc-1.41.0-py3-none-any.whl", hash = "sha256:3a1a86bd24806ccf136ec9737dbfa4c09b069f9130ff66b0acb014f9c5255fd1", size = 20299, upload-time = "2026-04-09T14:38:17.01Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.61b0"
+version = "0.62b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1048,14 +1048,14 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/37/6bf8e66bfcee5d3c6515b79cb2ee9ad05fe573c20f7ceb288d0e7eeec28c/opentelemetry_instrumentation-0.61b0.tar.gz", hash = "sha256:cb21b48db738c9de196eba6b805b4ff9de3b7f187e4bbf9a466fa170514f1fc7", size = 32606, upload-time = "2026-03-04T14:20:16.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/fd/b8e90bb340957f059084376f94cff336b0e871a42feba7d3f7342365e987/opentelemetry_instrumentation-0.62b0.tar.gz", hash = "sha256:aa1b0b9ab2e1722c2a8a5384fb016fc28d30bba51826676c8036074790d2861e", size = 34042, upload-time = "2026-04-09T14:40:22.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/3e/f6f10f178b6316de67f0dfdbbb699a24fbe8917cf1743c1595fb9dcdd461/opentelemetry_instrumentation-0.61b0-py3-none-any.whl", hash = "sha256:92a93a280e69788e8f88391247cc530fd81f16f2b011979d4d6398f805cfbc63", size = 33448, upload-time = "2026-03-04T14:19:02.447Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b6/3356d2e335e3c449c5183e9b023f30f04f1b7073a6583c68745ea2e704b1/opentelemetry_instrumentation-0.62b0-py3-none-any.whl", hash = "sha256:30d4e76486eae64fb095264a70c2c809c4bed17b73373e53091470661f7d477c", size = 34158, upload-time = "2026-04-09T14:39:21.428Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-asgi"
-version = "0.61b0"
+version = "0.62b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
@@ -1064,14 +1064,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/3e/143cf5c034e58037307e6a24f06e0dd64b2c49ae60a965fc580027581931/opentelemetry_instrumentation_asgi-0.61b0.tar.gz", hash = "sha256:9d08e127244361dc33976d39dd4ca8f128b5aa5a7ae425208400a80a095019b5", size = 26691, upload-time = "2026-03-04T14:20:21.038Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/38/999bf777774878971c2716de4b7a03cd57a7decb4af25090e703b79fa0e5/opentelemetry_instrumentation_asgi-0.62b0.tar.gz", hash = "sha256:93cde8c62e5918a3c1ff9ba020518127300e5e0816b7e8b14baf46a26ba619fc", size = 26779, upload-time = "2026-04-09T14:40:26.566Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/78/154470cf9d741a7487fbb5067357b87386475bbb77948a6707cae982e158/opentelemetry_instrumentation_asgi-0.61b0-py3-none-any.whl", hash = "sha256:e4b3ce6b66074e525e717efff20745434e5efd5d9df6557710856fba356da7a4", size = 16980, upload-time = "2026-03-04T14:19:10.894Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cf/29df82f5870178143bdb5c9a7be044b9f78c71e1c5dcf995242e86d80158/opentelemetry_instrumentation_asgi-0.62b0-py3-none-any.whl", hash = "sha256:89b62a6f996b260b162f515c25e6d78e39286e4cbe2f935899e51b32f31027e2", size = 17011, upload-time = "2026-04-09T14:39:27.305Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-fastapi"
-version = "0.61b0"
+version = "0.62b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1080,14 +1080,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/35/aa727bb6e6ef930dcdc96a617b83748fece57b43c47d83ba8d83fbeca657/opentelemetry_instrumentation_fastapi-0.61b0.tar.gz", hash = "sha256:3a24f35b07c557ae1bbc483bf8412221f25d79a405f8b047de8b670722e2fa9f", size = 24800, upload-time = "2026-03-04T14:20:32.759Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/09/92740c6d114d1bef392557a03ae6de64065c83c1b331dae9b57fe718497c/opentelemetry_instrumentation_fastapi-0.62b0.tar.gz", hash = "sha256:e4748e4e575077e08beaf2c5d2f369da63dd90882d89d73c4192a97356637dec", size = 25056, upload-time = "2026-04-09T14:40:36.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/05/acfeb2cccd434242a0a7d0ea29afaf077e04b42b35b485d89aee4e0d9340/opentelemetry_instrumentation_fastapi-0.61b0-py3-none-any.whl", hash = "sha256:a1a844d846540d687d377516b2ff698b51d87c781b59f47c214359c4a241047c", size = 13485, upload-time = "2026-03-04T14:19:30.351Z" },
+    { url = "https://files.pythonhosted.org/packages/64/bb/186ffe0fde0ad33ceb50e1d3596cc849b732d3b825592a6a507a40c8c49b/opentelemetry_instrumentation_fastapi-0.62b0-py3-none-any.whl", hash = "sha256:06d3272ad15f9daea5a0a27c32831aff376110a4b0394197120256ef6d610e6e", size = 13482, upload-time = "2026-04-09T14:39:43.446Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-httpx"
-version = "0.61b0"
+version = "0.62b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1096,27 +1096,27 @@ dependencies = [
     { name = "opentelemetry-util-http" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/2a/e2becd55e33c29d1d9ef76e2579040ed1951cb33bacba259f6aff2fdd2a6/opentelemetry_instrumentation_httpx-0.61b0.tar.gz", hash = "sha256:6569ec097946c5551c2a4252f74c98666addd1bf047c1dde6b4ef426719ff8dd", size = 24104, upload-time = "2026-03-04T14:20:34.752Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/a7/63e2c6325c8e99cd9b8e0229a8b61c37520ee537214a2c8d514e84486a94/opentelemetry_instrumentation_httpx-0.62b0.tar.gz", hash = "sha256:d865398db3f3c289ba226e355bf4d94460a4301c0c8916e3136caea55ae18000", size = 24182, upload-time = "2026-04-09T14:40:38.719Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/88/dde310dce56e2d85cf1a09507f5888544955309edc4b8d22971d6d3d1417/opentelemetry_instrumentation_httpx-0.61b0-py3-none-any.whl", hash = "sha256:dee05c93a6593a5dc3ae5d9d5c01df8b4e2c5d02e49275e5558534ee46343d5e", size = 17198, upload-time = "2026-03-04T14:19:33.585Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/5e/7d5fc28487637871b015128cd5dbb3c36f6d343a9098b893bd803d5a9cca/opentelemetry_instrumentation_httpx-0.62b0-py3-none-any.whl", hash = "sha256:c7660b939c12608fec67743126e9b4dc23dceef0ed631c415924966b0d1579e3", size = 17200, upload-time = "2026-04-09T14:39:46.618Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-logging"
-version = "0.61b0"
+version = "0.62b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/e0/69473f925acfe2d4edf5c23bcced36906ac3627aa7c5722a8e3f60825f3b/opentelemetry_instrumentation_logging-0.61b0.tar.gz", hash = "sha256:feaa30b700acd2a37cc81db5f562ab0c3a5b6cc2453595e98b72c01dcf649584", size = 17906, upload-time = "2026-03-04T14:20:37.398Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/47/8b81b7f007addf4dfd2b2f0753326e62822e1fec674605d0ec7c39d479b0/opentelemetry_instrumentation_logging-0.62b0.tar.gz", hash = "sha256:61f23be960e047054b3aa38998e7d1eb1fd9bef6f52097e28bc113af8b6f3bd8", size = 18968, upload-time = "2026-04-09T14:40:40.733Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/0e/2137db5239cc5e564495549a4d11488a7af9b48fc76520a0eea20e69ddae/opentelemetry_instrumentation_logging-0.61b0-py3-none-any.whl", hash = "sha256:6d87e5ded6a0128d775d41511f8380910a1b610671081d16efb05ac3711c0074", size = 17076, upload-time = "2026-03-04T14:19:36.765Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/36/135fd0f4a154ea225de0a418d36f8cf9cf273ad31d41a3a2aaa91862b817/opentelemetry_instrumentation_logging-0.62b0-py3-none-any.whl", hash = "sha256:9a27b6c3d419170d96dedcea7d38cc0418f0dd1054365f52499a0a1eb70b8faf", size = 17489, upload-time = "2026-04-09T14:39:49.384Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-sqlalchemy"
-version = "0.61b0"
+version = "0.62b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1125,57 +1125,57 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/4f/3a325b180944610697a0a926d49d782b41a86120050d44fefb2715b630ac/opentelemetry_instrumentation_sqlalchemy-0.61b0.tar.gz", hash = "sha256:13a3a159a2043a52f0180b3757fbaa26741b0e08abb50deddce4394c118956e6", size = 15343, upload-time = "2026-03-04T14:20:47.648Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/3d/40adc8c38e5be017ceb230a28ca57ca81981d4dc0c4b902cc930c77fd14f/opentelemetry_instrumentation_sqlalchemy-0.62b0.tar.gz", hash = "sha256:d02f85b83f349e9ef70a34cb3f4c3a3481fa15b11747f09209818663e161cac4", size = 18539, upload-time = "2026-04-09T14:40:50.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/97/b906a930c6a1a20c53ecc8b58cabc2cdd0ce560a2b5d44259084ffe4333e/opentelemetry_instrumentation_sqlalchemy-0.61b0-py3-none-any.whl", hash = "sha256:f115e0be54116ba4c327b8d7b68db4045ee18d44439d888ab8130a549c50d1c1", size = 14547, upload-time = "2026-03-04T14:19:53.088Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e0/77954ac593f34740dc32e28a15fe7170e90f6ba6398eaaa5c88b34c05ed1/opentelemetry_instrumentation_sqlalchemy-0.62b0-py3-none-any.whl", hash = "sha256:ec576e0660080d9d15ce4fa44d2a07fff8cb4b796a84344cb0f2c9e5d6e26f79", size = 15534, upload-time = "2026-04-09T14:40:03.957Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.40.0"
+version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/77/dd38991db037fdfce45849491cb61de5ab000f49824a00230afb112a4392/opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd", size = 45667, upload-time = "2026-03-04T14:17:31.194Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/d9/08e3dc6156878713e8c811682bc76151f5fe1a3cb7f3abda3966fd56e71e/opentelemetry_proto-1.41.0.tar.gz", hash = "sha256:95d2e576f9fb1800473a3e4cfcca054295d06bdb869fda4dc9f4f779dc68f7b6", size = 45669, upload-time = "2026-04-09T14:38:45.978Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/b2/189b2577dde745b15625b3214302605b1353436219d42b7912e77fa8dc24/opentelemetry_proto-1.40.0-py3-none-any.whl", hash = "sha256:266c4385d88923a23d63e353e9761af0f47a6ed0d486979777fe4de59dc9b25f", size = 72073, upload-time = "2026-03-04T14:17:16.673Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8c/65ef7a9383a363864772022e822b5d5c6988e6f9dabeebb9278f5b86ebc3/opentelemetry_proto-1.41.0-py3-none-any.whl", hash = "sha256:b970ab537309f9eed296be482c3e7cca05d8aca8165346e929f658dbe153b247", size = 72074, upload-time = "2026-04-09T14:38:29.38Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.40.0"
+version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/fd/3c3125b20ba18ce2155ba9ea74acb0ae5d25f8cd39cfd37455601b7955cc/opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2", size = 184252, upload-time = "2026-03-04T14:17:31.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/0e/a586df1186f9f56b5a0879d52653effc40357b8e88fc50fe300038c3c08b/opentelemetry_sdk-1.41.0.tar.gz", hash = "sha256:7bddf3961131b318fc2d158947971a8e37e38b1cd23470cfb72b624e7cc108bd", size = 230181, upload-time = "2026-04-09T14:38:47.225Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/c5/6a852903d8bfac758c6dc6e9a68b015d3c33f2f1be5e9591e0f4b69c7e0a/opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1", size = 141951, upload-time = "2026-03-04T14:17:17.961Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/13/a7825118208cb32e6a4edcd0a99f925cbef81e77b3b0aedfd9125583c543/opentelemetry_sdk-1.41.0-py3-none-any.whl", hash = "sha256:a596f5687964a3e0d7f8edfdcf5b79cbca9c93c7025ebf5fb00f398a9443b0bd", size = 180214, upload-time = "2026-04-09T14:38:30.657Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.61b0"
+version = "0.62b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/b0/c14f723e86c049b7bf8ff431160d982519b97a7be2857ed2247377397a24/opentelemetry_semantic_conventions-0.62b0.tar.gz", hash = "sha256:cbfb3c8fc259575cf68a6e1b94083cc35adc4a6b06e8cf431efa0d62606c0097", size = 145753, upload-time = "2026-04-09T14:38:48.274Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
+    { url = "https://files.pythonhosted.org/packages/58/6c/5e86fa1759a525ef91c2d8b79d668574760ff3f900d114297765eb8786cb/opentelemetry_semantic_conventions-0.62b0-py3-none-any.whl", hash = "sha256:0ddac1ce59eaf1a827d9987ab60d9315fb27aea23304144242d1fcad9e16b489", size = 231619, upload-time = "2026-04-09T14:38:32.394Z" },
 ]
 
 [[package]]
 name = "opentelemetry-util-http"
-version = "0.61b0"
+version = "0.62b0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/3c/f0196223efc5c4ca19f8fad3d5462b171ac6333013335ce540c01af419e9/opentelemetry_util_http-0.61b0.tar.gz", hash = "sha256:1039cb891334ad2731affdf034d8fb8b48c239af9b6dd295e5fabd07f1c95572", size = 11361, upload-time = "2026-03-04T14:20:57.01Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/e7/830f7c57135158eb8a8efd3f94ab191a89e3b8a49bed314a35ee501da3f2/opentelemetry_util_http-0.62b0.tar.gz", hash = "sha256:a62e4b19b8a432c0de657f167dee3455516136bb9c6ed463ca8063019970d835", size = 11393, upload-time = "2026-04-09T14:40:59.442Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/e5/c08aaaf2f64288d2b6ef65741d2de5454e64af3e050f34285fb1907492fe/opentelemetry_util_http-0.61b0-py3-none-any.whl", hash = "sha256:8e715e848233e9527ea47e275659ea60a57a75edf5206a3b937e236a6da5fc33", size = 9281, upload-time = "2026-03-04T14:20:08.364Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/7f/5c1b7d4385852b9e5eacd4e7f9d8b565d3d351d17463b24916ad098adf1a/opentelemetry_util_http-0.62b0-py3-none-any.whl", hash = "sha256:c20462808d8cc95b69b0dc4a3e02a9d36beb663347e96c931f51ffd78bd318ad", size = 9294, upload-time = "2026-04-09T14:40:19.014Z" },
 ]
 
 [[package]]
@@ -1549,11 +1549,11 @@ wheels = [
 
 [[package]]
 name = "python-json-logger"
-version = "3.3.0"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/de/d3144a0bceede957f961e975f3752760fbe390d57fbe194baf709d8f1f7b/python_json_logger-3.3.0.tar.gz", hash = "sha256:12b7e74b17775e7d565129296105bbe3910842d9d0eb083fc83a6a617aa8df84", size = 16642, upload-time = "2025-03-07T07:08:27.301Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl", hash = "sha256:dd980fae8cffb24c13caf6e158d3d61c0d6d22342f932cb6e9deedab3d35eec7", size = 15163, upload-time = "2025-03-07T07:08:25.627Z" },
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
 ]
 
 [[package]]
@@ -1632,14 +1632,11 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "5.3.1"
+version = "7.4.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyjwt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
 ]
 
 [package.optional-dependencies]
@@ -1702,11 +1699,11 @@ wheels = [
 
 [[package]]
 name = "scalar-fastapi"
-version = "1.8.1"
+version = "1.8.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/95/bbbf63b38eafc93862827bda0fba415a486882642d9293f6b918145fd4f9/scalar_fastapi-1.8.1.tar.gz", hash = "sha256:eadb625d386fa94a79e5463af0aa6bcf5e02bc4d665454ed0795960987152531", size = 8258, upload-time = "2026-03-18T09:36:57.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/81/c0c70776a3d7d371ee06d38d26a8d361c97439d46f79acb6d67cf6c760ad/scalar_fastapi-1.8.2.tar.gz", hash = "sha256:0de09b8c63f78c1052792faa200d740b2ccaeeb88ac54e7ea633ac4edc6fde82", size = 8371, upload-time = "2026-04-09T22:41:24.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/29/584cc791765b92a35362733875ff881df3b3d181670285eaf571a17170d7/scalar_fastapi-1.8.1-py3-none-any.whl", hash = "sha256:0ff296877d65082039eba8682fef6eafbe1cd77c5b55a3b3c0b96681eb15ca62", size = 7636, upload-time = "2026-03-18T09:36:56.224Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/b1/b9a482620479b2801a4dfa5c4c10b4cc280097e894114e0298f21a0fca55/scalar_fastapi-1.8.2-py3-none-any.whl", hash = "sha256:d96e2c8b3676491eaebb4ec8d9f4de77adb2374d86f87d321546fa6f084e8cb8", size = 7677, upload-time = "2026-04-09T22:41:23.209Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Extracts generic `BaseRepository[T]` into `backend/app/repositories/base.py` with shared `create`, `get`, `update`, `delete`, `commit`, `rollback` methods (PEP 695 type parameter syntax)
- Moves `RepositoryConflictError` from `user.py` to `base.py` — all 7 concrete repos and 22 consuming files updated
- Fixes rollback-on-conflict inconsistency: `user.py` and `provider.py` previously rolled back before raising `RepositoryConflictError`, while other repos did not. All repos now consistently do NOT rollback (service layer owns the transaction boundary)
- All 7 repositories inherit `BaseRepository` and only contain domain-specific methods
- Re-exports all concrete repos from `app.repositories.__init__`
- Extracts shared E2E helpers (`unique_name`, formerly `_unique_name`/`_unique_id`) into `tests/e2e/helpers/api.py`, removing duplication across 7 test files
- Removes `timed_request`/`MAX_API_RESPONSE_MS` from all E2E tests — latency monitoring belongs in OTel, not test assertions
- No service or router layer changes needed — public interfaces unchanged

## Test plan

- [x] `make lint` passes (ruff check + format)
- [x] 1676 unit tests passing (1667 existing + 9 new `test_base_repository.py`)
- [x] New `test_base_repository.py`: generic CRUD, conflict handling, inheritance verification
- [x] Adversarial code review passed (Blind Hunter, Edge Case Hunter, Acceptance Auditor — 0 patch findings)
- [ ] Existing E2E tests pass (`make test-e2e`)
- [ ] New `test_identity_repository_api.py`: full lifecycle chain, conflict handling, concurrent entity operations
- [ ] New `test_identity_repository_ui.py`: authenticated navigation, data display via API+browser, error states

🤖 Generated with [Claude Code](https://claude.com/claude-code)