### PR TITLE
fix(tests): wait for testcontainer port before alembic upgrade

### DIFF
--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -104,6 +104,22 @@ async def client():
 # ──────────────────────────────────────────────
 
 
+def _wait_for_port(host: str, port: int, timeout: float = 30.0) -> None:
+    import socket
+    import time
+
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return
+        except OSError as e:
+            last_err = e
+            time.sleep(0.25)
+    raise RuntimeError(f"Postgres at {host}:{port} not reachable after {timeout}s: {last_err}")
+
+
 @pytest.fixture(scope="session")
 def postgres_container():
     """Start a real Postgres container for the test session."""
@@ -118,6 +134,7 @@ def postgres_url(postgres_container):
 
     sync_url = postgres_container.get_connection_url()
     parsed = urlparse(sync_url)
+    _wait_for_port(parsed.hostname or "127.0.0.1", parsed.port or 5432)
     # Replace any sync scheme (postgresql+psycopg2, postgresql, etc.) with asyncpg
     async_url = urlunparse(parsed._replace(scheme="postgresql+asyncpg"))
     return async_url

--- a/backend/tests/unit/repositories/conftest.py
+++ b/backend/tests/unit/repositories/conftest.py
@@ -24,6 +24,22 @@ def postgres_container():
         yield pg
 
 
+def _wait_for_port(host: str, port: int, timeout: float = 30.0) -> None:
+    import socket
+    import time
+
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return
+        except OSError as e:
+            last_err = e
+            time.sleep(0.25)
+    raise RuntimeError(f"Postgres at {host}:{port} not reachable after {timeout}s: {last_err}")
+
+
 @pytest.fixture(scope="session")
 def postgres_url(postgres_container):
     """Async-compatible connection URL for the testcontainers Postgres instance."""
@@ -31,6 +47,7 @@ def postgres_url(postgres_container):
 
     sync_url = postgres_container.get_connection_url()
     parsed = urlparse(sync_url)
+    _wait_for_port(parsed.hostname or "127.0.0.1", parsed.port or 5432)
     async_url = urlunparse(parsed._replace(scheme="postgresql+asyncpg"))
     return async_url
 


### PR DESCRIPTION
## Summary

`testcontainers.PostgresContainer` waits for the in-container \`ready to accept connections\` log line, but the host-side port forwarding through Rancher Desktop's Lima VM can lag behind that. The Alembic subprocess that runs immediately after container start races against the port forwarder and fails with \`ConnectionRefusedError\` on the host-mapped port — reproducibly breaking 95 unit-test repository tests locally, even though CI passes (GitHub Actions has direct Docker access, no Lima hop).

## Fix

Add a TCP-level \`_wait_for_port\` probe with a 30s deadline between container start and the Alembic upgrade. \`socket.create_connection\` is the right level: once the host-side proxy answers TCP, asyncpg's subsequent connect proceeds normally. No new dependencies; works on every docker host.

Applied to both conftests (\`tests/unit/repositories/\` and \`tests/integration/\`) since both follow the same pattern.

## Why now

Owner directive: all unit tests must always pass. The DS-4.0 integration backfill loop (PR #300) ran into this and rationalized the failures as "environmental flakiness" — encoding it as a memory and proceeding past test/review-fix with only the integration suite checked. The phase prompts have been tightened separately (identity-stack-planning PR #31) so no loop can advance past a failing unit test again. This PR removes the underlying environmental cause so the rule is enforceable, not punitive.

## Test plan

- [x] \`make test-unit\` locally — 1676 passed, 0 errors (previously 1605 passed, 95 errors)
- [x] \`make test-integration\` locally — 46 passed, 13 skipped (unchanged, no regression)
- [ ] CI: lint + unit + integration + e2e all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)