### PR TITLE
fix: catch-all route redirects unknown paths to dashboard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,6 +109,7 @@ export default function App() {
         <Route path="members" element={<MemberManagement />} />
         <Route path="fga" element={<FGAManagement />} />
       </Route>
+      <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- Unmatched frontend routes (e.g. `/providers`, `/sync`, `/events`) rendered blank white pages because `App.tsx` had no fallback route
- Adds `<Route path="*" element={<Navigate to="/" replace />} />` so unknown paths redirect to the dashboard

Found during design system audit — these routes will be properly implemented in DS-4.x stories.

## Test plan
- [x] All 138 frontend unit tests pass
- [x] TypeScript type check passes
- [ ] Verify navigating to `/nonexistent` redirects to `/` in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)